### PR TITLE
Remove old refresh button and dummy data

### DIFF
--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -28,7 +28,7 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: "chore: daily stock report update [skip ci]"
-          file_pattern: stocks.html
+          file_pattern: stocks.html src/template.html
           skip_dirty_check: true
 
       - name: GitHub Pages 배포

--- a/src/build.js
+++ b/src/build.js
@@ -10,17 +10,9 @@ import path from 'path';
 // Load HTML template
 const tpl = fs.readFileSync(path.resolve('src/template.html'), 'utf-8');
 
-// offline mode for environments without network access
-const OFFLINE = process.env.OFFLINE === '1' || process.argv.includes('--offline');
-let sampleIndices = {};
-if (OFFLINE) {
-  try {
-    sampleIndices = JSON.parse(fs.readFileSync(path.resolve('data/sample_market_data.json'), 'utf-8'));
-    console.log('Using sample market data (offline mode)');
-  } catch (err) {
-    console.warn('Failed to load sample data:', err.message);
-  }
-}
+// offline mode previously allowed using sample data, but this build strictly
+// fetches live information so that no stale placeholders appear in the output
+const OFFLINE = false;
 
 // Format date in Korean
 function formatDateKR(date) {
@@ -59,8 +51,6 @@ function getLastBusinessDay() {
 // URLs of the recommendation data
 const SCRIPT_URL =
   'https://script.google.com/macros/s/AKfycbzwMGmZ9Si_TIgB-kgk_b8TC2O30nyq1v1ZHjUFzpnFO4BHbJY1Ktvv5f_vhF5l0s9aLQ/exec';
-const DRIVE_URL =
-  'https://drive.google.com/uc?export=download&id=1OE6OGkhextQCBRG_jG3TC05LdV6RKRHZ';
 
 // 재시도 함수
 async function fetchWithRetry(url, retries = 3, timeout = 10000) {
@@ -96,26 +86,6 @@ async function fetchMarketIndices() {
   ];
 
   const rows = [];
-  if (OFFLINE) {
-    for (const idx of indices) {
-      const data = sampleIndices[idx.name] || {};
-      const price = data.price || 'N/A';
-      const changePct = data.changePct || 'N/A';
-      const changeNum = parseFloat(changePct);
-      const cls = changeNum > 0 ? 'positive' : changeNum < 0 ? 'negative' : 'neutral';
-      rows.push(`<tr><td>${idx.name}</td><td>${price}</td><td class="${cls}">${changePct}</td></tr>`);
-    }
-    return `
-    <table>
-      <thead>
-        <tr><th>지수</th><th>현재지수</th><th>등락(%)</th></tr>
-      </thead>
-      <tbody id="marketBody">
-        ${rows.join('')}
-      </tbody>
-    </table>
-  `;
-  }
   for (const idx of indices) {
     let price = 'N/A';
     let prevClose = 'N/A';
@@ -207,24 +177,6 @@ async function fetchMarketIndices() {
       
     } catch (err) {
       console.error(`Error fetching ${idx.name}:`, err.message);
-      // 더미 데이터라도 표시
-      if (idx.name === 'KOSPI') {
-        price = '2,400.00';
-        prevClose = '2,390.00';
-        changePct = '+0.5%';
-      } else if (idx.name === 'KOSDAQ') {
-        price = '700.00';
-        prevClose = '702.10';
-        changePct = '-0.3%';
-      } else if (idx.name === 'S&P500') {
-        price = '4,500.00';
-        prevClose = '4,490.00';
-        changePct = '+0.22%';
-      } else if (idx.name === 'NASDAQ100') {
-        price = '15,000.00';
-        prevClose = '14,900.00';
-        changePct = '+0.67%';
-      }
     }
 
     const changeNum = parseFloat(changePct);
@@ -247,30 +199,14 @@ async function fetchMarketIndices() {
 // Fetch portfolio recommendations from Google Drive and build HTML
 async function fetchPortfolioRecommendations() {
   let data;
-  if (OFFLINE) {
-    try {
-      data = JSON.parse(fs.readFileSync(path.resolve('recommendations.json'), 'utf-8'));
-      console.log('Using local recommendations data (offline mode)');
-    } catch (err) {
-      console.warn('Failed to load local recommendations:', err.message);
-    }
-  } else {
-    try {
-      data = await fetchWithRetry(SCRIPT_URL);
-    } catch (err) {
-      console.warn('Script fetch failed:', err.message);
-      try {
-        data = await fetchWithRetry(DRIVE_URL);
-      } catch (driveErr) {
-        console.warn('Drive fetch failed:', driveErr.message);
-        try {
-          data = JSON.parse(fs.readFileSync(path.resolve('recommendations.json'), 'utf-8'));
-          console.log('Using local recommendations.json as fallback');
-        } catch (fallbackErr) {
-          console.error('Failed to load local recommendations', fallbackErr);
-        }
-      }
-    }
+  try {
+    data = await fetchWithRetry(SCRIPT_URL);
+  } catch (err) {
+    console.error('Failed to fetch recommendations:', err.message);
+    return {
+      html: '<div id="recommendations"><p class="error">추천 데이터를 불러오지 못했습니다.</p></div>',
+      lastUpdated: new Date(),
+    };
   }
 
   try {

--- a/src/template.html
+++ b/src/template.html
@@ -244,7 +244,6 @@
     </ul>
     <button onclick="toggleDebug()">디버그 모드 토글</button>
     <button onclick="refreshAllData(event)">데이터 새로고침</button>
-    <button onclick="runWebAppAndReload(event)">웹앱 실행 후 새로고침</button>
   </div>
 
   <div id="disclaimer" role="note">
@@ -433,22 +432,6 @@
           button.textContent = '데이터 새로고침';
         }
       });
-    }
-
-    // 웹앱 실행 후 페이지 새로고침
-    async function runWebAppAndReload(e) {
-      const button = e ? e.target : document.querySelector('button[onclick*="runWebAppAndReload"]');
-      if (button) {
-        button.disabled = true;
-        button.textContent = '업데이트 중...';
-      }
-      try {
-        await fetch(ENDPOINT);
-      } catch (err) {
-        console.error('Web app run failed:', err);
-      } finally {
-        location.reload();
-      }
     }
     
     // 페이지 로드 시 실행

--- a/stocks.html
+++ b/stocks.html
@@ -244,7 +244,6 @@
     </ul>
     <button onclick="toggleDebug()">디버그 모드 토글</button>
     <button onclick="refreshAllData(event)">데이터 새로고침</button>
-    <button onclick="runWebAppAndReload(event)">웹앱 실행 후 새로고침</button>
   </div>
 
   <div id="disclaimer" role="note">
@@ -259,7 +258,7 @@
         <tr><th>지수</th><th>현재지수</th><th>등락(%)</th></tr>
       </thead>
       <tbody id="marketBody">
-        <tr><td>KOSPI</td><td>2,400.00</td><td class="positive">+0.5%</td></tr><tr><td>KOSDAQ</td><td>700.00</td><td class="negative">-0.3%</td></tr><tr><td>S&P500</td><td>4,500.00</td><td class="positive">+0.22%</td></tr><tr><td>NASDAQ100</td><td>15,000.00</td><td class="positive">+0.67%</td></tr>
+        <tr><td>KOSPI</td><td>N/A</td><td class="neutral">N/A</td></tr><tr><td>KOSDAQ</td><td>N/A</td><td class="neutral">N/A</td></tr><tr><td>S&P500</td><td>N/A</td><td class="neutral">N/A</td></tr><tr><td>NASDAQ100</td><td>N/A</td><td class="neutral">N/A</td></tr>
       </tbody>
     </table>
   
@@ -269,7 +268,7 @@
 
   <section id="portfolioRecommendations">
     <h2>포트폴리오 추천</h2>
-    <div id="recommendations"><div class="portfolio-group"><h3>KOSPI 안전주</h3><ul><li>삼성전자</li><li>현대차</li><li>LG화학</li><li>SK텔레콤</li><li>POSCO홀딩스</li></ul></div><div class="portfolio-group"><h3>KOSPI 공격적 종목</h3><ul><li>카카오</li><li>네이버</li><li>셀트리온</li><li>HMM</li><li>두산에너빌리티</li></ul></div><div class="portfolio-group"><h3>KOSDAQ 안전주</h3><ul><li>셀트리온헬스케어</li><li>에코프로비엠</li><li>카카오게임즈</li><li>CJ ENM</li><li>스튜디오드래곤</li></ul></div><div class="portfolio-group"><h3>KOSDAQ 공격적 종목</h3><ul><li>제넥신</li><li>펄어비스</li><li>에이치엘비</li><li>알테오젠</li><li>씨젠</li></ul></div><div class="portfolio-group"><h3>NASDAQ 안전주</h3><ul><li>Apple</li><li>Microsoft</li><li>Amazon</li><li>Alphabet</li><li>Meta</li></ul></div><div class="portfolio-group"><h3>NASDAQ 공격적 종목</h3><ul><li>NVIDIA</li><li>Tesla</li><li>AMD</li><li>Netflix</li><li>Palantir</li></ul></div><div class="portfolio-group"><h3>NYSE 안전주</h3><ul><li>Coca-Cola</li><li>Johnson & Johnson</li><li>Procter & Gamble</li><li>Walmart</li><li>McDonald's</li></ul></div><div class="portfolio-group"><h3>NYSE 공격적 종목</h3><ul><li>Snowflake</li><li>Shopify</li><li>Uber</li><li>Block</li><li>Coinbase</li></ul></div></div>
+    <div id="recommendations"><p class="error">추천 데이터를 불러오지 못했습니다.</p></div>
     <div id="portfolioUpdated" class="last-updated"></div>
   </section>
   
@@ -444,21 +443,6 @@
       });
     }
 
-    // 웹앱 실행 후 페이지 새로고침
-    async function runWebAppAndReload(e) {
-      const button = e ? e.target : document.querySelector('button[onclick*="runWebAppAndReload"]');
-      if (button) {
-        button.disabled = true;
-        button.textContent = '업데이트 중...';
-      }
-      try {
-        await fetch(ENDPOINT);
-      } catch (err) {
-        console.error('Web app run failed:', err);
-      } finally {
-        location.reload();
-      }
-    }
     
     // 페이지 로드 시 실행
     document.addEventListener('DOMContentLoaded', function() {


### PR DESCRIPTION
## Summary
- stop using offline fallback data in build script
- remove webapp refresh button from template
- update daily workflow to watch template.html changes
- rebuild stocks page with new template

## Testing
- `node tests/apple_association.test.js`
- `node src/build.js` *(fails to fetch live data but builds with N/A)*

------
https://chatgpt.com/codex/tasks/task_b_688b27491550832abd064191052c0fb3