### PR TITLE
Update market news fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@ This prevents unnecessary network requests during daily builds.
 
 ## Updating market news
 
-`fetchNews.js` gathers the latest headlines from several RSS feeds, including
-three Korean sources, and writes them to `data/market_news.json`. The script
-keeps the file fresh by skipping the download when it was updated within the
-last six hours.
+`fetchNews.js` gathers the latest headlines from several RSS feeds. It collects
+five US market items from Yahoo Finance and one headline from each of three
+Korean Google News queries, then writes them to `data/market_news.json`. The
+file is only refreshed when the previous update is older than six hours.
 
 Run it manually whenever you want to refresh the news:
 

--- a/data/market_news.json
+++ b/data/market_news.json
@@ -1,6 +1,37 @@
 {
-  "lastUpdated": "2025-08-01T00:00:00Z",
+  "lastUpdated": "2025-08-01T12:42:28.322Z",
   "items": [
-    {"title": "Example Headline", "link": "https://example.com"}
+    {
+      "title": "Chevron Stock Rises After Earnings Beat. These Concerns Remain.",
+      "link": "https://finance.yahoo.com/m/8e81c070-1d0a-3834-b76e-4e132a8cbff7/chevron-stock-rises-after.html?.tsrc=rss"
+    },
+    {
+      "title": "Exxon Mobil Stock Rises on Earnings. CEO Cites Highest Upstream Production in 25 Years.",
+      "link": "https://finance.yahoo.com/m/43b1ce72-d8ad-34de-85a2-af68b6330593/exxon-mobil-stock-rises-on.html?.tsrc=rss"
+    },
+    {
+      "title": "Tesla Stock Slips. Musk Faces Questions About Robo-Taxi Expansion.",
+      "link": "https://finance.yahoo.com/m/99f5a2d5-f7ad-3a4e-b84f-fb5abb84647e/tesla-stock-slips.-musk-faces.html?.tsrc=rss"
+    },
+    {
+      "title": "Trending tickers: Figma, Apple, Amazon, Reddit and IAG",
+      "link": "https://uk.finance.yahoo.com/news/trending-tickers-figma-apple-amazon-reddit-and-iag-083420275.html?.tsrc=rss"
+    },
+    {
+      "title": "Coinbase Misses on Revenue. The Shares Are Falling.",
+      "link": "https://finance.yahoo.com/m/f745155f-1e5b-3e95-b9bd-b8c953981433/coinbase-misses-on-revenue..html?.tsrc=rss"
+    },
+    {
+      "title": "[주식] 국내 증시 4% 급락...알테오젠 등 상위 바이오주도 약세 - 히트뉴스",
+      "link": "https://news.google.com/rss/articles/CBMiakFVX3lxTE9MRXVEcXlFWXlOWHpDeEZYcGVSWWt1ckgxU09ueC1GdjBXUVNVdUk3azh2cE1YekE0NHZpOGp2QjFIMHZhSi0wbjFuNmJ2Mzczd092Wi14ZHd3Q1ZXWUtyYjFsdEllaUw0NkE?oc=5"
+    },
+    {
+      "title": "세제개편 실망에 '검은 금요일'…코스피 3.9% 급락해 3,110대(종합) - 연합뉴스",
+      "link": "https://news.google.com/rss/articles/CBMiW0FVX3lxTE5YYTl4RWw3QzByTFBNN1JQWHY0REdSak1jN2FiZ0ZKR0hpOHVtMC1BeTJTYjl3OEc5U09uaDFjNGFiTjRUNmFJQW5PZXJOT19TeFAtUzh4eElod1XSAWBBVV95cUxOZm1SWHIwOXRwd2xxaGhab0hwRkFoR2E1R3NRSkwyai12YkpBNE44NGdVdkdmdGNJQUZGUzhneWpXOHItVms2SlVVanlrTG0wa2NNTjcxNmUxOHlCVHMwcTA?oc=5"
+    },
+    {
+      "title": "오늘주식시황(7월30일), 코스피 및 대형주 중심으로.. : 네이버 블로그 - Naver Blog",
+      "link": "https://news.google.com/rss/articles/CBMif0FVX3lxTFBpQUZFcW5Ga29Oc3BtZm9WaXN2ZnlJUWxjTFRoOHRtTmVLc1NzdV82d3l1dWs1RGxkeUpyWVlHSjNyM0ZpYlh4c19vY2t2ZU9vdDBRallQZi1aSnd0Mk9FZTl5dE85bDViemVfa1F1YUhjeVRJZ1FKLV9uQ0tQZ00?oc=5"
+    }
   ]
 }

--- a/fetchNews.js
+++ b/fetchNews.js
@@ -56,14 +56,14 @@ async function main() {
   const all = [];
   try {
     const items = await fetchFeed(FEEDS.en);
-    all.push(...items.slice(0, 2));
+    all.push(...items.slice(0, 5));
   } catch (e) {
     console.error('Failed EN feed', e.message);
   }
   for (const key of ['kr1', 'kr2', 'kr3']) {
     try {
       const items = await fetchFeed(FEEDS[key]);
-      all.push(...items.slice(0, 2));
+      all.push(...items.slice(0, 1));
     } catch (e) {
       console.error('Failed', key, e.message);
     }


### PR DESCRIPTION
## Summary
- adjust `fetchNews.js` to gather five US headlines and three Korean ones
- refresh `data/market_news.json` with the new mix
- document updated behaviour in `README.md`

## Testing
- `node fetchNews.js`
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_688cb09980e0832aa4aa6563ae83b16d