### PR TITLE
Allow overriding recommendations with local JS

### DIFF
--- a/recommendations.js
+++ b/recommendations.js
@@ -1,0 +1,227 @@
+window.recommendationsOverride = {
+  "KOSPI": {
+    "safe": [
+      {
+        "name": "삼성전자",
+        "sector": "Technology",
+        "prevClose": null
+      },
+      {
+        "name": "SK하이닉스",
+        "sector": "Technology",
+        "prevClose": null
+      },
+      {
+        "name": "현대차",
+        "sector": "Consumer Discretionary",
+        "prevClose": null
+      },
+      {
+        "name": "LG화학",
+        "sector": "Materials",
+        "prevClose": null
+      },
+      {
+        "name": "포스코퓨처엠",
+        "sector": "Materials",
+        "prevClose": null
+      }
+    ],
+    "aggressive": [
+      {
+        "name": "LG에너지솔루션",
+        "sector": "Industrials",
+        "prevClose": null
+      },
+      {
+        "name": "삼성SDI",
+        "sector": "Industrials",
+        "prevClose": null
+      },
+      {
+        "name": "네이버",
+        "sector": "Communication Services",
+        "prevClose": null
+      },
+      {
+        "name": "카카오",
+        "sector": "Communication Services",
+        "prevClose": null
+      },
+      {
+        "name": "셀트리온",
+        "sector": "Healthcare",
+        "prevClose": null
+      }
+    ]
+  },
+  "KOSDAQ": {
+    "safe": [
+      {
+        "name": "셀트리온헬스케어",
+        "sector": "Healthcare",
+        "prevClose": null
+      },
+      {
+        "name": "에코프로비엠",
+        "sector": "Materials",
+        "prevClose": null
+      },
+      {
+        "name": "카카오게임즈",
+        "sector": "Communication Services",
+        "prevClose": null
+      },
+      {
+        "name": "CJ ENM",
+        "sector": "Communication Services",
+        "prevClose": null
+      },
+      {
+        "name": "스튜디오드래곤",
+        "sector": "Communication Services",
+        "prevClose": null
+      }
+    ],
+    "aggressive": [
+      {
+        "name": "알테오젠",
+        "sector": "Healthcare",
+        "prevClose": null
+      },
+      {
+        "name": "제넥신",
+        "sector": "Healthcare",
+        "prevClose": null
+      },
+      {
+        "name": "헬릭스미스",
+        "sector": "Healthcare",
+        "prevClose": null
+      },
+      {
+        "name": "씨젠",
+        "sector": "Healthcare",
+        "prevClose": null
+      },
+      {
+        "name": "펄어비스",
+        "sector": "Communication Services",
+        "prevClose": null
+      }
+    ]
+  },
+  "NASDAQ": {
+    "safe": [
+      {
+        "name": "Apple",
+        "sector": "Technology",
+        "prevClose": null
+      },
+      {
+        "name": "Microsoft",
+        "sector": "Technology",
+        "prevClose": null
+      },
+      {
+        "name": "Amazon",
+        "sector": "Consumer Cyclical",
+        "prevClose": null
+      },
+      {
+        "name": "Alphabet",
+        "sector": "Communication Services",
+        "prevClose": null
+      },
+      {
+        "name": "Visa",
+        "sector": "Financial Services",
+        "prevClose": null
+      }
+    ],
+    "aggressive": [
+      {
+        "name": "NVIDIA",
+        "sector": "Technology",
+        "prevClose": null
+      },
+      {
+        "name": "AMD",
+        "sector": "Technology",
+        "prevClose": null
+      },
+      {
+        "name": "C3.ai",
+        "sector": "Technology",
+        "prevClose": null
+      },
+      {
+        "name": "Snowflake",
+        "sector": "Technology",
+        "prevClose": null
+      },
+      {
+        "name": "CrowdStrike",
+        "sector": "Technology",
+        "prevClose": null
+      }
+    ]
+  },
+  "S&P 500": {
+    "safe": [
+      {
+        "name": "Coca-Cola",
+        "sector": "Consumer Defensive",
+        "prevClose": null
+      },
+      {
+        "name": "Johnson & Johnson",
+        "sector": "Healthcare",
+        "prevClose": null
+      },
+      {
+        "name": "Procter & Gamble",
+        "sector": "Consumer Defensive",
+        "prevClose": null
+      },
+      {
+        "name": "Walmart",
+        "sector": "Consumer Defensive",
+        "prevClose": null
+      },
+      {
+        "name": "Costco",
+        "sector": "Consumer Defensive",
+        "prevClose": null
+      }
+    ],
+    "aggressive": [
+      {
+        "name": "NVIDIA",
+        "sector": "Technology",
+        "prevClose": null
+      },
+      {
+        "name": "Tesla",
+        "sector": "Consumer Cyclical",
+        "prevClose": null
+      },
+      {
+        "name": "AMD",
+        "sector": "Technology",
+        "prevClose": null
+      },
+      {
+        "name": "Palantir",
+        "sector": "Technology",
+        "prevClose": null
+      },
+      {
+        "name": "Snowflake",
+        "sector": "Technology",
+        "prevClose": null
+      }
+    ]
+  },
+  "lastUpdated": "2025-08-02T06:30:00.000Z"
+};

