### PR TITLE
Fix portfolio data fallback

### DIFF
--- a/stocks.html
+++ b/stocks.html
@@ -299,8 +299,16 @@
                     portfolioData = await driveRes.json();
                     initializeDashboard();
                 } catch (err2) {
-                    console.error('Error loading data:', err2);
-                    document.getElementById('app').innerHTML = '<div class="loading error">Error loading portfolio data</div>';
+                    console.warn('Drive fetch failed, trying local fallback', err2);
+                    try {
+                        const localRes = await fetch('recommendations.json');
+                        if (!localRes.ok) throw new Error('Local file not found');
+                        portfolioData = await localRes.json();
+                        initializeDashboard();
+                    } catch (err3) {
+                        console.error('Error loading data:', err3);
+                        document.getElementById('app').innerHTML = '<div class="loading error">Error loading portfolio data</div>';
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- fallback to `recommendations.json` if remote portfolio sources fail

## Testing
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_688aec752ec0832aa06cc7739998886e