### PR TITLE
Add back market news section

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ The page also shows a "latest market news" section. Headlines are fetched from
 Yahoo Finance with a fallback to `data/sample_market_news.json` when network
 access is unavailable.
 
+The S&P 500 tracks 500 large companies listed on U.S. exchanges, while the
+NASDAQ 100 focuses on major non‑financial companies trading on the Nasdaq
+exchange. Many technology giants such as Apple and Microsoft are members of
+both indices, so an individual stock may appear in each section of the
+recommendations.
+
 ## Running tests
 
 The repository includes a simple Node.js script that verifies the `apple-app-site-association` file. Make sure Node.js is installed and run.
@@ -65,3 +71,9 @@ Page visits are tracked via a Google Apps Script. Send a request with the
 
 
 The script responds with JSON containing the `daily` and `total` fields.
+
+## Ideas for improvement
+
+- Add a dark mode toggle for better readability at night
+- Provide filters to sort recommendations by sector
+- Show small charts next to each index for quick visual trends

--- a/recommendations.json
+++ b/recommendations.json
@@ -115,54 +115,54 @@
     "safe": [
       {
         "name": "Apple",
-        "sector": null,
+        "sector": "Technology",
         "prevClose": null
       },
       {
         "name": "Microsoft",
-        "sector": null,
+        "sector": "Technology",
         "prevClose": null
       },
       {
         "name": "Amazon",
-        "sector": null,
+        "sector": "Consumer Cyclical",
         "prevClose": null
       },
       {
         "name": "Alphabet",
-        "sector": null,
+        "sector": "Communication Services",
         "prevClose": null
       },
       {
         "name": "Meta",
-        "sector": null,
+        "sector": "Communication Services",
         "prevClose": null
       }
     ],
     "aggressive": [
       {
         "name": "NVIDIA",
-        "sector": null,
+        "sector": "Technology",
         "prevClose": null
       },
       {
         "name": "Tesla",
-        "sector": null,
+        "sector": "Consumer Cyclical",
         "prevClose": null
       },
       {
         "name": "AMD",
-        "sector": null,
+        "sector": "Technology",
         "prevClose": null
       },
       {
         "name": "Netflix",
-        "sector": null,
+        "sector": "Communication Services",
         "prevClose": null
       },
       {
         "name": "Coinbase",
-        "sector": null,
+        "sector": "Financial Services",
         "prevClose": null
       }
     ]
@@ -171,54 +171,54 @@
     "safe": [
       {
         "name": "Coca-Cola",
-        "sector": null,
+        "sector": "Consumer Defensive",
         "prevClose": null
       },
       {
         "name": "Johnson & Johnson",
-        "sector": null,
+        "sector": "Healthcare",
         "prevClose": null
       },
       {
         "name": "Procter & Gamble",
-        "sector": null,
+        "sector": "Consumer Defensive",
         "prevClose": null
       },
       {
         "name": "Walmart",
-        "sector": null,
+        "sector": "Consumer Defensive",
         "prevClose": null
       },
       {
         "name": "McDonald's",
-        "sector": null,
+        "sector": "Consumer Cyclical",
         "prevClose": null
       }
     ],
     "aggressive": [
       {
         "name": "Snowflake",
-        "sector": null,
+        "sector": "Technology",
         "prevClose": null
       },
       {
         "name": "Shopify",
-        "sector": null,
+        "sector": "Technology",
         "prevClose": null
       },
       {
         "name": "Uber",
-        "sector": null,
+        "sector": "Industrials",
         "prevClose": null
       },
       {
         "name": "Block",
-        "sector": null,
+        "sector": "Technology",
         "prevClose": null
       },
       {
         "name": "Palantir",
-        "sector": null,
+        "sector": "Technology",
         "prevClose": null
       }
     ]

