### PR TITLE
Fix news refresh with local JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ The build script collects market index data from Naver for the Korean indices
 (KOSPI, KOSDAQ) and from Investing.com for the S&P 500 and NASDAQ 100. It now
 parses the previous closing value for KOSPI and KOSDAQ so the generated
 `stocks.html` page can display those figures alongside the current index value.
-The page also shows a "latest market news" section. Headlines are fetched from
-Yahoo Finance with a fallback to `data/sample_market_news.json` when network
-access is unavailable.
+The page also shows a "latest market news" section. A helper script pulls
+headlines from Yahoo Finance and several Korean sources every six hours and
+writes them to `data/market_news.json`. When the page loads it reads this file,
+falling back to `data/sample_market_news.json` if needed.
 
 The S&P 500 tracks 500 large companies listed on U.S. exchanges, while the
 NASDAQ 100 focuses on major non‑financial companies trading on the Nasdaq
@@ -43,6 +44,19 @@ fetch fresh data through a Google Apps Script and writes the result back to the 
 If the fetch fails it will still fall back to the local file
 ([link](https://drive.google.com/file/d/1OE6OGkhextQCBRG_jG3TC05LdV6RKRHZ/view?usp=drive_link)).
 This prevents unnecessary network requests during daily builds.
+
+## Updating market news
+
+`fetchNews.js` gathers the latest headlines from several RSS feeds, including
+three Korean sources, and writes them to `data/market_news.json`. The script
+keeps the file fresh by skipping the download when it was updated within the
+last six hours.
+
+Run it manually whenever you want to refresh the news:
+
+```bash
+node fetchNews.js
+```
 
 ## Building `stocks.html`
 

--- a/data/market_news.json
+++ b/data/market_news.json
@@ -1,0 +1,6 @@
+{
+  "lastUpdated": "2025-08-01T00:00:00Z",
+  "items": [
+    {"title": "Example Headline", "link": "https://example.com"}
+  ]
+}

--- a/fetchNews.js
+++ b/fetchNews.js
@@ -1,0 +1,85 @@
+import fs from 'fs';
+import fetch from 'node-fetch';
+import { HttpsProxyAgent } from 'https-proxy-agent';
+
+const OUTPUT = 'data/market_news.json';
+const SIX_HOURS = 6 * 60 * 60 * 1000;
+
+const proxy = process.env.HTTPS_PROXY || process.env.HTTP_PROXY;
+const agent = proxy ? new HttpsProxyAgent(proxy) : undefined;
+
+const FEEDS = {
+  en: 'https://feeds.finance.yahoo.com/rss/2.0/headline?s=%5EGSPC&region=US&lang=en-US',
+  kr1: 'https://news.google.com/rss/search?q=%ED%95%9C%EA%B5%AD%20%EC%A6%9D%EC%8B%9C&hl=ko&gl=KR&ceid=KR:ko',
+  kr2: 'https://news.google.com/rss/search?q=%EC%BD%94%EC%8A%A4%ED%94%BC&hl=ko&gl=KR&ceid=KR:ko',
+  kr3: 'https://news.google.com/rss/search?q=%EC%A3%BC%EC%8B%9D%20%EC%8B%9C%ED%99%A9&hl=ko&gl=KR&ceid=KR:ko'
+};
+
+function parseItems(xml) {
+  const items = [];
+  const regex = /<item>([\s\S]*?)<\/item>/g;
+  let m;
+  while ((m = regex.exec(xml)) && items.length < 5) {
+    const item = m[1];
+    const titleMatch = item.match(/<title>(?:<!\[CDATA\[)?([\s\S]*?)(?:\]\]>)?<\/title>/);
+    const linkMatch = item.match(/<link>([\s\S]*?)<\/link>/);
+    if (titleMatch && linkMatch) {
+      const title = titleMatch[1].trim();
+      const link = linkMatch[1].trim();
+      items.push({ title, link });
+    }
+  }
+  return items;
+}
+
+async function fetchFeed(url) {
+  const proxyUrl = `https://api.allorigins.win/get?url=${encodeURIComponent(url)}`;
+  const res = await fetch(proxyUrl, { agent });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const { contents } = await res.json();
+  return parseItems(contents);
+}
+
+async function main() {
+  let current;
+  try {
+    current = JSON.parse(fs.readFileSync(OUTPUT, 'utf8'));
+  } catch {}
+  if (current && current.lastUpdated) {
+    const age = Date.now() - new Date(current.lastUpdated).getTime();
+    if (age < SIX_HOURS && current.items?.length) {
+      console.log('News is up to date.');
+      return;
+    }
+  }
+
+  const all = [];
+  try {
+    const items = await fetchFeed(FEEDS.en);
+    all.push(...items.slice(0, 2));
+  } catch (e) {
+    console.error('Failed EN feed', e.message);
+  }
+  for (const key of ['kr1', 'kr2', 'kr3']) {
+    try {
+      const items = await fetchFeed(FEEDS[key]);
+      all.push(...items.slice(0, 2));
+    } catch (e) {
+      console.error('Failed', key, e.message);
+    }
+  }
+
+  if (all.length === 0 && current) {
+    console.log('Using existing news due to failures.');
+    return;
+  }
+
+  const out = { lastUpdated: new Date().toISOString(), items: all.slice(0, 8) };
+  fs.writeFileSync(OUTPUT, JSON.stringify(out, null, 2));
+  console.log('Updated', OUTPUT);
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/template.html
+++ b/src/template.html
@@ -258,45 +258,49 @@
     }
 
   // 최신 마켓 뉴스 로드
-  async function loadMarketNews() {
-      let sample = [];
-      try {
-        const res = await fetch('data/sample_market_news.json');
-        sample = await res.json();
-      } catch (e) {
-        console.warn('sample market news load failed', e);
-      }
+  let newsTimestamp = null;
 
+  function renderNewsUpdated() {
+      const upd = document.getElementById('newsUpdated');
+      if (upd && newsTimestamp) {
+        const locale = currentLang === 'ko' ? 'ko-KR' : 'en-US';
+        upd.textContent = translations[currentLang].updated + newsTimestamp.toLocaleString(locale);
+      }
+  }
+
+  async function loadMarketNews() {
+      let data = null;
       try {
-        const feedUrl = 'https://feeds.finance.yahoo.com/rss/2.0/headline?s=%5EGSPC&region=US&lang=en-US';
-        const res = await fetch(`https://api.allorigins.win/get?url=${encodeURIComponent(feedUrl)}`);
-        const { contents } = await res.json();
-        const parser = new DOMParser();
-        const xml = parser.parseFromString(contents, 'text/xml');
-        const items = Array.from(xml.querySelectorAll('item')).slice(0,5);
-        const headlines = items.map(it => ({
-          title: it.querySelector('title').textContent,
-          link: it.querySelector('link').textContent
-        }));
-        document.getElementById('newsList').innerHTML = headlines
-          .map(h => `<li><a href="${h.link}" target="_blank" rel="noopener">${h.title}</a></li>`)
-          .join('');
-        document.getElementById('newsError').style.display = 'none';
-      } catch (err) {
-        console.error('news load failed', err);
-        if (sample.length) {
-          document.getElementById('newsList').innerHTML = sample.map(h => `<li>${h}</li>`).join('');
-          document.getElementById('newsError').style.display = 'none';
-        } else {
-          document.getElementById('newsError').textContent = translations[currentLang].newsError;
-          document.getElementById('newsError').style.display = 'block';
+        const res = await fetch('data/market_news.json');
+        if (!res.ok) throw new Error('HTTP ' + res.status);
+        data = await res.json();
+      } catch (e) {
+        console.warn('market_news.json load failed', e);
+        try {
+          const res = await fetch('data/sample_market_news.json');
+          data = await res.json();
+        } catch (err) {
+          console.warn('sample market news load failed', err);
+          data = null;
         }
       }
-      const upd = document.getElementById('newsUpdated');
-      if (upd) {
-        const locale = currentLang === 'ko' ? 'ko-KR' : 'en-US';
-        upd.textContent = translations[currentLang].updated + new Date().toLocaleString(locale);
+
+      if (data) {
+        if (Array.isArray(data)) {
+          newsTimestamp = new Date();
+          document.getElementById('newsList').innerHTML = data.map(t => `<li>${t}</li>`).join('');
+        } else if (Array.isArray(data.items)) {
+          newsTimestamp = new Date(data.lastUpdated);
+          document.getElementById('newsList').innerHTML = data.items
+            .map(h => `<li><a href="${h.link}" target="_blank" rel="noopener">${h.title}</a></li>`)
+            .join('');
+        }
+        document.getElementById('newsError').style.display = 'none';
+      } else {
+        document.getElementById('newsError').textContent = translations[currentLang].newsError;
+        document.getElementById('newsError').style.display = 'block';
       }
+      renderNewsUpdated();
   }
 
     // 추천 종목 로드
@@ -359,7 +363,10 @@
       }
     }
 
+    let lastRecommendations = null;
+
     function render(data) {
+      lastRecommendations = data;
       const container = document.getElementById('recommendations');
       if (!container) return;
       const markets = Array.from(new Set(
@@ -413,12 +420,16 @@
         currentLang = 'ko';
         applyTranslations();
         updateCurrentDate();
+        renderNewsUpdated();
+        if (lastRecommendations) render(lastRecommendations);
         updateVisitCounts();
       });
       document.getElementById('btnEn').addEventListener('click', function() {
         currentLang = 'en';
         applyTranslations();
         updateCurrentDate();
+        renderNewsUpdated();
+        if (lastRecommendations) render(lastRecommendations);
         updateVisitCounts();
       });
 

--- a/stocks.html
+++ b/stocks.html
@@ -258,45 +258,49 @@
     }
 
   // 최신 마켓 뉴스 로드
-  async function loadMarketNews() {
-      let sample = [];
-      try {
-        const res = await fetch('data/sample_market_news.json');
-        sample = await res.json();
-      } catch (e) {
-        console.warn('sample market news load failed', e);
-      }
+  let newsTimestamp = null;
 
+  function renderNewsUpdated() {
+      const upd = document.getElementById('newsUpdated');
+      if (upd && newsTimestamp) {
+        const locale = currentLang === 'ko' ? 'ko-KR' : 'en-US';
+        upd.textContent = translations[currentLang].updated + newsTimestamp.toLocaleString(locale);
+      }
+  }
+
+  async function loadMarketNews() {
+      let data = null;
       try {
-        const feedUrl = 'https://feeds.finance.yahoo.com/rss/2.0/headline?s=%5EGSPC&region=US&lang=en-US';
-        const res = await fetch(`https://api.allorigins.win/get?url=${encodeURIComponent(feedUrl)}`);
-        const { contents } = await res.json();
-        const parser = new DOMParser();
-        const xml = parser.parseFromString(contents, 'text/xml');
-        const items = Array.from(xml.querySelectorAll('item')).slice(0,5);
-        const headlines = items.map(it => ({
-          title: it.querySelector('title').textContent,
-          link: it.querySelector('link').textContent
-        }));
-        document.getElementById('newsList').innerHTML = headlines
-          .map(h => `<li><a href="${h.link}" target="_blank" rel="noopener">${h.title}</a></li>`)
-          .join('');
-        document.getElementById('newsError').style.display = 'none';
-      } catch (err) {
-        console.error('news load failed', err);
-        if (sample.length) {
-          document.getElementById('newsList').innerHTML = sample.map(h => `<li>${h}</li>`).join('');
-          document.getElementById('newsError').style.display = 'none';
-        } else {
-          document.getElementById('newsError').textContent = translations[currentLang].newsError;
-          document.getElementById('newsError').style.display = 'block';
+        const res = await fetch('data/market_news.json');
+        if (!res.ok) throw new Error('HTTP ' + res.status);
+        data = await res.json();
+      } catch (e) {
+        console.warn('market_news.json load failed', e);
+        try {
+          const res = await fetch('data/sample_market_news.json');
+          data = await res.json();
+        } catch (err) {
+          console.warn('sample market news load failed', err);
+          data = null;
         }
       }
-      const upd = document.getElementById('newsUpdated');
-      if (upd) {
-        const locale = currentLang === 'ko' ? 'ko-KR' : 'en-US';
-        upd.textContent = translations[currentLang].updated + new Date().toLocaleString(locale);
+
+      if (data) {
+        if (Array.isArray(data)) {
+          newsTimestamp = new Date();
+          document.getElementById('newsList').innerHTML = data.map(t => `<li>${t}</li>`).join('');
+        } else if (Array.isArray(data.items)) {
+          newsTimestamp = new Date(data.lastUpdated);
+          document.getElementById('newsList').innerHTML = data.items
+            .map(h => `<li><a href="${h.link}" target="_blank" rel="noopener">${h.title}</a></li>`)
+            .join('');
+        }
+        document.getElementById('newsError').style.display = 'none';
+      } else {
+        document.getElementById('newsError').textContent = translations[currentLang].newsError;
+        document.getElementById('newsError').style.display = 'block';
       }
+      renderNewsUpdated();
   }
 
     // 추천 종목 로드
@@ -359,7 +363,10 @@
       }
     }
 
+    let lastRecommendations = null;
+
     function render(data) {
+      lastRecommendations = data;
       const container = document.getElementById('recommendations');
       if (!container) return;
       const markets = Array.from(new Set(
@@ -413,12 +420,16 @@
         currentLang = 'ko';
         applyTranslations();
         updateCurrentDate();
+        renderNewsUpdated();
+        if (lastRecommendations) render(lastRecommendations);
         updateVisitCounts();
       });
       document.getElementById('btnEn').addEventListener('click', function() {
         currentLang = 'en';
         applyTranslations();
         updateCurrentDate();
+        renderNewsUpdated();
+        if (lastRecommendations) render(lastRecommendations);
         updateVisitCounts();
       });
 


### PR DESCRIPTION
## Summary
- fetch news to `data/market_news.json` with new `fetchNews.js`
- load news from the JSON file in the stock page
- remove six‑hour client timer
- document how to update the news cache

## Testing
- `node tests/apple_association.test.js`
- `node src/build.js` *(fails to fetch market data but succeeds using cached data)*

------
https://chatgpt.com/codex/tasks/task_b_688ca906e384832a898f38cde99fd4fa