### PR TITLE
Fix GitHub workflow push permission

### DIFF
--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   build-and-deploy:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: 코드 체크아웃


### PR DESCRIPTION
## Summary
- allow `daily-build.yml` workflow to push changes by granting write permissions

## Testing
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_688c23960f3c832a855f4fec386772b7