### PR TITLE
Restore baseline styles for keyboard SVG

### DIFF
--- a/voice-hotkey/index.html
+++ b/voice-hotkey/index.html
@@ -99,7 +99,20 @@
     if (!res.ok) throw new Error('SVG fetch failed: ' + res.status);
     mount.innerHTML = await res.text();
     const svg = mount.querySelector('svg');
-    if (svg) svg.classList.add('keyboard');
+    if (svg) {
+      svg.classList.add('keyboard');
+      const style = document.createElement('style');
+      style.textContent = `svg.keyboard .key rect,
+svg.keyboard .key path { fill:#fff; stroke:#ccc; }
+svg.keyboard .key text { fill:#333; }
+svg.keyboard .key.pressed rect,
+svg.keyboard .key.pressed path {
+  fill: var(--key-pressed-fill, hsl(205 85% 55%)) !important;
+  stroke: var(--key-pressed-stroke, hsl(205 90% 40%)) !important;
+  filter: drop-shadow(0 0 .4rem hsla(205,90%,45%,.55));
+}`;
+      svg.appendChild(style);
+    }
     if (typeof validateKeyboardSVG === 'function') validateKeyboardSVG();
   }
   injectSVG().catch(e => {

--- a/voice-hotkey/styles.css
+++ b/voice-hotkey/styles.css
@@ -67,6 +67,15 @@ svg.keyboard { display:block; height:auto; max-width:100%; }
 .transcript, .result {
   min-height: 1.5rem;
 }
+svg.keyboard .key rect,
+svg.keyboard .key path { fill:#fff; stroke:#ccc; }
+svg.keyboard .key text { fill:#333; }
+svg.keyboard .key.pressed rect,
+svg.keyboard .key.pressed path {
+  fill: var(--key-pressed-fill, hsl(205 85% 55%)) !important;
+  stroke: var(--key-pressed-stroke, hsl(205 90% 40%)) !important;
+  filter: drop-shadow(0 0 .4rem hsla(205,90%,45%,.55));
+}
 .key { transition: fill .18s ease, stroke .18s ease, filter .18s ease; }
 .key.pressed {
   fill: var(--key-pressed-fill) !important;


### PR DESCRIPTION
## Summary
- Add default key fill, stroke, and pressed colors to `voice-hotkey/styles.css` so keyboard SVG is visible.
- Inject identical style block into fetched keyboard SVG for fallback rendering if external CSS fails.

## Testing
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_689b1b763400832aa368aaae73e43dc9