### PR TITLE
Add keyboard map examples to voice hotkey demo

### DIFF
--- a/voice-hotkey/app.js
+++ b/voice-hotkey/app.js
@@ -88,6 +88,9 @@ function highlightKeys(labels) {
   saveHeat();
 }
 
+export { highlightKeys };
+window.VoiceKeys = Object.assign({}, window.VoiceKeys, { highlightKeys });
+
 async function processText(text) {
   const transcriptEl = document.getElementById('transcript');
   const resultEl = document.getElementById('result');

--- a/voice-hotkey/index.html
+++ b/voice-hotkey/index.html
@@ -40,6 +40,29 @@
       </select>
       <button id="clearBtn">Clear</button>
     </div>
+    <section id="keyboard-map" class="kb-section">
+      <h2 class="kb-title">Keyboard Map</h2>
+      <p class="kb-desc">Click an example to visualize the keys.</p>
+
+      <div class="kb-controls">
+        <div class="kb-examples" aria-label="Common shortcuts"></div>
+      </div>
+
+      <p id="kb-status" class="sr-only" aria-live="polite"></p>
+    </section>
+
+    <style>
+      /* Scoped styles */
+      #keyboard-map { margin-top: 1.25rem; }
+      #keyboard-map .kb-title { font-size: 1.1rem; margin: 0 0 .25rem; }
+      #keyboard-map .kb-desc { margin: 0 0 .5rem; opacity: .8; }
+      #keyboard-map .kb-examples { display: flex; flex-wrap: wrap; gap: .5rem; }
+      #keyboard-map .kb-examples button {
+        padding: .4rem .6rem; border: 1px solid #d0d0d0; border-radius: .5rem; background: #fff; cursor: pointer;
+      }
+      #keyboard-map .kb-examples button:hover { background: #f7f7f7; }
+      .sr-only { position:absolute; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden; clip:rect(0,0,0,0); border:0; }
+    </style>
   </main>
   <dialog id="settingsModal">
     <form method="dialog" class="settings-form">
@@ -66,5 +89,6 @@
       </menu>
     </form>
   </dialog>
+  <script type="module" src="./kb-map.js"></script>
 </body>
 </html>

--- a/voice-hotkey/kb-map.js
+++ b/voice-hotkey/kb-map.js
@@ -1,0 +1,45 @@
+// kb-map.js
+import { COMMON_INTENTS, OS_OVERRIDES } from './keymap.js';
+import { highlightKeysPublic, getCurrentOS } from './public-api.js';
+
+const examplesWrap = document.querySelector('#keyboard-map .kb-examples');
+const statusEl = document.getElementById('kb-status');
+
+init();
+
+function init(){
+  buildExamples();
+}
+
+function buildExamples(){
+  if (!examplesWrap) return;
+  examplesWrap.innerHTML = '';
+
+  const shortlist = ['close tab','new tab','refresh','find','copy','paste','undo','save'];
+  const ordered = Object.entries(COMMON_INTENTS)
+    .sort((a,b)=> shortlist.indexOf(a[0]) - shortlist.indexOf(b[0]));
+
+  for (const [action, winKeys] of ordered){
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.textContent = labelFor(action);
+    btn.setAttribute('aria-label', `Highlight keys for ${action}`);
+    btn.addEventListener('click', ()=>{
+      const os = getCurrentOS?.() || 'windows';
+      const keys = OS_OVERRIDES[os]?.[action] || winKeys;
+      highlightKeysPublic(keys);
+      say(`Keys: ${keys.join(' + ')} for ${action}`);
+    });
+    examplesWrap.appendChild(btn);
+  }
+}
+
+function labelFor(action){
+  const map = {
+    'close tab': 'Close tab', 'new tab': 'New tab', refresh: 'Refresh', find: 'Find',
+    copy: 'Copy', paste: 'Paste', undo: 'Undo', save: 'Save'
+  };
+  return map[action] || action;
+}
+
+function say(text){ if (statusEl) statusEl.textContent = text; }

--- a/voice-hotkey/public-api.js
+++ b/voice-hotkey/public-api.js
@@ -1,0 +1,17 @@
+// public-api.js
+// These functions delegate to app.js internals without changing behavior.
+export function highlightKeysPublic(keys){
+  // app.js should attach a global or export a function; support both:
+  if (window?.VoiceKeys?.highlightKeys) return window.VoiceKeys.highlightKeys(keys);
+  if (typeof window.highlightKeys === 'function') return window.highlightKeys(keys);
+  // If app.js exports it (ESM), it will be re-exported there; see app.js change below.
+  console.warn('highlightKeys not found');
+}
+
+export function getCurrentOS(){
+  // Prefer an existing OS selector with id 'os-select' or 'os' if present.
+  const sel = document.getElementById('os-select') || document.getElementById('os');
+  if (sel && sel.value) return sel.value;
+  // Fallback to 'windows'
+  return 'windows';
+}


### PR DESCRIPTION
## Summary
- add Keyboard Map section with example shortcut buttons
- expose highlight API and helpers for internal reuse
- support example shortcuts to highlight keys based on current OS

## Testing
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_689b15b516b8832a95d160c7aa5852d3