### PR TITLE
Update Node.js version to 18

### DIFF
--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Node.js 설정
         uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
 
       - name: 의존성 설치
         run: npm ci

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   },
   "dependencies": {
   },
+  "engines": {
+    "node": ">=18"
+  },
   "type": "module"
 }
 

--- a/tests/apple_association.test.js
+++ b/tests/apple_association.test.js
@@ -1,5 +1,5 @@
-const fs = require('fs');
-const assert = require('assert');
+import fs from 'fs';
+import assert from 'assert';
 
 let data;
 try {


### PR DESCRIPTION
## Summary
- use Node 18 in the daily-build workflow
- specify Node >=18 in `package.json`
- update tests to ESM so they run under modern Node

## Testing
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_6889d71afa50832aaf069eafffcefa6e