### PR TITLE
feat: enlarge keyboard preview and relocate

### DIFF
--- a/voice-hotkey/index.html
+++ b/voice-hotkey/index.html
@@ -14,9 +14,6 @@
   <header class="top-bar">
     <div class="title-block">
       <h1>voice to keys</h1>
-      <div class="kb-card">
-        <div id="kb-preview" class="kb-preview" aria-hidden="false"></div>
-      </div>
     </div>
 
     <div class="top-controls">
@@ -56,6 +53,10 @@
 
       <p id="kb-status" class="sr-only" aria-live="polite"></p>
     </section>
+
+    <div class="kb-card">
+      <div id="kb-preview" class="kb-preview" aria-hidden="false"></div>
+    </div>
 
     <style>
       /* Scoped styles */

--- a/voice-hotkey/styles.css
+++ b/voice-hotkey/styles.css
@@ -157,14 +157,14 @@ h1{ font-weight:700; letter-spacing:.2px; margin: 0 0 .4rem 0; }
 
 /* preview card */
 .kb-card{
-  margin: .25rem 0 1.25rem;
+  margin: 1.5rem auto 0;
   background: var(--surface);
   border: 1px solid var(--surface-border);
   border-radius: var(--radius);
   box-shadow: var(--shadow);
   padding: .75rem 1rem;
 }
-.kb-preview{ max-width: 860px; max-height: 160px; }
+.kb-preview{ max-width: clamp(1000px, 95vw, 1400px); max-height: 400px; }
 .kb-preview svg{ display:block; width:100%; height:auto; }
 
 /* baseline keyboard visuals (apply to BOTH preview & main) */
@@ -240,5 +240,5 @@ svg.keyboard .key.pressed path {
 }
 
 /* Optional: make preview/main bigger and centered */
-.kb-preview { max-width: clamp(900px, 95vw, 1200px); max-height: 280px; }
-.keyboard-container, .kb-wrap { max-width: clamp(900px, 95vw, 1200px); }
+.kb-preview { max-width: clamp(1000px, 95vw, 1400px); max-height: 400px; }
+.keyboard-container, .kb-wrap { max-width: clamp(1000px, 95vw, 1400px); }


### PR DESCRIPTION
## Summary
- Move keyboard preview out of header and place at bottom of main content
- Increase preview keyboard size for better visibility

## Testing
- `node tests/apple_association.test.js`

------
https://chatgpt.com/codex/tasks/task_b_689be1219bb4832a82939f5e43e02979