### PR TITLE
Use new visit count endpoint with cache busting

### DIFF
--- a/index.html
+++ b/index.html
@@ -1129,7 +1129,8 @@
 <script>
   (async function() {
     try {
-      const res = await fetch('https://script.google.com/macros/s/AKfycbyM94HyV7c_eqq3SPLMZlBcJVh6KeyygmR4bq_NM80_li9MIM2WWQ25wnd3S51FR4igLw/exec?page=index');
+      const url = 'https://script.google.com/macros/s/AKfycbxBiwioYKbne1bcGebEvflVvgBAVvAt7DwkCrTGDXBUti9NNd6kVF3kS-pst_uMlQObzA/exec?page=index&_=' + Date.now();
+      const res = await fetch(url, { cache: 'no-store' });
       const data = await res.json();
       document.getElementById('visitCounts').textContent =
         `Visits today: ${data.daily} | Total: ${data.total}`;

--- a/src/template.html
+++ b/src/template.html
@@ -472,7 +472,8 @@
   <script>
     (async function() {
       try {
-        const res = await fetch('https://script.google.com/macros/s/AKfycbyM94HyV7c_eqq3SPLMZlBcJVh6KeyygmR4bq_NM80_li9MIM2WWQ25wnd3S51FR4igLw/exec?page=stocks');
+        const url = 'https://script.google.com/macros/s/AKfycbxBiwioYKbne1bcGebEvflVvgBAVvAt7DwkCrTGDXBUti9NNd6kVF3kS-pst_uMlQObzA/exec?page=stocks&_=' + Date.now();
+        const res = await fetch(url, { cache: 'no-store' });
         const data = await res.json();
         visitData = data;
         updateVisitCounts();

--- a/stocks.html
+++ b/stocks.html
@@ -475,7 +475,8 @@
   <script>
     (async function() {
       try {
-        const res = await fetch('https://script.google.com/macros/s/AKfycbyM94HyV7c_eqq3SPLMZlBcJVh6KeyygmR4bq_NM80_li9MIM2WWQ25wnd3S51FR4igLw/exec?page=stocks');
+        const url = 'https://script.google.com/macros/s/AKfycbxBiwioYKbne1bcGebEvflVvgBAVvAt7DwkCrTGDXBUti9NNd6kVF3kS-pst_uMlQObzA/exec?page=stocks&_=' + Date.now();
+        const res = await fetch(url, { cache: 'no-store' });
         const data = await res.json();
         visitData = data;
         updateVisitCounts();


### PR DESCRIPTION
## Summary
- Fetch visit counts from new Google Apps Script endpoint for `index.html` and `stocks.html`
- Add cache-busting query and `fetch` options to avoid cached responses
- Mirror visit count update in `src/template.html` for future stock page builds

## Testing
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_6896ee9285f0832aa289c2fdff4a3a69