### PR TITLE
feat: rotate recommendations without heavy fetch

### DIFF
--- a/fetchStockInfo.js
+++ b/fetchStockInfo.js
@@ -244,42 +244,34 @@ async function updateRecommendations() {
     process.exit(1);
   }
 
-  if (data.lastUpdated && !FORCE) {
-    const age = Date.now() - new Date(data.lastUpdated).getTime();
-    if (age < SIX_HOURS) {
-      console.log(`${RECS_FILE} is up to date (<6h). Use --force to override.`);
-      data.lastUpdated = nowKSTISO();
-      await fs.writeFile(RECS_FILE, JSON.stringify(data, null, 2));
-      return;
+  const seed = new Date().toLocaleDateString('sv-SE', { timeZone: 'Asia/Seoul' });
+  const log = {};
+  for (const [market, buckets] of Object.entries(POOLS)) {
+    data[market] = data[market] || {};
+    for (const bucket of ['safe', 'aggressive']) {
+      const source = buckets[bucket] || [];
+      const chosen = process.env.FIXED_RECS === '1'
+        ? source.slice(0, 5)
+        : pickDeterministic(source, 5, `${seed}:${market}:${bucket}`);
+      data[market][bucket] = chosen.map(n => (typeof n === 'string' ? { name: n } : n));
     }
+    log[market] = {
+      safe: data[market].safe.map(x => x.name),
+      aggressive: data[market].aggressive.map(x => x.name)
+    };
+  }
+  console.log('[SELECTED]', JSON.stringify(log, null, 2));
+
+  const age = data.lastUpdated ? Date.now() - new Date(data.lastUpdated).getTime() : Infinity;
+  const isFresh = age < SIX_HOURS;
+  if (isFresh && !FORCE) {
+    const out = { ...data, lastUpdated: nowKSTISO() };
+    await fs.writeFile(RECS_FILE, JSON.stringify(out, null, 2));
+    console.log(`[SKIP] Cache <6h. Wrote rotated selection at ${out.lastUpdated}`);
+    return;
   }
 
   const markets = Object.keys(data).filter(k => typeof data[k] === 'object' && data[k] !== null);
-  const todaySeed = new Date().toLocaleDateString('sv-SE', { timeZone: 'Asia/Seoul' });
-  for (const market of markets) {
-    const pool = POOLS[market];
-    if (!pool) continue;
-    for (const bucket of ['safe', 'aggressive']) {
-      if (process.env.FIXED_RECS === '1') continue;
-      const source = pool[bucket] || [];
-      const selected = pickDeterministic(source, 5, `${todaySeed}:${market}:${bucket}`);
-      data[market][bucket] = selected.map(x => (typeof x === 'string' ? { name: x } : x));
-    }
-  }
-  console.log(
-    '[COMPOSE]',
-    JSON.stringify(
-      Object.fromEntries(
-        markets.map(m => [m, {
-          safe: data[m]?.safe?.map(it => it.name),
-          aggressive: data[m]?.aggressive?.map(it => it.name)
-        }])
-      ),
-      null,
-      2
-    )
-  );
-
   const missingStatic = findMissingStaticMappings(data);
   if (missingStatic.length) {
     console.warn('[INFO] Not in static map (will auto-resolve):', missingStatic.join(', '));

--- a/recommendations.json
+++ b/recommendations.json
@@ -2,186 +2,146 @@
   "KOSPI": {
     "safe": [
       {
-        "name": "NAVER",
-        "sector": null
+        "name": "NAVER"
       },
       {
-        "name": "현대차",
-        "sector": null
+        "name": "현대차"
       },
       {
-        "name": "카카오",
-        "sector": null
+        "name": "카카오"
       },
       {
-        "name": "LG화학",
-        "sector": null
+        "name": "LG화학"
       },
       {
-        "name": "SK하이닉스",
-        "sector": null
+        "name": "SK하이닉스"
       }
     ],
     "aggressive": [
       {
-        "name": "HD한국조선해양",
-        "sector": null
+        "name": "HD한국조선해양"
       },
       {
-        "name": "POSCO퓨처엠",
-        "sector": null
+        "name": "POSCO퓨처엠"
       },
       {
-        "name": "BGF리테일",
-        "sector": null
+        "name": "BGF리테일"
       },
       {
-        "name": "한화에어로스페이스",
-        "sector": null
+        "name": "한화에어로스페이스"
       },
       {
-        "name": "HD현대일렉트릭",
-        "sector": null
+        "name": "HD현대일렉트릭"
       }
     ]
   },
   "KOSDAQ": {
     "safe": [
       {
-        "name": "JYP엔터테인먼트",
-        "sector": null
+        "name": "JYP엔터테인먼트"
       },
       {
-        "name": "리노공업",
-        "sector": null
+        "name": "리노공업"
       },
       {
-        "name": "천보",
-        "sector": null
+        "name": "천보"
       },
       {
-        "name": "카카오게임즈",
-        "sector": null
+        "name": "카카오게임즈"
       },
       {
-        "name": "엘앤에프",
-        "sector": null
+        "name": "엘앤에프"
       }
     ],
     "aggressive": [
       {
-        "name": "레고켐바이오",
-        "sector": null
+        "name": "레고켐바이오"
       },
       {
-        "name": "HLB",
-        "sector": null
+        "name": "HLB"
       },
       {
-        "name": "지아이이노베이션",
-        "sector": null
+        "name": "지아이이노베이션"
       },
       {
-        "name": "펩트론",
-        "sector": null
+        "name": "펩트론"
       },
       {
-        "name": "한미반도체",
-        "sector": null
+        "name": "한미반도체"
       }
     ]
   },
   "NASDAQ": {
     "safe": [
       {
-        "name": "Amazon",
-        "sector": null
+        "name": "Amazon"
       },
       {
-        "name": "Apple",
-        "sector": null
+        "name": "Apple"
       },
       {
-        "name": "Alphabet",
-        "sector": null
+        "name": "Alphabet"
       },
       {
-        "name": "Broadcom",
-        "sector": null
+        "name": "Broadcom"
       },
       {
-        "name": "Advanced Micro Devices",
-        "sector": null
+        "name": "Advanced Micro Devices"
       }
     ],
     "aggressive": [
       {
-        "name": "Snowflake",
-        "sector": null
+        "name": "Snowflake"
       },
       {
-        "name": "Micron Technology",
-        "sector": null
+        "name": "Micron Technology"
       },
       {
-        "name": "Super Micro Computer",
-        "sector": null
+        "name": "Super Micro Computer"
       },
       {
-        "name": "Palantir",
-        "sector": null
+        "name": "Palantir"
       },
       {
-        "name": "Datadog",
-        "sector": null
+        "name": "Datadog"
       }
     ]
   },
   "S&P 500": {
     "safe": [
       {
-        "name": "Coca-Cola",
-        "sector": null
+        "name": "Coca-Cola"
       },
       {
-        "name": "Walmart",
-        "sector": null
+        "name": "Walmart"
       },
       {
-        "name": "PepsiCo",
-        "sector": null
+        "name": "PepsiCo"
       },
       {
-        "name": "Procter & Gamble",
-        "sector": null
+        "name": "Procter & Gamble"
       },
       {
-        "name": "Visa",
-        "sector": null
+        "name": "Visa"
       }
     ],
     "aggressive": [
       {
-        "name": "NRG Energy",
-        "sector": null
+        "name": "NRG Energy"
       },
       {
-        "name": "Tesla",
-        "sector": null
+        "name": "Tesla"
       },
       {
-        "name": "Meta Platforms",
-        "sector": null
+        "name": "Meta Platforms"
       },
       {
-        "name": "ServiceNow",
-        "sector": null
+        "name": "ServiceNow"
       },
       {
-        "name": "Uber Technologies",
-        "sector": null
+        "name": "Uber Technologies"
       }
     ]
   },
-  "lastUpdated": "2025-08-13T15:25:36+09:00"
+  "lastUpdated": "2025-08-13T17:01:36+09:00"
 }


### PR DESCRIPTION
## Summary
- deterministically rotate company picks each run before checking cache age
- skip rate-limited API calls when data is fresher than 6h, yet still write a new recommendations.json

## Testing
- `node tests/apple_association.test.js`
- `node fetchStockInfo.js`
- `OFFLINE=1 node src/build.js`


------
https://chatgpt.com/codex/tasks/task_b_689c45cc7f5c832ab1c54553e1458d8c