### PR TITLE
Cache recommendations to avoid extra fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,12 @@ Run the script with:
 node fetchStockInfo.js
 ```
 
-`src/build.js` no longer reads `recommendations.json` directly. It first tries to fetch the data through a Google Apps Script and, if that fails, falls back to a public Google Drive file
-([link](https://drive.google.com/file/d/1OE6OGkhextQCBRG_jG3TC05LdV6RKRHZ/view?usp=drive_link)). This lets the build run without local JSON updates.
+`src/build.js` now uses `recommendations.json` as a cache. It first checks if the file was
+updated within the last 24 hours and, if so, uses the cached data. Otherwise it attempts to
+fetch fresh data through a Google Apps Script and writes the result back to the JSON file.
+If the fetch fails it will still fall back to the local file
+([link](https://drive.google.com/file/d/1OE6OGkhextQCBRG_jG3TC05LdV6RKRHZ/view?usp=drive_link)).
+This prevents unnecessary network requests during daily builds.
 
 ## Building `stocks.html`
 

--- a/src/build.js
+++ b/src/build.js
@@ -220,22 +220,41 @@ async function fetchMarketIndices() {
 
 // Fetch portfolio recommendations from Google Drive and build HTML
 async function fetchPortfolioRecommendations() {
+  const filePath = path.resolve('recommendations.json');
+  const CACHE_MAX_AGE = 1000 * 60 * 60 * 24; // 24 hours
   let data;
-  if (OFFLINE) {
+
+  // Try to use cached data if it is recent
+  if (fs.existsSync(filePath)) {
     try {
-      data = JSON.parse(fs.readFileSync(path.resolve('recommendations.json'), 'utf-8'));
+      const stat = fs.statSync(filePath);
+      if (Date.now() - stat.mtimeMs < CACHE_MAX_AGE) {
+        console.log('Using cached recommendations.json');
+        data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+      }
     } catch (err) {
-      console.error('Failed to load local recommendations:', err.message);
-      return {
-        html: '<div id="recommendations"><p class="error">추천 데이터를 불러오지 못했습니다.</p></div>',
-        lastUpdated: new Date(),
-      };
+      console.error('Failed to read cached recommendations:', err.message);
     }
-  } else {
+  }
+
+  // Fetch from remote if no valid cache and not in offline mode
+  if (!data && !OFFLINE) {
     try {
       data = await fetchWithRetry(SCRIPT_URL);
+      data.lastUpdated = new Date().toISOString();
+      fs.writeFileSync(filePath, JSON.stringify(data, null, 2));
+      console.log('recommendations.json updated');
     } catch (err) {
       console.error('Failed to fetch recommendations:', err.message);
+    }
+  }
+
+  // Fallback to local file when fetch failed or offline
+  if (!data) {
+    try {
+      data = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+    } catch (err) {
+      console.error('Failed to load local recommendations:', err.message);
       return {
         html: '<div id="recommendations"><p class="error">추천 데이터를 불러오지 못했습니다.</p></div>',
         lastUpdated: new Date(),


### PR DESCRIPTION
## Summary
- cache recommendation JSON so the build only fetches new data when necessary
- document caching behavior in the README

## Testing
- `node tests/apple_association.test.js`
- `OFFLINE=1 node src/build.js`

------
https://chatgpt.com/codex/tasks/task_b_688c268f72d8832ab9dbdcac82dc5507