--- a/src/build.js
+++ b/src/build.js
@@ -294,13 +294,15 @@ async function fetchPortfolioRecommendations() {
     }
     return {
       html: `<div id="recommendations">${htmlParts.join('')}</div>`,
-      lastUpdated: data.lastUpdated ? new Date(data.lastUpdated) : new Date()
+      lastUpdated: data.lastUpdated ? new Date(data.lastUpdated) : new Date(),
+      data
     };
   } catch (err) {
     console.error('Failed to process recommendations', err);
     return {
       html: '<div id="recommendations"><p class="error">추천 데이터를 불러오지 못했습니다.</p></div>',
-      lastUpdated: new Date()
+      lastUpdated: new Date(),
+      data: null
     };
   }
 }
@@ -315,7 +317,7 @@ async function build() {
     fetchMarketIndices(),
     fetchPortfolioRecommendations(),
   ]);
-  const { html: portfolioHTML } = portfolioData;
+  const { html: portfolioHTML, data: portfolioJSON } = portfolioData;
 
   console.log('📝 HTML 템플릿 처리 중...');
   const result = tpl
@@ -323,8 +325,11 @@ async function build() {
     .replace('{{MARKET_TABLE}}', marketTable)
     .replace('{{PORTFOLIO_SECTIONS}}', portfolioHTML)
     .replace('{{BUILD_TIMESTAMP}}', now.toISOString().replace('T', ' ').split('.')[0] + ' KST');
-
   await fsp.writeFile(path.resolve('stocks.html'), result, 'utf-8');
+
+  // Write JS override file
+  const jsContent = 'window.recommendationsOverride = ' + JSON.stringify(portfolioJSON, null, 2) + ';\n';
+  await fsp.writeFile(path.resolve('recommendations.js'), jsContent, 'utf-8');
   console.log('✅ stocks.html 생성 완료');
   console.log(`📅 생성 시간: ${now.toLocaleString('ko-KR')}`);
 }

--- a/src/template.html
+++ b/src/template.html
@@ -343,23 +343,28 @@
 
     async function fetchRecs() {
       const local = await loadLocalRecs();
+      let data;
       try {
         const url = ENDPOINT + '?_=' + Date.now();
         const res = await fetch(url);
         if (!res.ok) throw new Error('HTTP ' + res.status);
-        const data = await res.json();
+        data = mergeWithFallback(await res.json(), local);
         console.log('Recommendations:', data);
-        render(mergeWithFallback(data, local));
       } catch (err) {
         console.error('Failed to load recommendations:', err);
-        if (local) {
-          render(local);
-        } else {
-          const container = document.getElementById('recommendations');
-          if (container) {
-            container.innerHTML = `<p class="error">${translations[currentLang].recsError}</p>`;
-          }
+        data = local;
+      }
+      if (data) {
+        render(data);
+      } else {
+        const container = document.getElementById('recommendations');
+        if (container) {
+          container.innerHTML = `<p class="error">${translations[currentLang].recsError}</p>`;
         }
+      }
+      if (window.recommendationsOverride) {
+        console.log('Using recommendations override');
+        render(window.recommendationsOverride);
       }
     }
 
@@ -477,5 +482,6 @@
       }
     })();
   </script>
+  <script src="recommendations.js"></script>
 </body>
 </html>

