### PR TITLE
Add language toggle to stocks page

### DIFF
--- a/stocks.css
+++ b/stocks.css
@@ -62,6 +62,11 @@ h3 {
   text-decoration: underline;
 }
 
+#languageSwitcher {
+  text-align: right;
+  margin-bottom: 10px;
+}
+
 button {
   background-color: #3498db;
   color: white;

--- a/stocks.html
+++ b/stocks.html
@@ -9,6 +9,10 @@
 <body>
   <h1 data-i18n="title">데일리 주식 리포트 자동화</h1>
   <p id="currentDate"><span id="datePrefix" data-i18n="today">오늘:</span> 2025년 8월 1일</p>
+  <div id="languageSwitcher">
+    <button onclick="setLanguage('en')">English</button>
+    <button onclick="setLanguage('ko')">한국어</button>
+  </div>
   
   <div id="debugInfo" class="debug" style="display: none;">
     <h4>디버그 정보:</h4>
@@ -94,7 +98,19 @@
       }
     };
 
-    const currentLang = (navigator.language || 'en').startsWith('ko') ? 'ko' : 'en';
+    let currentLang = localStorage.getItem('lang') || ((navigator.language || 'en').startsWith('ko') ? 'ko' : 'en');
+
+    function setLanguage(lang) {
+      currentLang = lang;
+      localStorage.setItem('lang', lang);
+      applyTranslations();
+      const dateEl = document.getElementById('currentDate');
+      if (dateEl) {
+        const opts = { year: 'numeric', month: 'long', day: 'numeric' };
+        const locale = currentLang === 'ko' ? 'ko-KR' : 'en-US';
+        dateEl.innerHTML = `<span id="datePrefix" data-i18n="today">${translations[currentLang].today}</span> ` + new Date().toLocaleDateString(locale, opts);
+      }
+    }
 
     function applyTranslations() {
       const t = translations[currentLang];


### PR DESCRIPTION
## Summary
- add UI for choosing Korean or English on the stock report page
- remember language choice and update date label automatically
- style the new language switcher

## Testing
- `node tests/apple_association.test.js`

------
https://chatgpt.com/codex/tasks/task_b_688c9ebbacc8832aae494773d9b6ad37