### PR TITLE
Update README with Node version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ This repository contains files used for the Singaseong website.
 
 ## Running tests
 
-The repository includes a simple Node.js script that verifies the `apple-app-site-association` file. Make sure Node.js is installed and run:
+The repository includes a simple Node.js script that verifies the `apple-app-site-association` file. Make sure Node.js is installed and run.
+Node.js 18 or newer is required to run the update and build scripts.
 
 ```bash
 node tests/apple_association.test.js


### PR DESCRIPTION
## Summary
- clarify that Node.js 18 or newer is required for update and build scripts

## Testing
- `node tests/apple_association.test.js` *(fails: require is not defined)*
- `npm run build` *(fails: network fetch errors)*

------
https://chatgpt.com/codex/tasks/task_b_6889d73a3734832a86e186bf4e89a364