### PR TITLE
Remove leftover market snapshot table

### DIFF
--- a/stocks.html
+++ b/stocks.html
@@ -32,18 +32,6 @@
   </div>
 
   <section id="marketSnapshot">
-    
-    <table>
-      <thead>
-        <tr><th>지수</th><th>현재지수</th><th>등락(%)</th></tr>
-      </thead>
-      <tbody id="marketBody">
-        <tr><td>KOSPI</td><td>2400.00</td><td class="positive">+0.5%</td></tr><tr><td>KOSDAQ</td><td>700.00</td><td class="negative">-0.3%</td></tr><tr><td>S&P500</td><td>4500.00</td><td class="positive">+0.22%</td></tr><tr><td>NASDAQ100</td><td>15000.00</td><td class="positive">+0.67%</td></tr>
-      </tbody>
-    </table>
-  
-    <div id="marketError" class="error" style="display:none;" role="alert"></div>
-    <div id="lastUpdated" class="last-updated"></div>
   </section>
 
   <section id="marketNews">


### PR DESCRIPTION
## Summary
- remove static table rows and status message from `stocks.html`

## Testing
- `node tests/apple_association.test.js`

------
https://chatgpt.com/codex/tasks/task_b_688c529617b8832a884b2835310f21eb