--- a/src/build.js
+++ b/src/build.js
@@ -271,16 +271,24 @@ async function fetchPortfolioRecommendations() {
     const markets = ['KOSPI', 'KOSDAQ', 'NASDAQ', 'S&P 500'];
     const htmlParts = [];
     for (const m of markets) {
-      const info = data[m];
+      const info = data[m] || (m === 'S&P 500' ? data['NYSE'] : undefined);
       if (!info) continue;
       htmlParts.push(
         `<div class="portfolio-group"><h3>${m} 안전주</h3><ul>` +
-          info.safe.map(s => `<li>${typeof s === 'string' ? s : s.name}</li>`).join('') +
+          info.safe.map(s => {
+            const name = typeof s === 'string' ? s : s.name;
+            const sector = s.sector ? `<span class="sector">${s.sector}</span>` : '';
+            return `<li>${name}${sector}</li>`;
+          }).join('') +
         '</ul></div>'
       );
       htmlParts.push(
         `<div class="portfolio-group"><h3>${m} 공격적 종목</h3><ul>` +
-          info.aggressive.map(s => `<li>${typeof s === 'string' ? s : s.name}</li>`).join('') +
+          info.aggressive.map(s => {
+            const name = typeof s === 'string' ? s : s.name;
+            const sector = s.sector ? `<span class="sector">${s.sector}</span>` : '';
+            return `<li>${name}${sector}</li>`;
+          }).join('') +
         '</ul></div>'
       );
     }

--- a/src/template.html
+++ b/src/template.html
@@ -31,11 +31,10 @@
     본 페이지의 정보는 투자 참고용이며, 제공된 데이터의 정확성을 보장하지 않습니다. 투자 판단의 책임은 이용자에게 있습니다.
   </div>
 
-  <section id="marketSnapshot">
-    <h2>마켓 스냅샷</h2>
-    {{MARKET_TABLE}}
-    <div id="marketError" class="error" style="display:none;" role="alert"></div>
-    <div id="lastUpdated" class="last-updated"></div>
+  <section id="marketNews">
+    <h2>최신 마켓 뉴스</h2>
+    <ul id="newsList" class="news-list"></ul>
+    <div id="newsError" class="error" style="display:none;" role="alert"></div>
   </section>
 
   <section id="portfolioRecommendations">
@@ -174,6 +173,38 @@
       document.getElementById('lastUpdated').textContent = ts;
     }
 
+  // 최신 마켓 뉴스 로드
+  async function loadMarketNews() {
+      let sample = [];
+      try {
+        const res = await fetch('data/sample_market_news.json');
+        sample = await res.json();
+      } catch (e) {
+        console.warn('sample market news load failed', e);
+      }
+
+      try {
+        const feedUrl = 'https://feeds.finance.yahoo.com/rss/2.0/headline?s=%5EGSPC&region=US&lang=en-US';
+        const res = await fetch(`https://api.allorigins.win/get?url=${encodeURIComponent(feedUrl)}`);
+        const { contents } = await res.json();
+        const parser = new DOMParser();
+        const xml = parser.parseFromString(contents, 'text/xml');
+        const items = Array.from(xml.querySelectorAll('item')).slice(0,5);
+        const headlines = items.map(it => it.querySelector('title').textContent);
+        document.getElementById('newsList').innerHTML = headlines.map(h => `<li>${h}</li>`).join('');
+        document.getElementById('newsError').style.display = 'none';
+      } catch (err) {
+        console.error('news load failed', err);
+        if (sample.length) {
+          document.getElementById('newsList').innerHTML = sample.map(h => `<li>${h}</li>`).join('');
+          document.getElementById('newsError').style.display = 'none';
+        } else {
+          document.getElementById('newsError').textContent = '뉴스를 불러오지 못했습니다.';
+          document.getElementById('newsError').style.display = 'block';
+        }
+      }
+  }
+
     // 추천 종목 로드
     const ENDPOINT = 'https://script.google.com/macros/s/AKfycbzgzE7psPX5rfMLsDprAy8jmYqwUphiKuzCDUc2ji3-dRKWSgIhb1O4Kgnrg7zk1FCyrA/exec';
 
