### PR TITLE
Add daily/total visit count widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,15 @@ When network access isn't available, enable offline mode to use
 ```bash
 OFFLINE=1 node src/build.js
 ```
+
+## Visit count server
+
+A small Node.js script records page visits in `visits.json`. Start it before opening
+`index.html` or `stocks.html` so the pages can update the counts:
+
+```bash
+node server.js
+```
+
+The server exposes `/visit?page=index` and `/visit?page=stocks` endpoints and stores
+the daily and total visit numbers separately for each page.

--- a/index.html
+++ b/index.html
@@ -1120,7 +1120,19 @@
                     list.appendChild(div);
                 });
             }
-        }
-    </script>
+</script>
+<div id="visitCounts" style="text-align:center;margin-top:20px;font-size:0.8rem;color:#64748b;"></div>
+<script>
+  (async function() {
+    try {
+      const res = await fetch('/visit?page=index');
+      const data = await res.json();
+      document.getElementById('visitCounts').textContent =
+        `Visits today: ${data.daily} | Total: ${data.total}`;
+    } catch (err) {
+      console.error('Visit count failed', err);
+    }
+  })();
+</script>
 </body>
 </html>

--- a/server.js
+++ b/server.js
@@ -1,0 +1,57 @@
+import http from 'http';
+import fs from 'fs';
+import { URL } from 'url';
+
+const PORT = process.env.PORT || 3000;
+const DATA_FILE = 'visits.json';
+
+function loadData() {
+  try {
+    return JSON.parse(fs.readFileSync(DATA_FILE, 'utf-8'));
+  } catch {
+    return { index: { total: 0, daily: 0, date: '' }, stocks: { total: 0, daily: 0, date: '' } };
+  }
+}
+
+function saveData(data) {
+  fs.writeFileSync(DATA_FILE, JSON.stringify(data, null, 2));
+}
+
+function handleVisit(page) {
+  const data = loadData();
+  const entry = data[page] || { total: 0, daily: 0, date: '' };
+  const today = new Date().toISOString().split('T')[0];
+  if (entry.date !== today) {
+    entry.date = today;
+    entry.daily = 1;
+  } else {
+    entry.daily += 1;
+  }
+  entry.total += 1;
+  data[page] = entry;
+  saveData(data);
+  return entry;
+}
+
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+
+  if (url.pathname === '/visit') {
+    const page = url.searchParams.get('page');
+    if (!page) {
+      res.statusCode = 400;
+      res.end('page parameter required');
+      return;
+    }
+    const counts = handleVisit(page);
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify(counts));
+  } else {
+    res.statusCode = 404;
+    res.end('Not found');
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`Visit count server running on port ${PORT}`);
+});

--- a/stocks.html
+++ b/stocks.html
@@ -453,6 +453,19 @@
         refreshAllData();
       }
     });
-  </script>
+</script>
+<div id="visitCounts" style="text-align:center;margin-top:20px;font-size:0.8rem;color:#64748b;"></div>
+<script>
+  (async function() {
+    try {
+      const res = await fetch('/visit?page=stocks');
+      const data = await res.json();
+      document.getElementById('visitCounts').textContent =
+        `Visits today: ${data.daily} | Total: ${data.total}`;
+    } catch (err) {
+      console.error('Visit count failed', err);
+    }
+  })();
+</script>
 </body>
 </html>

--- a/visits.json
+++ b/visits.json
@@ -1,0 +1,4 @@
+{
+  "index": { "total": 0, "daily": 0, "date": "" },
+  "stocks": { "total": 0, "daily": 0, "date": "" }
+}


### PR DESCRIPTION
## Summary
- add a simple HTTP server that stores visit counts in `visits.json`
- display visit counts on `index.html` and `stocks.html`
- document how to run the visit counter

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688a99309164832a9d28380919bcfce6