### PR TITLE
feat: add KST timestamp helper and workflow diagnostics

### DIFF
--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -52,12 +52,21 @@ jobs:
       - name: 뉴스 데이터 업데이트
         run: node fetchNews.js
 
-      - name: Verify generated files
+      - name: Verify generated files (enhanced)
         run: |
-          ls -la
-          test -f data/market_news.json && echo "✅ data/market_news.json OK" || (echo "❌ data/market_news.json missing"; exit 1)
-          node -e "const fs=require('fs');const d=JSON.parse(fs.readFileSync('data/market_news.json','utf8'));console.log('market_news lastUpdated:',d.lastUpdated)"
-          test -f recommendations.json && echo "✅ recommendations.json OK" || (echo "❌ recommendations.json missing"; exit 1)
+          set -e
+          echo "== list files ==" && ls -la
+          echo "== check targets exist =="
+          test -f data/market_news.json && echo "✅ data/market_news.json OK" || (echo "❌ missing"; exit 1)
+          test -f recommendations.json && echo "✅ recommendations.json OK" || (echo "❌ missing"; exit 1)
+          echo "== show lastUpdated =="
+          node -e "const fs=require('fs');const d=JSON.parse(fs.readFileSync('data/market_news.json','utf8'));console.log('market_news lastUpdated:', d.lastUpdated)"
+          node -e "const fs=require('fs');const d=JSON.parse(fs.readFileSync('recommendations.json','utf8'));console.log('recommendations lastUpdated:', d.lastUpdated)"
+          echo "== git status & diff =="
+          git status
+          git diff --name-only
+          git diff -- data/market_news.json || true
+          git diff -- recommendations.json || true
 
       - name: Commit & push changes
         uses: stefanzweifel/git-auto-commit-action@v5

--- a/fetchNews.js
+++ b/fetchNews.js
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { XMLParser } from 'fast-xml-parser';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
+import { nowKSTISO } from './utils/time.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -27,13 +28,6 @@ const KR_FEEDS = [
   'https://news.google.com/rss/search?q=%EC%A6%9D%EC%8B%9C&hl=ko&gl=KR&ceid=KR:ko',
   'https://news.google.com/rss/search?q=%EC%BD%94%EC%8A%A4%ED%94%BC&hl=ko&gl=KR&ceid=KR:ko'
 ];
-
-function toKSTISOString(d = new Date()) {
-  const kst = new Date(d.getTime() + (9 * 60 - d.getTimezoneOffset()) * 60000);
-  const p = n => String(n).padStart(2, '0');
-  return `${kst.getFullYear()}-${p(kst.getMonth() + 1)}-${p(kst.getDate())}` +
-    `T${p(kst.getHours())}:${p(kst.getMinutes())}:${p(kst.getSeconds())}+09:00`;
-}
 
 const parser = new XMLParser({ ignoreAttributes: false });
 const execFileP = promisify(execFile);
@@ -109,7 +103,7 @@ async function gather() {
 async function main() {
   const items = await gather();
   if (!items.length) throw new Error('No news items after filtering');
-  const out = { lastUpdated: toKSTISOString(), items };
+  const out = { lastUpdated: nowKSTISO(), items };
   await fs.writeFile(OUT_FILE, JSON.stringify(out, null, 2));
   console.log(`Wrote ${items.length} items to ${OUT_FILE}`);
 }

--- a/fetchStockInfo.js
+++ b/fetchStockInfo.js
@@ -4,6 +4,7 @@ import fs from 'fs/promises';
 import { existsSync } from 'fs';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
+import { nowKSTISO } from './utils/time.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -28,19 +29,7 @@ const SLEEP_MS = Number((process.argv.find(a => a.startsWith('--delay=')) || '')
 const CACHE_FILE = path.join(__dirname, 'ticker-cache.json');
 const RECS_FILE  = path.join(__dirname, 'recommendations.json');
 
-// --- KST timestamp helper ---
-function toKSTISOString(d = new Date()) {
-  const utc = d.getTime();
-  const kst = new Date(utc + 9 * 60 * 60 * 1000);
-  const pad = n => String(n).padStart(2, '0');
-  const yyyy = kst.getUTCFullYear();
-  const mm   = pad(kst.getUTCMonth() + 1);
-  const dd   = pad(kst.getUTCDate());
-  const hh   = pad(kst.getUTCHours());
-  const mi   = pad(kst.getUTCMinutes());
-  const ss   = pad(kst.getUTCSeconds());
-  return `${yyyy}-${mm}-${dd}T${hh}:${mi}:${ss}+09:00`;
-}
+// KST timestamp helper is provided by utils/time.js
 
 // -------- Static ticker map (first priority) --------
 const TICKER_MAP = {
@@ -261,7 +250,7 @@ async function updateRecommendations() {
     }
   }
 
-  data.lastUpdated = toKSTISOString(new Date());
+  data.lastUpdated = nowKSTISO();
   await fs.writeFile(RECS_FILE, JSON.stringify(data, null, 2));
   console.log(`Updated ${RECS_FILE}`);
 }

--- a/utils/time.js
+++ b/utils/time.js
@@ -1,0 +1,9 @@
+export function nowKSTISO() {
+  const dtf = new Intl.DateTimeFormat('sv-SE', {
+    timeZone: 'Asia/Seoul', year: 'numeric', month: '2-digit', day: '2-digit',
+    hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false
+  });
+  const parts = dtf.formatToParts(new Date()).reduce((o, p) => (o[p.type] = p.value, o), {});
+  const stamp = `${parts.year}-${parts.month}-${parts.day}T${parts.hour}:${parts.minute}:${parts.second}+09:00`;
+  return stamp;
+}


### PR DESCRIPTION
## Summary
- add nowKSTISO helper to generate Asia/Seoul timestamps
- use helper in fetch scripts to bump lastUpdated on each run
- enhance workflow with file verification and git diff diagnostics

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689a83680170832abf6ad42cb1734761