--- a/stocks.html
+++ b/stocks.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <h1 data-i18n="title">데일리 주식 리포트 자동화</h1>
-  <p id="currentDate"><span id="datePrefix" data-i18n="today">오늘:</span> 2025년 8월 1일</p>
+  <p id="currentDate"><span id="datePrefix" data-i18n="today">오늘:</span> 2025년 8월 2일</p>
   
   <div id="debugInfo" class="debug" style="display: none;">
     <h4>디버그 정보:</h4>
@@ -41,7 +41,7 @@
 
   <section id="portfolioRecommendations">
     <h2 data-i18n="portfolioRecs">포트폴리오 추천</h2>
-    <div id="recommendations"><div class="portfolio-group"><h3>KOSPI 안전주</h3><ul><li>삼성전자<span class="sector">Technology</span></li><li>SK텔레콤<span class="sector">Communication Services</span></li><li>현대차<span class="sector">Consumer Discretionary</span></li><li>KB금융<span class="sector">Financials</span></li><li>LG에너지솔루션<span class="sector">Industrials</span></li></ul></div><div class="portfolio-group"><h3>KOSPI 공격주</h3><ul><li>카카오<span class="sector">Communication Services</span></li><li>네이버<span class="sector">Communication Services</span></li><li>SK바이오사이언스<span class="sector">Healthcare</span></li><li>두산에너빌리티<span class="sector">Industrials</span></li><li>LG디스플레이<span class="sector">Technology</span></li></ul></div><div class="portfolio-group"><h3>KOSDAQ 안전주</h3><ul><li>셀트리온헬스케어<span class="sector">Healthcare</span></li><li>에코프로비엠<span class="sector">Materials</span></li><li>카카오게임즈<span class="sector">Communication Services</span></li><li>스튜디오드래곤<span class="sector">Communication Services</span></li><li>컴투스<span class="sector">Communication Services</span></li></ul></div><div class="portfolio-group"><h3>KOSDAQ 공격주</h3><ul><li>제넥신<span class="sector">Healthcare</span></li><li>알테오젠<span class="sector">Healthcare</span></li><li>씨젠<span class="sector">Healthcare</span></li><li>에이치엘비<span class="sector">Healthcare</span></li><li>넷마블<span class="sector">Communication Services</span></li></ul></div><div class="portfolio-group"><h3>NASDAQ 안전주</h3><ul><li>Apple<span class="sector">Technology</span></li><li>Microsoft<span class="sector">Technology</span></li><li>Alphabet<span class="sector">Communication Services</span></li><li>Amazon<span class="sector">Consumer Cyclical</span></li><li>Visa<span class="sector">Financial Services</span></li></ul></div><div class="portfolio-group"><h3>NASDAQ 공격주</h3><ul><li>NVIDIA<span class="sector">Technology</span></li><li>Tesla<span class="sector">Consumer Cyclical</span></li><li>Snowflake<span class="sector">Technology</span></li><li>Palantir<span class="sector">Technology</span></li><li>Airbnb<span class="sector">Consumer Cyclical</span></li></ul></div><div class="portfolio-group"><h3>S&P 500 안전주</h3><ul><li>Coca-Cola<span class="sector">Consumer Defensive</span></li><li>Johnson & Johnson<span class="sector">Healthcare</span></li><li>Procter & Gamble<span class="sector">Consumer Defensive</span></li><li>Walmart<span class="sector">Consumer Defensive</span></li><li>Visa<span class="sector">Financial Services</span></li></ul></div><div class="portfolio-group"><h3>S&P 500 공격주</h3><ul><li>Airbnb<span class="sector">Consumer Cyclical</span></li><li>Uber<span class="sector">Industrials</span></li><li>Block<span class="sector">Technology</span></li><li>Snowflake<span class="sector">Technology</span></li><li>Palantir<span class="sector">Technology</span></li></ul></div></div>
+    <div id="recommendations"><div class="portfolio-group"><h3>KOSPI 안전주</h3><ul><li>삼성전자<span class="sector">Technology</span></li><li>SK하이닉스<span class="sector">Technology</span></li><li>현대차<span class="sector">Consumer Discretionary</span></li><li>LG화학<span class="sector">Materials</span></li><li>포스코퓨처엠<span class="sector">Materials</span></li></ul></div><div class="portfolio-group"><h3>KOSPI 공격주</h3><ul><li>LG에너지솔루션<span class="sector">Industrials</span></li><li>삼성SDI<span class="sector">Industrials</span></li><li>네이버<span class="sector">Communication Services</span></li><li>카카오<span class="sector">Communication Services</span></li><li>셀트리온<span class="sector">Healthcare</span></li></ul></div><div class="portfolio-group"><h3>KOSDAQ 안전주</h3><ul><li>셀트리온헬스케어<span class="sector">Healthcare</span></li><li>에코프로비엠<span class="sector">Materials</span></li><li>카카오게임즈<span class="sector">Communication Services</span></li><li>CJ ENM<span class="sector">Communication Services</span></li><li>스튜디오드래곤<span class="sector">Communication Services</span></li></ul></div><div class="portfolio-group"><h3>KOSDAQ 공격주</h3><ul><li>알테오젠<span class="sector">Healthcare</span></li><li>제넥신<span class="sector">Healthcare</span></li><li>헬릭스미스<span class="sector">Healthcare</span></li><li>씨젠<span class="sector">Healthcare</span></li><li>펄어비스<span class="sector">Communication Services</span></li></ul></div><div class="portfolio-group"><h3>NASDAQ 안전주</h3><ul><li>Apple<span class="sector">Technology</span></li><li>Microsoft<span class="sector">Technology</span></li><li>Amazon<span class="sector">Consumer Cyclical</span></li><li>Alphabet<span class="sector">Communication Services</span></li><li>Visa<span class="sector">Financial Services</span></li></ul></div><div class="portfolio-group"><h3>NASDAQ 공격주</h3><ul><li>NVIDIA<span class="sector">Technology</span></li><li>AMD<span class="sector">Technology</span></li><li>C3.ai<span class="sector">Technology</span></li><li>Snowflake<span class="sector">Technology</span></li><li>CrowdStrike<span class="sector">Technology</span></li></ul></div><div class="portfolio-group"><h3>S&P 500 안전주</h3><ul><li>Coca-Cola<span class="sector">Consumer Defensive</span></li><li>Johnson & Johnson<span class="sector">Healthcare</span></li><li>Procter & Gamble<span class="sector">Consumer Defensive</span></li><li>Walmart<span class="sector">Consumer Defensive</span></li><li>Costco<span class="sector">Consumer Defensive</span></li></ul></div><div class="portfolio-group"><h3>S&P 500 공격주</h3><ul><li>NVIDIA<span class="sector">Technology</span></li><li>Tesla<span class="sector">Consumer Cyclical</span></li><li>AMD<span class="sector">Technology</span></li><li>Palantir<span class="sector">Technology</span></li><li>Snowflake<span class="sector">Technology</span></li></ul></div></div>
     <div id="portfolioUpdated" class="last-updated"></div>
   </section>
   
