### PR TITLE
Log timestamp when writing recommendations

### DIFF
--- a/fetchStockInfo.js
+++ b/fetchStockInfo.js
@@ -252,7 +252,7 @@ async function updateRecommendations() {
 
   data.lastUpdated = nowKSTISO();
   await fs.writeFile(RECS_FILE, JSON.stringify(data, null, 2));
-  console.log(`Updated ${RECS_FILE}`);
+  console.log(`Wrote recommendations to recommendations.json at ${data.lastUpdated}`);
 }
 
 updateRecommendations().catch(err => {


### PR DESCRIPTION
## Summary
- Log a message with the KST timestamp when `fetchStockInfo.js` writes `recommendations.json`

## Testing
- `node tests/apple_association.test.js`
- `node fetchStockInfo.js` *(fetch warnings due to network restrictions, but script completed and logged write timestamp)*

------
https://chatgpt.com/codex/tasks/task_b_689a89101a34832aba85c1d123687f5d