### PR TITLE
feat: add keyboard preview and scope interactions

### DIFF
--- a/voice-hotkey/app.js
+++ b/voice-hotkey/app.js
@@ -9,17 +9,6 @@ let controller = null;
 const heat = new Map();
 let options = { ping: true, heatmap: false, eye: { enabled: false, dwell: 700, sensitivity: 0.5 } };
 
-function getKeyboardSvgs() {
-  const mainHost = document.getElementById('kb-mount');
-  const previewHost = document.getElementById('kb-preview');
-  return {
-    mainHost,
-    previewHost,
-    mainSvg: mainHost?.querySelector('svg.keyboard') || null,
-    previewSvg: previewHost?.querySelector('svg.keyboard') || null,
-  };
-}
-
 function lerpColorHSL(a,b,t){
   const pa=a.match(/[\d.]+/g).map(Number);
   const pb=b.match(/[\d.]+/g).map(Number);
@@ -30,26 +19,23 @@ function lerpColorHSL(a,b,t){
 }
 
 function applyHeatmap(){
-  const { mainSvg, previewSvg } = getKeyboardSvgs();
-  const svgs = [mainSvg, previewSvg].filter(Boolean);
-  if(!svgs.length) return;
+  const svg = document.querySelector('#kb-mount svg.keyboard');
+  if(!svg) return;
   const max=Math.max(...heat.values(),0);
   const cs=getComputedStyle(document.documentElement);
   const cMin=cs.getPropertyValue('--key-heatmap-min').trim();
   const cMax=cs.getPropertyValue('--key-heatmap-max').trim();
-  svgs.forEach(svg=>{
-    heat.forEach((count,id)=>{
-      const g=svg.querySelector('#'+CSS.escape(id));
-      if(!g) return;
-      if(options.heatmap && max){
-        const t=count/max;
-        g.classList.add('heatmap');
-        g.style.fill=lerpColorHSL(cMin,cMax,t);
-      }else{
-        g.classList.remove('heatmap');
-        g.style.fill='';
-      }
-    });
+  heat.forEach((count,id)=>{
+    const g=svg.querySelector('#'+CSS.escape(id));
+    if(!g) return;
+    if(options.heatmap && max){
+      const t=count/max;
+      g.classList.add('heatmap');
+      g.style.fill=lerpColorHSL(cMin,cMax,t);
+    }else{
+      g.classList.remove('heatmap');
+      g.style.fill='';
+    }
   });
 }
 
@@ -76,7 +62,6 @@ export function showPressPing(g, { host, scale = 1 } = {}) {
   ping.className = 'press-ping';
   ping.style.left = (screen.x - rect.left) + 'px';
   ping.style.top  = (screen.y - rect.top)  + 'px';
-  // make preview pings smaller via scale
   ping.style.transform = `translate(-50%,-50%) scale(${0.7 * scale})`;
   host.appendChild(ping);
   setTimeout(() => ping.remove(), 650);
@@ -108,9 +93,10 @@ function resolveIdsFromLabels(inputKeys) {
   return [...new Set(out)];
 }
 
-export function highlightKeys(keys, { mirrorPreview = true } = {}) {
-  const { mainSvg, previewSvg, mainHost, previewHost } = getKeyboardSvgs();
-  if (!mainSvg && !previewSvg) return;
+export function highlightKeys(keys) {
+  const svg = document.querySelector('#kb-mount svg.keyboard');
+  const host = document.getElementById('kb-mount');
+  if (!svg || !host) return;
 
   const ids = resolveIdsFromLabels(keys);
 
@@ -119,32 +105,25 @@ export function highlightKeys(keys, { mirrorPreview = true } = {}) {
     heat.set(id, count);
   });
 
-  const targets = [mainSvg].filter(Boolean);
-  if (mirrorPreview && previewSvg) targets.push(previewSvg);
+  ids.forEach(id => {
+    const g = svg.querySelector(`#${CSS.escape(id)}.key`);
+    if (!g) return;
+    g.classList.add('pressed');
 
-  targets.forEach((svg) => {
-    ids.forEach((id) => {
-      const g = svg.querySelector(`#${CSS.escape(id)}.key`);
-      if (!g) return;
-      g.classList.add('pressed');
+    if (options.ping && typeof showPressPing === 'function') {
+      showPressPing(g, { host });
+    }
 
-      // ping in both; preview gets smaller scale
-      if (options.ping && typeof showPressPing === 'function') {
-        const host = (svg === mainSvg) ? mainHost : previewHost;
-        const scale = (svg === mainSvg) ? 1 : 0.6;
-        showPressPing(g, { host, scale });
-      }
-
-      setTimeout(() => g.classList.remove('pressed'), 1200);
-    });
+    setTimeout(() => g.classList.remove('pressed'), 1200);
   });
+
   applyHeatmap();
   saveHeat();
 }
 window.VoiceKeys = Object.assign({}, window.VoiceKeys, { highlightKeys });
 
 export function validateKeyboardSVG(){
-  const svg = document.querySelector('svg.keyboard');
+  const svg = document.querySelector('#kb-mount svg.keyboard');
   if(!svg) return;
   const miss=[];
   for(const k of KEYS){

--- a/voice-hotkey/index.html
+++ b/voice-hotkey/index.html
@@ -12,7 +12,12 @@
 </head>
 <body>
   <header class="top-bar">
-    <h1>voice to keys</h1>
+    <div class="title-block">
+      <h1>voice to keys</h1>
+      <!-- preview SVG goes here -->
+      <div id="kb-preview" class="kb-preview" aria-hidden="true"></div>
+    </div>
+
     <div class="top-controls">
       <label class="sr-only" for="os">OS</label>
       <select id="os">
@@ -91,30 +96,42 @@
   </dialog>
   <script type="module" src="./kb-map.js"></script>
   <script type="module">
-  import { validateKeyboardSVG } from './app.js'; // export a no-op if not present
+  import { validateKeyboardSVG } from './app.js';
 
   async function injectSVG() {
-    const mount = document.getElementById('kb-mount');
     const res = await fetch('./assets/keyboard.svg', { cache: 'no-store' });
     if (!res.ok) throw new Error('SVG fetch failed: ' + res.status);
-    mount.innerHTML = await res.text();
-    const svg = mount.querySelector('svg');
-    if (svg) {
+    const svgText = await res.text();
+
+    function mountInto(el) {
+      if (!el) return;
+      el.innerHTML = svgText;
+      const svg = el.querySelector('svg');
+      if (!svg) return;
       svg.classList.add('keyboard');
+
+      // baseline styles INSIDE the SVG (namespace matters)
       const style = document.createElementNS('http://www.w3.org/2000/svg','style');
       style.textContent = `
-  .key rect, .key path { fill: var(--key-fill); stroke: var(--key-stroke); }
-  .key text { fill:#333; }
-  .key.pressed rect, .key.pressed path {
-    fill: var(--key-pressed-fill) !important;
-    stroke: var(--key-pressed-stroke) !important;
-    filter: drop-shadow(0 0 .4rem hsla(205,90%,45%,.55));
-  }
-`;
+        .key rect, .key path { fill: var(--key-fill); stroke: var(--key-stroke); }
+        .key text { fill:#333; }
+        .key.pressed rect, .key.pressed path {
+          fill: var(--key-pressed-fill) !important;
+          stroke: var(--key-pressed-stroke) !important;
+          filter: drop-shadow(0 0 .4rem hsla(205,90%,45%,.55));
+        }
+      `;
       svg.appendChild(style);
     }
+
+    // main (interactive) — existed before
+    mountInto(document.getElementById('kb-mount'));
+    // new preview (static) — just the image
+    mountInto(document.getElementById('kb-preview'));
+
     if (typeof validateKeyboardSVG === 'function') validateKeyboardSVG();
   }
+
   injectSVG().catch(e => {
     console.error(e);
     document.getElementById('kb-mount').textContent = 'Keyboard SVG failed to load.';

--- a/voice-hotkey/styles.css
+++ b/voice-hotkey/styles.css
@@ -113,3 +113,7 @@ svg.keyboard .key.pressed path {
 }
 
 /* The ping in preview will be smaller; no extra CSS needed if we scale in JS */
+.title-block{ display:flex; flex-direction:column; gap:.5rem; }
+.kb-preview{ max-width:640px; max-height:140px; pointer-events:none; opacity:.98; }
+.kb-preview svg{ display:block; width:100%; height:auto; }
+


### PR DESCRIPTION
## Summary
- show a static keyboard preview beneath the page title
- render keyboard.svg in both preview and interactive mounts
- restrict heatmap and highlighting to the main keyboard

## Testing
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_689b28b1cc44832aaf8a0e567ce01c9e