### PR TITLE
Fix canonical links in Log For Everything policy

### DIFF
--- a/logforeverything.html
+++ b/logforeverything.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Privacy Policy - Log For Everything</title>
-    <link rel="canonical" href="https://www.example.com/privacy-policy.html">
+    <link rel="canonical" href="https://singaseongj.github.io/logforeverything.html">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/tailwindcss/2.2.19/tailwind.min.css" rel="stylesheet">
 </head>
 <body class="bg-gray-100 font-sans leading-normal tracking-normal">
@@ -12,7 +12,7 @@
         <header class="mb-8">
             <h1 class="text-4xl font-bold text-gray-800 mb-2">Privacy Policy</h1>
             <p class="text-gray-600 italic">For Log For Everything App</p>
-            <p class="text-sm text-gray-500 mt-2">This policy is available at <a href="https://www.example.com/privacy-policy.html" class="text-blue-600 hover:underline">https://www.example.com/privacy-policy.html</a></p>
+            <p class="text-sm text-gray-500 mt-2">This policy is available at <a href="https://singaseongj.github.io/logforeverything.html" class="text-blue-600 hover:underline">https://singaseongj.github.io/logforeverything.html</a></p>
         </header>
         
         <main class="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4">


### PR DESCRIPTION
## Summary
- correct the canonical and reference URL in `logforeverything.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68887e1f8bb0832a989d632eee0ebf31