@@ -237,14 +268,16 @@
     function render(data) {
       const container = document.getElementById('recommendations');
       if (!container) return;
-      const markets = Object.keys(data).filter(k => k !== 'lastUpdated');
+      const markets = Object.keys(data).filter(k => k !== 'lastUpdated').map(k => k === 'NYSE' ? 'S&P 500' : k);
       const html = [];
       for (const m of markets) {
-        const info = data[m];
+        const key = m === 'S&P 500' && !data[m] && data['NYSE'] ? 'NYSE' : m;
+        const info = data[key];
         for (const bucket of ['safe', 'aggressive']) {
           const items = (info?.[bucket] || []).map(item => {
             const name = FULL_NAME_MAP[item.name] || item.name;
-            return `<li>${name}</li>`;
+            const sector = item.sector ? `<span class="sector">${item.sector}</span>` : '';
+            return `<li>${name}${sector}</li>`;
           }).join('');
           html.push(`<div class="portfolio-group"><h3>${m} ${bucket === 'safe' ? '안전주' : '공격적 종목'}</h3><ul>${items}</ul></div>`);
         }
@@ -263,7 +296,7 @@
         button.disabled = true;
         button.textContent = '새로고침 중...';
       }
-      Promise.all([loadMarketData(), fetchRecs()]).finally(() => {
+      Promise.all([loadMarketData(), fetchRecs(), loadMarketNews()]).finally(() => {
         if (button) {
           button.disabled = false;
           button.textContent = '데이터 새로고침';

--- a/stocks.css
+++ b/stocks.css
@@ -139,6 +139,12 @@ tr:hover {
   background-color: #fdfdfd;
 }
 
+.portfolio-group .sector {
+  margin-left: 4px;
+  color: #6b7280;
+  font-size: 0.85em;
+}
+
 .loading {
   text-align: center;
   color: #7f8c8d;

--- a/stocks.html
+++ b/stocks.html
@@ -31,17 +31,15 @@
     본 페이지의 정보는 투자 참고용이며, 제공된 데이터의 정확성을 보장하지 않습니다. 투자 판단의 책임은 이용자에게 있습니다.
   </div>
 
-
   <section id="marketNews">
     <h2>최신 마켓 뉴스</h2>
     <ul id="newsList" class="news-list"></ul>
     <div id="newsError" class="error" style="display:none;" role="alert"></div>
   </section>
 
-
   <section id="portfolioRecommendations">
     <h2>포트폴리오 추천</h2>
-    <div id="recommendations"><div class="portfolio-group"><h3>KOSPI 안전주</h3><ul><li>삼성전자</li><li>현대차</li><li>LG화학</li><li>SK텔레콤</li><li>POSCO홀딩스</li></ul></div><div class="portfolio-group"><h3>KOSPI 공격적 종목</h3><ul><li>카카오</li><li>네이버</li><li>셀트리온</li><li>HMM</li><li>두산에너빌리티</li></ul></div><div class="portfolio-group"><h3>KOSDAQ 안전주</h3><ul><li>셀트리온헬스케어</li><li>에코프로비엠</li><li>카카오게임즈</li><li>CJ ENM</li><li>스튜디오드래곤</li></ul></div><div class="portfolio-group"><h3>KOSDAQ 공격적 종목</h3><ul><li>제넥신</li><li>펄어비스</li><li>에이치엘비</li><li>알테오젠</li><li>씨젠</li></ul></div><div class="portfolio-group"><h3>NASDAQ 안전주</h3><ul><li>Apple</li><li>Microsoft</li><li>Amazon</li><li>Alphabet</li><li>Meta</li></ul></div><div class="portfolio-group"><h3>NASDAQ 공격적 종목</h3><ul><li>NVIDIA</li><li>Tesla</li><li>AMD</li><li>Netflix</li><li>Coinbase</li></ul></div><div class="portfolio-group"><h3>S&P 500 안전주</h3><ul><li>Coca-Cola</li><li>Johnson & Johnson</li><li>Procter & Gamble</li><li>Walmart</li><li>McDonald's</li></ul></div><div class="portfolio-group"><h3>S&P 500 공격적 종목</h3><ul><li>Snowflake</li><li>Shopify</li><li>Uber</li><li>Block</li><li>Palantir</li></ul></div></div>
+    <div id="recommendations"><div class="portfolio-group"><h3>KOSPI 안전주</h3><ul><li>삼성전자</li><li>현대차</li><li>LG화학</li><li>SK텔레콤</li><li>POSCO홀딩스</li></ul></div><div class="portfolio-group"><h3>KOSPI 공격적 종목</h3><ul><li>카카오</li><li>네이버</li><li>셀트리온</li><li>HMM</li><li>두산에너빌리티</li></ul></div><div class="portfolio-group"><h3>KOSDAQ 안전주</h3><ul><li>셀트리온헬스케어</li><li>에코프로비엠</li><li>카카오게임즈</li><li>CJ ENM</li><li>스튜디오드래곤</li></ul></div><div class="portfolio-group"><h3>KOSDAQ 공격적 종목</h3><ul><li>제넥신</li><li>펄어비스</li><li>에이치엘비</li><li>알테오젠</li><li>씨젠</li></ul></div><div class="portfolio-group"><h3>NASDAQ 안전주</h3><ul><li>Apple<span class="sector">Technology</span></li><li>Microsoft<span class="sector">Technology</span></li><li>Amazon<span class="sector">Consumer Cyclical</span></li><li>Alphabet<span class="sector">Communication Services</span></li><li>Meta<span class="sector">Communication Services</span></li></ul></div><div class="portfolio-group"><h3>NASDAQ 공격적 종목</h3><ul><li>NVIDIA<span class="sector">Technology</span></li><li>Tesla<span class="sector">Consumer Cyclical</span></li><li>AMD<span class="sector">Technology</span></li><li>Netflix<span class="sector">Communication Services</span></li><li>Coinbase<span class="sector">Financial Services</span></li></ul></div><div class="portfolio-group"><h3>S&P 500 안전주</h3><ul><li>Coca-Cola<span class="sector">Consumer Defensive</span></li><li>Johnson & Johnson<span class="sector">Healthcare</span></li><li>Procter & Gamble<span class="sector">Consumer Defensive</span></li><li>Walmart<span class="sector">Consumer Defensive</span></li><li>McDonald's<span class="sector">Consumer Cyclical</span></li></ul></div><div class="portfolio-group"><h3>S&P 500 공격적 종목</h3><ul><li>Snowflake<span class="sector">Technology</span></li><li>Shopify<span class="sector">Technology</span></li><li>Uber<span class="sector">Industrials</span></li><li>Block<span class="sector">Technology</span></li><li>Palantir<span class="sector">Technology</span></li></ul></div></div>
     <div id="portfolioUpdated" class="last-updated"></div>
   </section>
   
@@ -73,39 +71,7 @@
         sample = await res.json();
       } catch (e) {
         console.warn('sample market data load failed', e);
-  }
-
-  // 최신 마켓 뉴스 로드
-  async function loadNews() {
-      const rss = "https://news.google.com/rss/search?q=stock+market&hl=en-US&gl=US&ceid=US:en";
-      let sample = [];
-      try {
-        const res = await fetch('data/sample_market_news.json');
-        sample = await res.json();
-      } catch (e) {
-        console.warn('sample market news load failed', e);
       }
-
-      try {
-        const res = await fetch(`https://api.allorigins.win/get?url=${encodeURIComponent(rss)}`);
-        const { contents } = await res.json();
-        const parser = new DOMParser();
-        const doc = parser.parseFromString(contents, 'application/xml');
-        const items = Array.from(doc.querySelectorAll('item')).slice(0,5);
-        const headlines = items.map(it => it.querySelector('title').textContent);
-        document.getElementById('newsList').innerHTML = headlines.map(h => `<li>${h}</li>`).join('');
-        document.getElementById('newsError').style.display = 'none';
-      } catch (err) {
-        console.error('news load failed', err);
-        if (sample.length) {
-          document.getElementById('newsList').innerHTML = sample.map(h => `<li>${h}</li>`).join('');
-          document.getElementById('newsError').style.display = 'none';
-        } else {
-          document.getElementById('newsError').textContent = '뉴스를 불러오지 못했습니다.';
-          document.getElementById('newsError').style.display = 'block';
-        }
-      }
-  }
 
       const indices = [
         { name: 'KOSPI', code: 'KOSPI', type: 'naver' },
@@ -207,6 +173,38 @@
       document.getElementById('lastUpdated').textContent = ts;
     }
 
+  // 최신 마켓 뉴스 로드
+  async function loadMarketNews() {
+      let sample = [];
+      try {
+        const res = await fetch('data/sample_market_news.json');
+        sample = await res.json();
+      } catch (e) {
+        console.warn('sample market news load failed', e);
+      }
+
+      try {
+        const feedUrl = 'https://feeds.finance.yahoo.com/rss/2.0/headline?s=%5EGSPC&region=US&lang=en-US';
+        const res = await fetch(`https://api.allorigins.win/get?url=${encodeURIComponent(feedUrl)}`);
+        const { contents } = await res.json();
+        const parser = new DOMParser();
+        const xml = parser.parseFromString(contents, 'text/xml');
+        const items = Array.from(xml.querySelectorAll('item')).slice(0,5);
+        const headlines = items.map(it => it.querySelector('title').textContent);
+        document.getElementById('newsList').innerHTML = headlines.map(h => `<li>${h}</li>`).join('');
+        document.getElementById('newsError').style.display = 'none';
+      } catch (err) {
+        console.error('news load failed', err);
+        if (sample.length) {
+          document.getElementById('newsList').innerHTML = sample.map(h => `<li>${h}</li>`).join('');
+          document.getElementById('newsError').style.display = 'none';
+        } else {
+          document.getElementById('newsError').textContent = '뉴스를 불러오지 못했습니다.';
+          document.getElementById('newsError').style.display = 'block';
+        }
+      }
+  }
+
     // 추천 종목 로드
     const ENDPOINT = 'https://script.google.com/macros/s/AKfycbzgzE7psPX5rfMLsDprAy8jmYqwUphiKuzCDUc2ji3-dRKWSgIhb1O4Kgnrg7zk1FCyrA/exec';
 
@@ -270,14 +268,16 @@
     function render(data) {
       const container = document.getElementById('recommendations');
       if (!container) return;
-      const markets = Object.keys(data).filter(k => k !== 'lastUpdated');
+      const markets = Object.keys(data).filter(k => k !== 'lastUpdated').map(k => k === 'NYSE' ? 'S&P 500' : k);
       const html = [];
       for (const m of markets) {
-        const info = data[m];
+        const key = m === 'S&P 500' && !data[m] && data['NYSE'] ? 'NYSE' : m;
+        const info = data[key];
         for (const bucket of ['safe', 'aggressive']) {
           const items = (info?.[bucket] || []).map(item => {
             const name = FULL_NAME_MAP[item.name] || item.name;
-            return `<li>${name}</li>`;
+            const sector = item.sector ? `<span class="sector">${item.sector}</span>` : '';
+            return `<li>${name}${sector}</li>`;
           }).join('');
           html.push(`<div class="portfolio-group"><h3>${m} ${bucket === 'safe' ? '안전주' : '공격적 종목'}</h3><ul>${items}</ul></div>`);
         }
@@ -296,7 +296,7 @@
         button.disabled = true;
         button.textContent = '새로고침 중...';
       }
-      Promise.all([loadMarketData(), fetchRecs(), loadNews()]).finally(() => {
+      Promise.all([loadMarketData(), fetchRecs(), loadMarketNews()]).finally(() => {
         if (button) {
           button.disabled = false;
           button.textContent = '데이터 새로고침';


### PR DESCRIPTION
## Summary
- restore Yahoo Finance news feed on the stocks page
- keep sectors in portfolio recommendations
- document future improvement ideas

## Testing
- `node tests/apple_association.test.js`
- `OFFLINE=1 node src/build.js`


------
https://chatgpt.com/codex/tasks/task_b_688c603956e0832abc9d9ffb4ff4e2eb