### PR TITLE
Update recommendations timestamp when skipping stock fetch

### DIFF
--- a/fetchStockInfo.js
+++ b/fetchStockInfo.js
@@ -209,6 +209,8 @@ async function updateRecommendations() {
     const age = Date.now() - new Date(data.lastUpdated).getTime();
     if (age < SIX_HOURS) {
       console.log(`${RECS_FILE} is up to date (<6h). Use --force to override.`);
+      data.lastUpdated = nowKSTISO();
+      await fs.writeFile(RECS_FILE, JSON.stringify(data, null, 2));
       return;
     }
   }


### PR DESCRIPTION
## Summary
- Refresh recommendations.json timestamp even when fetch is skipped due to freshness

## Testing
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_689b1eee812c832a8a3c97f6e4ad33c0