### PR TITLE
Add overview navigation and readme page

### DIFF
--- a/seongsigan/readme.html
+++ b/seongsigan/readme.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>SeongSigan Readme</title>
+</head>
+<body>
+  <h1>About SeongSigan</h1>
+  <p>SeongSigan helps manage class schedules and offers quick access to an overview and chat-based adjustments.</p>
+</body>
+</html>

--- a/seongsigan/seongsigan.html
+++ b/seongsigan/seongsigan.html
@@ -42,5 +42,10 @@
   <div id="modalContainer" class="modal hidden" role="dialog" aria-modal="true"></div>
   <div id="toast" class="toast" role="status" aria-live="polite"></div>
   <script type="module" src="scripts/app.js"></script>
+  <script>
+    document.getElementById('overviewToggle').addEventListener('click', () => {
+      window.location.href = 'readme.html';
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Navigate to `readme.html` when clicking the SeongSigan overview button
- Add a simple `readme.html` describing the SeongSigan schedule page

## Testing
- `node --version`
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_689d2089b2e8832a9f06bf6bec25373b