### PR TITLE
Enable visit counters on stocks page

### DIFF
--- a/stocks.html
+++ b/stocks.html
@@ -455,5 +455,18 @@
       }
     });
   </script>
+<div id="visitCounts" style="text-align:center;margin-top:20px;font-size:0.8rem;color:#64748b;"></div>
+<script>
+  (async function() {
+    try {
+      const res = await fetch('https://script.google.com/macros/s/AKfycbyM94HyV7c_eqq3SPLMZlBcJVh6KeyygmR4bq_NM80_li9MIM2WWQ25wnd3S51FR4igLw/exec?page=stocks');
+      const data = await res.json();
+      document.getElementById('visitCounts').textContent =
+        `Visits today: ${data.daily} | Total: ${data.total}`;
+    } catch (err) {
+      console.error('Visit count failed', err);
+    }
+  })();
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- display visit counters on stocks page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688ae2205480832a99a70e366343f7a6