### PR TITLE
Refresh stock recommendations

### DIFF
--- a/recommendations.json
+++ b/recommendations.json
@@ -1,67 +1,67 @@
 {
   "KOSPI": {
     "safe": [
-      { "name": "삼성전자",        "sector": "Technology",             "prevClose": 70500 },
-      { "name": "SK하이닉스",      "sector": "Technology",             "prevClose": 262000 },
-      { "name": "삼성바이오로직스",  "sector": "Healthcare",             "prevClose": 1029000 },
-      { "name": "현대차",          "sector": "Consumer Discretionary", "prevClose": 212500 },
-      { "name": "POSCO홀딩스",     "sector": "Materials",              "prevClose": 298500 }
+      { "name": "삼성전자",         "sector": "Technology" },
+      { "name": "SK하이닉스",       "sector": "Technology" },
+      { "name": "삼성바이오로직스",   "sector": "Healthcare" },
+      { "name": "현대차",           "sector": "Consumer Discretionary" },
+      { "name": "LG에너지솔루션",    "sector": "Industrials" }
     ],
     "aggressive": [
-      { "name": "효성중공업",       "sector": "Industrials",            "prevClose": 1169000 },
-      { "name": "HD현대일렉트릭",    "sector": "Industrials",            "prevClose": 90800 },
-      { "name": "BGF리테일",        "sector": "Consumer Staples",       "prevClose": 166000 },
-      { "name": "두산에너빌리티",    "sector": "Industrials",            "prevClose": 17880 },
-      { "name": "한화에어로스페이스", "sector": "Industrials",            "prevClose": 961000 }
+      { "name": "한화에어로스페이스",  "sector": "Industrials" },
+      { "name": "HD현대일렉트릭",     "sector": "Industrials" },
+      { "name": "POSCO퓨처엠",       "sector": "Materials" },
+      { "name": "두산에너빌리티",     "sector": "Industrials" },
+      { "name": "HD한국조선해양",     "sector": "Industrials" }
     ]
   },
   "KOSDAQ": {
     "safe": [
-      { "name": "에코프로비엠",     "sector": "Materials",              "prevClose": 125900 },
-      { "name": "셀트리온헬스케어", "sector": "Healthcare",             "prevClose": 72800 },
-      { "name": "천보",             "sector": "Materials",              "prevClose": 157700 },
-      { "name": "리노공업",         "sector": "Technology",             "prevClose": 262000 },
-      { "name": "박셀바이오",       "sector": "Healthcare",             "prevClose": 109000 }
+      { "name": "에코프로비엠",        "sector": "Materials" },
+      { "name": "셀트리온헬스케어",    "sector": "Healthcare" },
+      { "name": "천보",              "sector": "Materials" },
+      { "name": "리노공업",           "sector": "Technology" },
+      { "name": "JYP엔터테인먼트",     "sector": "Communication Services" }
     ],
     "aggressive": [
-      { "name": "알테오젠",         "sector": "Healthcare",             "prevClose": 469000 },
-      { "name": "펩트론",           "sector": "Healthcare",             "prevClose": 18000 },
-      { "name": "레인보우로보틱스", "sector": "Industrials",            "prevClose": 169000 },
-      { "name": "지아이이노베이션", "sector": "Healthcare",             "prevClose": 44700 },
-      { "name": "에이프로젠",       "sector": "Healthcare",             "prevClose": 19200 }
+      { "name": "알테오젠",           "sector": "Healthcare" },
+      { "name": "레인보우로보틱스",     "sector": "Industrials" },
+      { "name": "HLB",              "sector": "Healthcare" },
+      { "name": "지아이이노베이션",     "sector": "Healthcare" },
+      { "name": "펩트론",            "sector": "Healthcare" }
     ]
   },
   "NASDAQ": {
     "safe": [
-      { "name": "Microsoft",       "sector": "Technology",             "prevClose": 520.84 },
-      { "name": "Apple",           "sector": "Technology",             "prevClose": 220.03 },
-      { "name": "NVIDIA",          "sector": "Technology",             "prevClose": 125.10 },
-      { "name": "Amazon",          "sector": "Consumer Discretionary", "prevClose": 204.56 },
-      { "name": "Meta Platforms",  "sector": "Communication Services", "prevClose": 498.70 }
+      { "name": "Microsoft",        "sector": "Technology" },
+      { "name": "Apple",            "sector": "Technology" },
+      { "name": "NVIDIA",           "sector": "Technology" },
+      { "name": "Amazon",           "sector": "Consumer Discretionary" },
+      { "name": "Alphabet",         "sector": "Communication Services" }
     ],
     "aggressive": [
-      { "name": "Super Micro Computer", "sector": "Technology",        "prevClose": 855.44 },
-      { "name": "Palantir",             "sector": "Technology",        "prevClose": 25.45 },
-      { "name": "Arm Holdings",         "sector": "Technology",        "prevClose": 153.21 },
-      { "name": "Micron Technology",    "sector": "Technology",        "prevClose": 128.90 },
-      { "name": "UiPath",               "sector": "Technology",        "prevClose": 18.77 }
+      { "name": "Super Micro Computer", "sector": "Technology" },
+      { "name": "Advanced Micro Devices", "sector": "Technology" },
+      { "name": "Arm Holdings",         "sector": "Technology" },
+      { "name": "Micron Technology",    "sector": "Technology" },
+      { "name": "CrowdStrike",          "sector": "Technology" }
     ]
   },
   "S&P 500": {
     "safe": [
-      { "name": "Berkshire Hathaway (B)", "sector": "Financial Services", "prevClose": 412.30 },
-      { "name": "Microsoft",              "sector": "Technology",         "prevClose": 520.84 },
-      { "name": "Johnson & Johnson",      "sector": "Healthcare",         "prevClose": 159.21 },
-      { "name": "Procter & Gamble",       "sector": "Consumer Defensive", "prevClose": 168.05 },
-      { "name": "Visa",                   "sector": "Financial Services", "prevClose": 276.12 }
+      { "name": "Berkshire Hathaway (B)", "sector": "Financial Services" },
+      { "name": "Microsoft",              "sector": "Technology" },
+      { "name": "Johnson & Johnson",      "sector": "Healthcare" },
+      { "name": "Procter & Gamble",       "sector": "Consumer Staples" },
+      { "name": "Visa",                   "sector": "Financial Services" }
     ],
     "aggressive": [
-      { "name": "Palantir",          "sector": "Technology",          "prevClose": 25.45 },
-      { "name": "Super Micro Computer","sector": "Technology",        "prevClose": 855.44 },
-      { "name": "Eli Lilly",         "sector": "Healthcare",          "prevClose": 890.11 },
-      { "name": "Uber Technologies", "sector": "Technology",          "prevClose": 69.12 },
-      { "name": "NRG Energy",        "sector": "Utilities",           "prevClose": 162.33 }
+      { "name": "Palantir",               "sector": "Technology" },
+      { "name": "Super Micro Computer",   "sector": "Technology" },
+      { "name": "Eli Lilly",              "sector": "Healthcare" },
+      { "name": "Uber Technologies",      "sector": "Industrials" },
+      { "name": "NRG Energy",             "sector": "Utilities" }
     ]
   },
-  "lastUpdated": "2025-08-07T15:30:00+09:00"
+  "lastUpdated": "2025-08-09T08:19:19+09:00"
 }


### PR DESCRIPTION
## Summary
- Replace stock recommendations with updated safe and aggressive picks for KOSPI, KOSDAQ, NASDAQ, and S&P 500.
- Set data timestamp to 2025-08-09T08:19:19+09:00.

## Testing
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_6896868e45fc832ab3eb73b362364ef7