### PR TITLE
Improve stock recommendation display

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,13 @@ node tests/apple_association.test.js
 ```
 
 If the file is valid you will see `All tests passed`.
+
+## Updating recommendation data
+
+`fetchStockInfo.js` fetches sector and previous close information from the Yahoo Finance API and stores the result in `recommendations.json`.
+
+Run the script with:
+
+```bash
+node fetchStockInfo.js
+```

--- a/fetchStockInfo.js
+++ b/fetchStockInfo.js
@@ -1,18 +1,63 @@
 import fs from 'fs/promises';
 
-const API_KEY = 'VQ7n0DBO8ssJTC6%2BKhDQujhh%2FU0sft03wYA7N81rQmCd7gnLWhJBVXL8oYSJqqIfEgFllrUsTJJ0NNVhKMoNzQ%3D%3D';
-const BASE_URL = 'https://apis.data.go.kr/1160100/service/GetKrxListedInfoService/getItemInfo';
+// Mapping of stock names to Yahoo Finance tickers
+const TICKER_MAP = {
+  '삼성전자': '005930.KS',
+  '현대차': '005380.KS',
+  'LG화학': '051910.KS',
+  'SK텔레콤': '017670.KS',
+  'POSCO홀딩스': '005490.KS',
+  '카카오': '035720.KS',
+  '네이버': '035420.KS',
+  '셀트리온': '068270.KS',
+  'HMM': '011200.KS',
+  '두산에너빌리티': '034020.KS',
+  '셀트리온헬스케어': '091990.KQ',
+  '에코프로비엠': '247540.KQ',
+  '카카오게임즈': '293490.KQ',
+  'CJ ENM': '035760.KQ',
+  '스튜디오드래곤': '253450.KQ',
+  '제넥신': '095700.KQ',
+  '펄어비스': '263750.KQ',
+  '에이치엘비': '028300.KQ',
+  '알테오젠': '196170.KQ',
+  '씨젠': '096530.KQ',
+  'Apple': 'AAPL',
+  'Microsoft': 'MSFT',
+  'Amazon': 'AMZN',
+  'Alphabet': 'GOOGL',
+  'Meta': 'META',
+  'NVIDIA': 'NVDA',
+  'Tesla': 'TSLA',
+  'AMD': 'AMD',
+  'Netflix': 'NFLX',
+  'Palantir': 'PLTR',
+  'Coca-Cola': 'KO',
+  'Johnson & Johnson': 'JNJ',
+  'Procter & Gamble': 'PG',
+  'Walmart': 'WMT',
+  "McDonald's": 'MCD',
+  'Snowflake': 'SNOW',
+  'Shopify': 'SHOP',
+  'Uber': 'UBER',
+  'Block': 'SQ',
+  'Coinbase': 'COIN'
+};
 
 async function fetchInfo(name) {
-  const url = `${BASE_URL}?serviceKey=${API_KEY}&itmsNm=${encodeURIComponent(name)}&resultType=json`;
+  const ticker = TICKER_MAP[name];
+  if (!ticker) {
+    throw new Error('Ticker not found');
+  }
+  const url = `https://query1.finance.yahoo.com/v7/finance/quote?symbols=${encodeURIComponent(ticker)}`;
   const res = await fetch(url);
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
   const data = await res.json();
-  const item = data?.response?.body?.items?.item?.[0];
+  const item = data?.quoteResponse?.result?.[0];
   if (!item) throw new Error('No data');
   return {
-    sector: item.sector || item.industClsNm || null,
-    prevClose: item.clpr || item.mkp || null,
+    sector: item.sector || null,
+    prevClose: item.regularMarketPreviousClose || null,
   };
 }
 

--- a/stocks.html
+++ b/stocks.html
@@ -143,6 +143,11 @@
       font-style: italic;
       padding: 20px;
     }
+
+    .details {
+      color: #7f8c8d;
+      font-size: 0.9em;
+    }
     
     .no-data {
       text-align: center;
@@ -366,18 +371,29 @@
         const data = await res.json();
         const container = document.getElementById('recommendations');
         if (!container) return;
+
         const markets = ['KOSPI', 'KOSDAQ', 'NASDAQ', 'NYSE'];
         const html = [];
         for (const m of markets) {
           const info = data[m];
           if (!info) continue;
-          html.push(`<div class="portfolio-group"><h3>${m} 안전주</h3><ul>` +
-            info.safe.map(s => `<li>${s}</li>`).join('') +
-            '</ul></div>');
-          html.push(`<div class="portfolio-group"><h3>${m} 공격적 종목</h3><ul>` +
-            info.aggressive.map(s => `<li>${s}</li>`).join('') +
-            '</ul></div>');
+
+          const renderItem = item => {
+            if (typeof item === 'string') return `<li>${item}</li>`;
+            const details = [];
+            if (item.sector) details.push(item.sector);
+            if (item.prevClose) details.push(`전일종가: ${item.prevClose}`);
+            const suffix = details.length ? ` <span class="details">(${details.join(', ')})</span>` : '';
+            return `<li>${item.name}${suffix}</li>`;
+          };
+
+          const safeList = info.safe.map(renderItem).join('');
+          const aggressiveList = info.aggressive.map(renderItem).join('');
+
+          html.push(`<div class="portfolio-group"><h3>${m} 안전주</h3><ul>${safeList}</ul></div>`);
+          html.push(`<div class="portfolio-group"><h3>${m} 공격적 종목</h3><ul>${aggressiveList}</ul></div>`);
         }
+
         container.innerHTML = html.join('');
       } catch (err) {
         console.error('추천 로드 실패', err);


### PR DESCRIPTION
## Summary
- document how to update recommendation data in README
- fetch stock info from Yahoo Finance in `fetchStockInfo.js`
- show sector and previous close in `stocks.html`

## Testing
- `node tests/apple_association.test.js`

------
https://chatgpt.com/codex/tasks/task_b_688a0c9c8628832a86a1b495f2cf634b