@@ -343,23 +343,28 @@
 
     async function fetchRecs() {
       const local = await loadLocalRecs();
+      let data;
       try {
         const url = ENDPOINT + '?_=' + Date.now();
         const res = await fetch(url);
         if (!res.ok) throw new Error('HTTP ' + res.status);
-        const data = await res.json();
+        data = mergeWithFallback(await res.json(), local);
         console.log('Recommendations:', data);
-        render(mergeWithFallback(data, local));
       } catch (err) {
         console.error('Failed to load recommendations:', err);
-        if (local) {
-          render(local);
-        } else {
-          const container = document.getElementById('recommendations');
-          if (container) {
-            container.innerHTML = `<p class="error">${translations[currentLang].recsError}</p>`;
-          }
+        data = local;
+      }
+      if (data) {
+        render(data);
+      } else {
+        const container = document.getElementById('recommendations');
+        if (container) {
+          container.innerHTML = `<p class="error">${translations[currentLang].recsError}</p>`;
         }
+      }
+      if (window.recommendationsOverride) {
+        console.log('Using recommendations override');
+        render(window.recommendationsOverride);
       }
     }
 
@@ -477,5 +482,6 @@
       }
     })();
   </script>
+  <script src="recommendations.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- generate `recommendations.js` during build so that the page can override
  data provided by the Google Apps Script
- update `stocks.html` and template to load the override script and use it
  when present
- expose raw recommendations data from `fetchPortfolioRecommendations`

## Testing
- `node src/build.js`
- `node tests/apple_association.test.js`

------
https://chatgpt.com/codex/tasks/task_b_688d5e36bf44832a99add1713ae063de