### PR TITLE
Drop sector and prevClose in stock page

### DIFF
--- a/src/build.js
+++ b/src/build.js
@@ -100,16 +100,15 @@ async function fetchMarketIndices() {
     for (const idx of indices) {
       const data = sampleIndices[idx.name] || {};
       const price = data.price || 'N/A';
-      const prevClose = data.prevClose || 'N/A';
       const changePct = data.changePct || 'N/A';
       const changeNum = parseFloat(changePct);
       const cls = changeNum > 0 ? 'positive' : changeNum < 0 ? 'negative' : 'neutral';
-      rows.push(`<tr><td>${idx.name}</td><td>${price}</td><td>${prevClose}</td><td class="${cls}">${changePct}</td></tr>`);
+      rows.push(`<tr><td>${idx.name}</td><td>${price}</td><td class="${cls}">${changePct}</td></tr>`);
     }
     return `
     <table>
       <thead>
-        <tr><th>지수</th><th>현재지수</th><th>전일종가</th><th>등락(%)</th></tr>
+        <tr><th>지수</th><th>현재지수</th><th>등락(%)</th></tr>
       </thead>
       <tbody id="marketBody">
         ${rows.join('')}
@@ -230,13 +229,13 @@ async function fetchMarketIndices() {
 
     const changeNum = parseFloat(changePct);
     const cls = changeNum > 0 ? 'positive' : changeNum < 0 ? 'negative' : 'neutral';
-    rows.push(`<tr><td>${idx.name}</td><td>${price}</td><td>${prevClose}</td><td class="${cls}">${changePct}</td></tr>`);
+    rows.push(`<tr><td>${idx.name}</td><td>${price}</td><td class="${cls}">${changePct}</td></tr>`);
   }
 
   return `
     <table>
       <thead>
-        <tr><th>지수</th><th>현재지수</th><th>전일종가</th><th>등락(%)</th></tr>
+        <tr><th>지수</th><th>현재지수</th><th>등락(%)</th></tr>
       </thead>
       <tbody id="marketBody">
         ${rows.join('')}

--- a/src/template.html
+++ b/src/template.html
@@ -252,7 +252,7 @@
   </div>
 
   <section id="marketSnapshot">
-    <h2>전일 종가 기준 마켓 스냅샷</h2>
+    <h2>마켓 스냅샷</h2>
     {{MARKET_TABLE}}
     <div id="marketError" class="error" style="display:none;" role="alert"></div>
     <div id="lastUpdated" class="last-updated"></div>
@@ -350,7 +350,7 @@
 
         const chg = parseFloat(changePct);
         const cls = chg > 0 ? 'positive' : chg < 0 ? 'negative' : 'neutral';
-        rows.push(`<tr><td>${idx.name}</td><td>${price}</td><td>${prevClose}</td><td class="${cls}">${changePct}</td></tr>`);
+        rows.push(`<tr><td>${idx.name}</td><td>${price}</td><td class="${cls}">${changePct}</td></tr>`);
       }
 
       const tbody = document.getElementById('marketBody');
@@ -408,7 +408,7 @@
         for (const bucket of ['safe', 'aggressive']) {
           const items = (info?.[bucket] || []).map(item => {
             const name = FULL_NAME_MAP[item.name] || item.name;
-            return `<li>${name} — ${item.sector || 'N/A'} @ ${item.prevClose}</li>`;
+            return `<li>${name}</li>`;
           }).join('');
           html.push(`<div class="portfolio-group"><h3>${m} ${bucket === 'safe' ? '안전주' : '공격적 종목'}</h3><ul>${items}</ul></div>`);
         }

--- a/stocks.html
+++ b/stocks.html
@@ -252,14 +252,14 @@
   </div>
 
   <section id="marketSnapshot">
-    <h2>전일 종가 기준 마켓 스냅샷</h2>
+    <h2>마켓 스냅샷</h2>
     
     <table>
       <thead>
-        <tr><th>지수</th><th>현재지수</th><th>전일종가</th><th>등락(%)</th></tr>
+        <tr><th>지수</th><th>현재지수</th><th>등락(%)</th></tr>
       </thead>
       <tbody id="marketBody">
-        <tr><td>KOSPI</td><td>2,400.00</td><td>2,390.00</td><td class="positive">+0.5%</td></tr><tr><td>KOSDAQ</td><td>700.00</td><td>702.10</td><td class="negative">-0.3%</td></tr><tr><td>S&P500</td><td>4,500.00</td><td>4,490.00</td><td class="positive">+0.22%</td></tr><tr><td>NASDAQ100</td><td>15,000.00</td><td>14,900.00</td><td class="positive">+0.67%</td></tr>
+        <tr><td>KOSPI</td><td>2,400.00</td><td class="positive">+0.5%</td></tr><tr><td>KOSDAQ</td><td>700.00</td><td class="negative">-0.3%</td></tr><tr><td>S&P500</td><td>4,500.00</td><td class="positive">+0.22%</td></tr><tr><td>NASDAQ100</td><td>15,000.00</td><td class="positive">+0.67%</td></tr>
       </tbody>
     </table>
   
@@ -359,7 +359,7 @@
 
         const chg = parseFloat(changePct);
         const cls = chg > 0 ? 'positive' : chg < 0 ? 'negative' : 'neutral';
-        rows.push(`<tr><td>${idx.name}</td><td>${price}</td><td>${prevClose}</td><td class="${cls}">${changePct}</td></tr>`);
+        rows.push(`<tr><td>${idx.name}</td><td>${price}</td><td class="${cls}">${changePct}</td></tr>`);
       }
 
       const tbody = document.getElementById('marketBody');
@@ -417,7 +417,7 @@
         for (const bucket of ['safe', 'aggressive']) {
           const items = (info?.[bucket] || []).map(item => {
             const name = FULL_NAME_MAP[item.name] || item.name;
-            return `<li>${name} — ${item.sector || 'N/A'} @ ${item.prevClose}</li>`;
+            return `<li>${name}</li>`;
           }).join('');
           html.push(`<div class="portfolio-group"><h3>${m} ${bucket === 'safe' ? '안전주' : '공격적 종목'}</h3><ul>${items}</ul></div>`);
         }


### PR DESCRIPTION
## Summary
- remove display of previous close and sector information
- update market table formatting
- rebuild stocks.html

## Testing
- `node tests/apple_association.test.js`
- `node src/build.js` *(fails to fetch live data; used fallbacks)*

------
https://chatgpt.com/codex/tasks/task_b_688b23bdc190832aae36973c0b8e5735