### PR TITLE
Display previous close in stock recommendations

### DIFF
--- a/src/template.html
+++ b/src/template.html
@@ -68,7 +68,8 @@
         safe: '안전주',
         aggressive: '공격주',
         updated: '업데이트: ',
-        visitsToday: '오늘 방문: {daily} | 총 방문: {total}'
+        visitsToday: '오늘 방문: {daily} | 총 방문: {total}',
+        prevCloseLabel: '전일 종가:'
       },
       en: {
         title: 'Daily Stock Report Automation',
@@ -91,7 +92,8 @@
         safe: 'Safe Picks',
         aggressive: 'Aggressive Picks',
         updated: 'Updated: ',
-        visitsToday: 'Visits today: {daily} | Total: {total}'
+        visitsToday: 'Visits today: {daily} | Total: {total}',
+        prevCloseLabel: 'Prev Close:'
       }
     };
 
@@ -383,8 +385,11 @@
         for (const bucket of ['safe', 'aggressive']) {
           const items = (info?.[bucket] || []).map(item => {
             const name = FULL_NAME_MAP[item.name] || item.name;
-            const sector = item.sector ? `<span class="sector">${item.sector}</span>` : '';
-            return `<li>${name}${sector}</li>`;
+            const sector = item.sector ? `<span class=\"sector\">${item.sector}</span>` : '';
+            const prevClose = (item.prevClose ?? null) !== null
+              ? `<span class=\"prev-close\">${translations[currentLang].prevCloseLabel} ${Number(item.prevClose).toLocaleString(currentLang === 'ko' ? 'ko-KR' : 'en-US')}</span>`
+              : '';
+            return `<li>${name}${sector}${prevClose}</li>`;
           }).join('');
           const label = bucket === 'safe' ? translations[currentLang].safe : translations[currentLang].aggressive;
           html.push(`<div class="portfolio-group"><h3>${m} ${label}</h3><ul>${items}</ul></div>`);

--- a/stocks.css
+++ b/stocks.css
@@ -139,7 +139,8 @@ tr:hover {
   background-color: #fdfdfd;
 }
 
-.portfolio-group .sector {
+.portfolio-group .sector,
+.portfolio-group .prev-close {
   margin-left: 4px;
   color: #6b7280;
   font-size: 0.85em;

--- a/stocks.html
+++ b/stocks.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <h1 data-i18n="title">데일리 주식 리포트 자동화</h1>
-  <p id="currentDate"><span id="datePrefix" data-i18n="today">오늘:</span> 2025년 8월 3일</p>
+  <p id="currentDate"><span id="datePrefix" data-i18n="today">오늘:</span> 2025년 8월 4일</p>
   
   <div id="debugInfo" class="debug" style="display: none;">
     <h4>디버그 정보:</h4>
@@ -41,7 +41,7 @@
 
   <section id="portfolioRecommendations">
     <h2 data-i18n="portfolioRecs">포트폴리오 추천</h2>
-    <div id="recommendations"><div class="portfolio-group"><h3>KOSPI 안전주</h3><ul><li>삼성전자</li><li>SK하이닉스</li><li>POSCO홀딩스</li><li>현대차</li><li>KB금융</li></ul></div><div class="portfolio-group"><h3>KOSPI 공격주</h3><ul><li>한미반도체</li><li>LG에너지솔루션</li><li>BGF리테일</li><li>두산에너빌리티</li><li>카카오</li></ul></div><div class="portfolio-group"><h3>KOSDAQ 안전주</h3><ul><li>셀트리온헬스케어</li><li>에코프로비엠</li><li>천보</li><li>리노공업</li><li>HPSP</li></ul></div><div class="portfolio-group"><h3>KOSDAQ 공격주</h3><ul><li>HLB</li><li>레인보우로보틱스</li><li>알테오젠</li><li>에코프로</li><li>지아이이노베이션</li></ul></div><div class="portfolio-group"><h3>NASDAQ 안전주</h3><ul><li>Microsoft</li><li>Broadcom</li><li>Apple</li><li>Alphabet</li><li>Meta Platforms</li></ul></div><div class="portfolio-group"><h3>NASDAQ 공격주</h3><ul><li>NVIDIA</li><li>Super Micro Computer</li><li>AMD</li><li>Arm Holdings</li><li>Palantir</li></ul></div><div class="portfolio-group"><h3>S&P 500 안전주</h3><ul><li>Berkshire Hathaway (B)</li><li>Johnson & Johnson</li><li>Procter & Gamble</li><li>Exxon Mobil</li><li>Visa</li></ul></div><div class="portfolio-group"><h3>S&P 500 공격주</h3><ul><li>Eli Lilly and Company</li><li>Micron Technology</li><li>Tesla</li><li>Lockheed Martin</li><li>CrowdStrike</li></ul></div></div>
+    <div id="recommendations"><div class="portfolio-group"><h3>KOSPI 안전주</h3><ul><li>삼성전자<span class="sector">Technology</span></li><li>SK하이닉스<span class="sector">Technology</span></li><li>삼성바이오로직스<span class="sector">Healthcare</span></li><li>현대차<span class="sector">Consumer Discretionary</span></li><li>POSCO홀딩스<span class="sector">Materials</span></li></ul></div><div class="portfolio-group"><h3>KOSPI 공격주</h3><ul><li>효성중공업<span class="sector">Industrials</span></li><li>HD현대일렉트릭<span class="sector">Industrials</span></li><li>BGF리테일<span class="sector">Consumer Staples</span></li><li>두산에너빌리티<span class="sector">Industrials</span></li><li>카카오<span class="sector">Communication Services</span></li></ul></div><div class="portfolio-group"><h3>KOSDAQ 안전주</h3><ul><li>에코프로비엠<span class="sector">Materials</span></li><li>셀트리온헬스케어<span class="sector">Healthcare</span></li><li>천보<span class="sector">Materials</span></li><li>리노공업<span class="sector">Technology</span></li><li>S&S테크<span class="sector">Technology</span></li></ul></div><div class="portfolio-group"><h3>KOSDAQ 공격주</h3><ul><li>HLB<span class="sector">Healthcare</span></li><li>레인보우로보틱스<span class="sector">Industrials</span></li><li>알테오젠<span class="sector">Healthcare</span></li><li>지아이이노베이션<span class="sector">Healthcare</span></li><li>펩트론<span class="sector">Healthcare</span></li></ul></div><div class="portfolio-group"><h3>NASDAQ 안전주</h3><ul><li>Microsoft<span class="sector">Technology</span></li><li>Apple<span class="sector">Technology</span></li><li>NVIDIA<span class="sector">Technology</span></li><li>Alphabet<span class="sector">Communication Services</span></li><li>Amazon<span class="sector">Consumer Discretionary</span></li></ul></div><div class="portfolio-group"><h3>NASDAQ 공격주</h3><ul><li>Super Micro Computer<span class="sector">Technology</span></li><li>Palantir<span class="sector">Technology</span></li><li>Arm Holdings<span class="sector">Technology</span></li><li>Micron Technology<span class="sector">Technology</span></li><li>Tesla<span class="sector">Consumer Cyclical</span></li></ul></div><div class="portfolio-group"><h3>S&P 500 안전주</h3><ul><li>Berkshire Hathaway (B)<span class="sector">Financial Services</span></li><li>Microsoft<span class="sector">Technology</span></li><li>Johnson & Johnson<span class="sector">Healthcare</span></li><li>Procter & Gamble<span class="sector">Consumer Defensive</span></li><li>Visa<span class="sector">Financial Services</span></li></ul></div><div class="portfolio-group"><h3>S&P 500 공격주</h3><ul><li>Palantir<span class="sector">Technology</span></li><li>GE Vernova<span class="sector">Industrials</span></li><li>Eli Lilly<span class="sector">Healthcare</span></li><li>Super Micro Computer<span class="sector">Technology</span></li><li>NRG Energy<span class="sector">Utilities</span></li></ul></div></div>
     <div id="portfolioUpdated" class="last-updated"></div>
   </section>
   
@@ -68,7 +68,8 @@
         safe: '안전주',
         aggressive: '공격주',
         updated: '업데이트: ',
-        visitsToday: '오늘 방문: {daily} | 총 방문: {total}'
+        visitsToday: '오늘 방문: {daily} | 총 방문: {total}',
+        prevCloseLabel: '전일 종가:'
       },
       en: {
         title: 'Daily Stock Report Automation',
@@ -91,7 +92,8 @@
         safe: 'Safe Picks',
         aggressive: 'Aggressive Picks',
         updated: 'Updated: ',
-        visitsToday: 'Visits today: {daily} | Total: {total}'
+        visitsToday: 'Visits today: {daily} | Total: {total}',
+        prevCloseLabel: 'Prev Close:'
       }
     };
 
@@ -383,8 +385,11 @@
         for (const bucket of ['safe', 'aggressive']) {
           const items = (info?.[bucket] || []).map(item => {
             const name = FULL_NAME_MAP[item.name] || item.name;
-            const sector = item.sector ? `<span class="sector">${item.sector}</span>` : '';
-            return `<li>${name}${sector}</li>`;
+            const sector = item.sector ? `<span class=\"sector\">${item.sector}</span>` : '';
+            const prevClose = (item.prevClose ?? null) !== null
+              ? `<span class=\"prev-close\">${translations[currentLang].prevCloseLabel} ${Number(item.prevClose).toLocaleString(currentLang === 'ko' ? 'ko-KR' : 'en-US')}</span>`
+              : '';
+            return `<li>${name}${sector}${prevClose}</li>`;
           }).join('');
           const label = bucket === 'safe' ? translations[currentLang].safe : translations[currentLang].aggressive;
           html.push(`<div class="portfolio-group"><h3>${m} ${label}</h3><ul>${items}</ul></div>`);


### PR DESCRIPTION
## Summary
- show previous close value next to each recommended stock
- add translations for "Prev Close" label in Korean and English
- style new previous close span to match existing sector style

## Testing
- `node src/build.js` *(fails to fetch live market data; uses cached data and builds stocks.html)*
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_688ffc2a4568832ab18a3119f33d8d4b