### PR TITLE
Fix Yahoo Finance fetching via CORS proxy

### DIFF
--- a/src/template.html
+++ b/src/template.html
@@ -300,7 +300,11 @@
             if (priceMatch) price = priceMatch[1].replace(/,/g, '');
             if (rateMatch) changePct = rateMatch[1].trim();
           } else if (idx.type === 'yahoo') {
-            const res = await fetch(`https://query1.finance.yahoo.com/v7/finance/quote?symbols=${encodeURIComponent(idx.symbol)}`);
+            // Yahoo Finance blocks CORS, so fetch through a proxy
+            const yahooUrl = `https://query1.finance.yahoo.com/v7/finance/quote?symbols=${encodeURIComponent(idx.symbol)}`;
+            const proxy = `https://api.allorigins.win/raw?url=${encodeURIComponent(yahooUrl)}`;
+
+            const res = await fetch(proxy);
             const data = await res.json();
             if (data.quoteResponse && data.quoteResponse.result && data.quoteResponse.result[0]) {
               const info = data.quoteResponse.result[0];

--- a/stocks.html
+++ b/stocks.html
@@ -309,7 +309,11 @@
             if (priceMatch) price = priceMatch[1].replace(/,/g, '');
             if (rateMatch) changePct = rateMatch[1].trim();
           } else if (idx.type === 'yahoo') {
-            const res = await fetch(`https://query1.finance.yahoo.com/v7/finance/quote?symbols=${encodeURIComponent(idx.symbol)}`);
+            // Use a CORS proxy since Yahoo Finance does not allow cross origin requests
+            const yahooUrl = `https://query1.finance.yahoo.com/v7/finance/quote?symbols=${encodeURIComponent(idx.symbol)}`;
+            const proxy = `https://api.allorigins.win/raw?url=${encodeURIComponent(yahooUrl)}`;
+
+            const res = await fetch(proxy);
             const data = await res.json();
             if (data.quoteResponse && data.quoteResponse.result && data.quoteResponse.result[0]) {
               const info = data.quoteResponse.result[0];


### PR DESCRIPTION
## Summary
- use AllOrigins proxy for Yahoo Finance requests in `stocks.html`
- update same logic in `src/template.html`

## Testing
- `node tests/apple_association.test.js`

------
https://chatgpt.com/codex/tasks/task_b_6889ecaffef0832a90e628566fef13e4