### PR TITLE
feat: mirror keyboard preview

### DIFF
--- a/voice-hotkey/app.js
+++ b/voice-hotkey/app.js
@@ -9,6 +9,17 @@ let controller = null;
 const heat = new Map();
 let options = { ping: true, heatmap: false, eye: { enabled: false, dwell: 700, sensitivity: 0.5 } };
 
+function getKeyboardSvgs(){
+  const mainHost = document.getElementById('kb-mount');
+  const previewHost = document.getElementById('kb-preview');
+  return {
+    mainHost,
+    previewHost,
+    mainSvg: mainHost?.querySelector('svg.keyboard') || null,
+    previewSvg: previewHost?.querySelector('svg.keyboard') || null,
+  };
+}
+
 function lerpColorHSL(a,b,t){
   const pa=a.match(/[\d.]+/g).map(Number);
   const pb=b.match(/[\d.]+/g).map(Number);
@@ -19,23 +30,24 @@ function lerpColorHSL(a,b,t){
 }
 
 function applyHeatmap(){
-  const svg = document.querySelector('#kb-mount svg.keyboard');
-  if(!svg) return;
   const max=Math.max(...heat.values(),0);
   const cs=getComputedStyle(document.documentElement);
   const cMin=cs.getPropertyValue('--key-heatmap-min').trim();
   const cMax=cs.getPropertyValue('--key-heatmap-max').trim();
-  heat.forEach((count,id)=>{
-    const g=svg.querySelector('#'+CSS.escape(id));
-    if(!g) return;
-    if(options.heatmap && max){
-      const t=count/max;
-      g.classList.add('heatmap');
-      g.style.fill=lerpColorHSL(cMin,cMax,t);
-    }else{
-      g.classList.remove('heatmap');
-      g.style.fill='';
-    }
+
+  applyHeatmapToBoth(svg=>{
+    heat.forEach((count,id)=>{
+      const g=svg.querySelector('#'+CSS.escape(id));
+      if(!g) return;
+      if(options.heatmap && max){
+        const t=count/max;
+        g.classList.add('heatmap');
+        g.style.fill=lerpColorHSL(cMin,cMax,t);
+      }else{
+        g.classList.remove('heatmap');
+        g.style.fill='';
+      }
+    });
   });
 }
 
@@ -93,10 +105,9 @@ function resolveIdsFromLabels(inputKeys) {
   return [...new Set(out)];
 }
 
-export function highlightKeys(keys) {
-  const svg = document.querySelector('#kb-mount svg.keyboard');
-  const host = document.getElementById('kb-mount');
-  if (!svg || !host) return;
+export function highlightKeys(keys, { mirrorPreview = true } = {}){
+  const { mainSvg, previewSvg, mainHost, previewHost } = getKeyboardSvgs();
+  if (!mainSvg && !previewSvg) return;
 
   const ids = resolveIdsFromLabels(keys);
 
@@ -105,16 +116,21 @@ export function highlightKeys(keys) {
     heat.set(id, count);
   });
 
-  ids.forEach(id => {
-    const g = svg.querySelector(`#${CSS.escape(id)}.key`);
-    if (!g) return;
-    g.classList.add('pressed');
+  const targets = [mainSvg].filter(Boolean);
+  if (mirrorPreview && previewSvg) targets.push(previewSvg);
 
-    if (options.ping && typeof showPressPing === 'function') {
-      showPressPing(g, { host });
-    }
-
-    setTimeout(() => g.classList.remove('pressed'), 1200);
+  targets.forEach(svg => {
+    ids.forEach(id => {
+      const g = svg.querySelector(`#${CSS.escape(id)}.key`);
+      if (!g) return;
+      g.classList.add('pressed');
+      if (options.ping && typeof showPressPing === 'function'){
+        const host = (svg === mainSvg) ? mainHost : previewHost;
+        const scale = (svg === mainSvg) ? 1 : 0.65;
+        showPressPing(g, { host, scale });
+      }
+      setTimeout(()=> g.classList.remove('pressed'), 1200);
+    });
   });
 
   applyHeatmap();
@@ -122,12 +138,17 @@ export function highlightKeys(keys) {
 }
 window.VoiceKeys = Object.assign({}, window.VoiceKeys, { highlightKeys });
 
+function applyHeatmapToBoth(updateFnPerKey){
+  const { mainSvg, previewSvg } = getKeyboardSvgs();
+  [mainSvg, previewSvg].filter(Boolean).forEach(svg => updateFnPerKey(svg));
+}
+
 export function validateKeyboardSVG(){
-  const svg = document.querySelector('#kb-mount svg.keyboard');
-  if(!svg) return;
+  const { mainSvg } = getKeyboardSvgs();
+  if(!mainSvg) return;
   const miss=[];
   for(const k of KEYS){
-    if(!svg.querySelector(`#${CSS.escape(k.svgId)}.key`)) miss.push(k.svgId);
+    if(!mainSvg.querySelector(`#${CSS.escape(k.svgId)}.key`)) miss.push(k.svgId);
   }
   if(miss.length) console.warn('[keyboard.svg] Missing key ids:', miss);
 }

--- a/voice-hotkey/index.html
+++ b/voice-hotkey/index.html
@@ -14,8 +14,9 @@
   <header class="top-bar">
     <div class="title-block">
       <h1>voice to keys</h1>
-      <!-- preview SVG goes here -->
-      <div id="kb-preview" class="kb-preview" aria-hidden="true"></div>
+      <div class="kb-card">
+        <div id="kb-preview" class="kb-preview" aria-hidden="false"></div>
+      </div>
     </div>
 
     <div class="top-controls">
@@ -98,44 +99,42 @@
   <script type="module">
   import { validateKeyboardSVG } from './app.js';
 
-  async function injectSVG() {
+  async function injectKeyboardSVG() {
     const res = await fetch('./assets/keyboard.svg', { cache: 'no-store' });
     if (!res.ok) throw new Error('SVG fetch failed: ' + res.status);
     const svgText = await res.text();
 
-    function mountInto(el) {
+    function mountInto(el){
       if (!el) return;
       el.innerHTML = svgText;
       const svg = el.querySelector('svg');
       if (!svg) return;
       svg.classList.add('keyboard');
 
-      // baseline styles INSIDE the SVG (namespace matters)
+      /* ensure base styles even if external CSS fails */
       const style = document.createElementNS('http://www.w3.org/2000/svg','style');
       style.textContent = `
         .key rect, .key path { fill: var(--key-fill); stroke: var(--key-stroke); }
-        .key text { fill:#333; }
+        .key text { fill: var(--key-text); }
         .key.pressed rect, .key.pressed path {
           fill: var(--key-pressed-fill) !important;
           stroke: var(--key-pressed-stroke) !important;
-          filter: drop-shadow(0 0 .4rem hsla(205,90%,45%,.55));
+          filter: drop-shadow(0 0 .35rem hsla(205, 90%, 45%, .55));
         }
       `;
       svg.appendChild(style);
     }
 
-    // main (interactive) — existed before
-    mountInto(document.getElementById('kb-mount'));
-    // new preview (static) — just the image
-    mountInto(document.getElementById('kb-preview'));
+    mountInto(document.getElementById('kb-mount'));   // main
+    mountInto(document.getElementById('kb-preview')); // picture
 
     if (typeof validateKeyboardSVG === 'function') validateKeyboardSVG();
   }
 
-  injectSVG().catch(e => {
-    console.error(e);
-    document.getElementById('kb-mount').textContent = 'Keyboard SVG failed to load.';
-  });
+  if (document.readyState === 'loading')
+    document.addEventListener('DOMContentLoaded', injectKeyboardSVG);
+  else
+    injectKeyboardSVG();
   </script>
 </body>
 </html>

--- a/voice-hotkey/keymap.js
+++ b/voice-hotkey/keymap.js
@@ -22,7 +22,8 @@ export const ALIASES = {
   command: 'Cmd', cmd: 'Cmd', '⌘': 'Cmd', 커맨드: 'Cmd',
   option: 'Alt', alt: 'Alt', 알트: 'Alt',
   shift: 'Shift', 쉬프트: 'Shift',
-  windows: 'Win', window: 'Win', win: 'Win', 윈도우: 'Win', 윈키: 'Win'
+  windows: 'Win', window: 'Win', win: 'Win', 윈도우: 'Win', 윈키: 'Win',
+  '-': 'Minus', '=': 'Equal', '[': 'BracketLeft', ']': 'BracketRight'
 };
 
 export const COMMON_INTENTS = {

--- a/voice-hotkey/styles.css
+++ b/voice-hotkey/styles.css
@@ -117,3 +117,82 @@ svg.keyboard .key.pressed path {
 .kb-preview{ max-width:640px; max-height:140px; pointer-events:none; opacity:.98; }
 .kb-preview svg{ display:block; width:100%; height:auto; }
 
+:root{
+  --bg: #f7f8fa;
+  --text: #1b1f23;
+  --muted: #6b7280;
+  --surface: #ffffff;
+  --surface-border: #e5e7eb;
+  --shadow: 0 8px 24px rgba(0,0,0,.08);
+  --radius: 14px;
+
+  /* keyboard colors */
+  --key-fill: #ffffff;
+  --key-stroke: #cfcfcf;
+  --key-text: #333333;
+  --key-pressed-fill: hsl(205 85% 55%);
+  --key-pressed-stroke: hsl(205 90% 40%);
+}
+
+@media (prefers-color-scheme: dark){
+  :root{
+    --bg: #0b0f14;
+    --text: #e5e7eb;
+    --muted: #9aa3af;
+    --surface: #111827;
+    --surface-border: #1f2937;
+    --shadow: 0 8px 24px rgba(0,0,0,.35);
+
+    --key-fill: #1a2230;
+    --key-stroke: #2a3342;
+    --key-text: #d1d5db;
+    --key-pressed-fill: hsl(205 90% 55%);
+    --key-pressed-stroke: hsl(205 95% 40%);
+  }
+}
+
+/* page chrome */
+body{ background: var(--bg); color: var(--text); }
+h1{ font-weight:700; letter-spacing:.2px; margin: 0 0 .4rem 0; }
+
+/* preview card */
+.kb-card{
+  margin: .25rem 0 1.25rem;
+  background: var(--surface);
+  border: 1px solid var(--surface-border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  padding: .75rem 1rem;
+}
+.kb-preview{ max-width: 860px; max-height: 160px; }
+.kb-preview svg{ display:block; width:100%; height:auto; }
+
+/* baseline keyboard visuals (apply to BOTH preview & main) */
+svg.keyboard .key rect,
+svg.keyboard .key path { fill: var(--key-fill); stroke: var(--key-stroke); }
+svg.keyboard .key text { fill: var(--key-text); }
+
+/* pressed state (both) */
+svg.keyboard .key.pressed rect,
+svg.keyboard .key.pressed path {
+  fill: var(--key-pressed-fill) !important;
+  stroke: var(--key-pressed-stroke) !important;
+  filter: drop-shadow(0 0 .35rem hsla(205, 90%, 45%, .55));
+}
+
+/* preview: slightly softer glow */
+#kb-preview .key.pressed rect,
+#kb-preview .key.pressed path {
+  filter: drop-shadow(0 0 .25rem hsla(205, 90%, 45%, .4));
+}
+
+/* ping overlay dot */
+.press-ping {
+  position:absolute; pointer-events:none;
+  width:16px;height:16px;border-radius:50%;
+  background: hsla(205, 90%, 60%, .35);
+  transform: translate(-50%,-50%) scale(.7);
+  animation: ping 600ms ease-out forwards;
+}
+@keyframes ping { 60%{transform:translate(-50%,-50%) scale(1.55); opacity:.65} 100%{opacity:0} }
+


### PR DESCRIPTION
## Summary
- add card-style keyboard preview and dual SVG injector
- mirror key highlights, pings, and heatmap between main and preview keyboards
- support symbol key aliases

## Testing
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_689b2c5aa658832abbae48ab33f390cc