### PR TITLE
Fix keyboard rendering in voice-hotkey app

### DIFF
--- a/voice-hotkey/index.html
+++ b/voice-hotkey/index.html
@@ -101,16 +101,16 @@
     const svg = mount.querySelector('svg');
     if (svg) {
       svg.classList.add('keyboard');
-      const style = document.createElement('style');
-      style.textContent = `svg.keyboard .key rect,
-svg.keyboard .key path { fill:#fff; stroke:#ccc; }
-svg.keyboard .key text { fill:#333; }
-svg.keyboard .key.pressed rect,
-svg.keyboard .key.pressed path {
-  fill: var(--key-pressed-fill, hsl(205 85% 55%)) !important;
-  stroke: var(--key-pressed-stroke, hsl(205 90% 40%)) !important;
-  filter: drop-shadow(0 0 .4rem hsla(205,90%,45%,.55));
-}`;
+      const style = document.createElementNS('http://www.w3.org/2000/svg','style');
+      style.textContent = `
+  .key rect, .key path { fill: var(--key-fill); stroke: var(--key-stroke); }
+  .key text { fill:#333; }
+  .key.pressed rect, .key.pressed path {
+    fill: var(--key-pressed-fill) !important;
+    stroke: var(--key-pressed-stroke) !important;
+    filter: drop-shadow(0 0 .4rem hsla(205,90%,45%,.55));
+  }
+`;
       svg.appendChild(style);
     }
     if (typeof validateKeyboardSVG === 'function') validateKeyboardSVG();

--- a/voice-hotkey/styles.css
+++ b/voice-hotkey/styles.css
@@ -68,7 +68,10 @@ svg.keyboard { display:block; height:auto; max-width:100%; }
   min-height: 1.5rem;
 }
 svg.keyboard .key rect,
-svg.keyboard .key path { fill:#fff; stroke:#ccc; }
+svg.keyboard .key path {
+  fill: var(--key-fill);       /* hsl(220 8% 18%) */
+  stroke: var(--key-stroke);   /* hsl(220 10% 32%) */
+}
 svg.keyboard .key text { fill:#333; }
 svg.keyboard .key.pressed rect,
 svg.keyboard .key.pressed path {


### PR DESCRIPTION
## Summary
- use CSS variables so keycaps appear before any key presses
- inject style element into keyboard SVG with correct namespace and selectors

## Testing
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_689b20f171d4832abd717911f521fd37