### PR TITLE
Add favicons and home navigation across site

### DIFF
--- a/appdownload.html
+++ b/appdownload.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Manage Students App</title>
+    <link rel="icon" type="image/png" sizes="32x32" href="src/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="src/favicon-16x16.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="src/apple-touch-icon.png">
     <style>
         body {
             font-family: Arial, sans-serif;
@@ -30,9 +33,25 @@
         .store-badge:hover {
             transform: scale(1.05);
         }
+        .home-button {
+            position: fixed;
+            top: 10px;
+            left: 10px;
+            background-color: #4CAF50;
+            color: #fff;
+            padding: 8px 12px;
+            border-radius: 4px;
+            text-decoration: none;
+            font-weight: bold;
+            z-index: 1000;
+        }
+        .home-button:hover {
+            background-color: #45a049;
+        }
     </style>
 </head>
 <body>
+    <a href="index.html" class="home-button">Home</a>
     <h1>Manage Students App</h1>
     <p>Download our app from your device's app store</p>
     <p>플레이스토어 또는 앱스토어에서 다운로드하세요.</p>

--- a/appdownloadGS.html
+++ b/appdownloadGS.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Gridlock Shooter</title>
+    <link rel="icon" type="image/png" sizes="32x32" href="src/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="src/favicon-16x16.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="src/apple-touch-icon.png">
     <style>
         body {
             font-family: Arial, sans-serif;
@@ -30,9 +33,25 @@
         .store-badge:hover {
             transform: scale(1.05);
         }
+        .home-button {
+            position: fixed;
+            top: 10px;
+            left: 10px;
+            background-color: #4CAF50;
+            color: #fff;
+            padding: 8px 12px;
+            border-radius: 4px;
+            text-decoration: none;
+            font-weight: bold;
+            z-index: 1000;
+        }
+        .home-button:hover {
+            background-color: #45a049;
+        }
     </style>
 </head>
 <body>
+    <a href="index.html" class="home-button">Home</a>
     <h1>Gridlock Shooter</h1>
     <p>Download our app from your device's app store</p>
     <p>플레이스토어 또는 앱스토어에서 다운로드하세요.</p>

--- a/appdownloadLFE.html
+++ b/appdownloadLFE.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Log for Everything</title>
+    <link rel="icon" type="image/png" sizes="32x32" href="src/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="src/favicon-16x16.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="src/apple-touch-icon.png">
     <style>
         body {
             font-family: Arial, sans-serif;
@@ -30,9 +33,25 @@
         .store-badge:hover {
             transform: scale(1.05);
         }
+        .home-button {
+            position: fixed;
+            top: 10px;
+            left: 10px;
+            background-color: #4CAF50;
+            color: #fff;
+            padding: 8px 12px;
+            border-radius: 4px;
+            text-decoration: none;
+            font-weight: bold;
+            z-index: 1000;
+        }
+        .home-button:hover {
+            background-color: #45a049;
+        }
     </style>
 </head>
 <body>
+    <a href="index.html" class="home-button">Home</a>
     <h1>Log for Everything</h1>
     <p>Download our app from your device's app store</p>
     <p>플레이스토어 또는 앱스토어에서 다운로드하세요.</p>

--- a/cardbenefitapp.html
+++ b/cardbenefitapp.html
@@ -4,9 +4,30 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Privacy Policy - Card Benefits</title>
+    <link rel="icon" type="image/png" sizes="32x32" href="src/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="src/favicon-16x16.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="src/apple-touch-icon.png">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/tailwindcss/2.2.19/tailwind.min.css" rel="stylesheet">
+    <style>
+        .home-button {
+            position: fixed;
+            top: 10px;
+            left: 10px;
+            background-color: #4CAF50;
+            color: #fff;
+            padding: 8px 12px;
+            border-radius: 4px;
+            text-decoration: none;
+            font-weight: bold;
+            z-index: 1000;
+        }
+        .home-button:hover {
+            background-color: #45a049;
+        }
+    </style>
 </head>
 <body class="bg-gray-100 font-sans leading-normal tracking-normal">
+    <a href="index.html" class="home-button">Home</a>
     <div class="container mx-auto p-8">
         <header class="mb-8">
             <h1 class="text-4xl font-bold text-gray-800 mb-2">Privacy Policy</h1>

--- a/logforeverything.html
+++ b/logforeverything.html
@@ -4,10 +4,31 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Privacy Policy - Log For Everything</title>
+    <link rel="icon" type="image/png" sizes="32x32" href="src/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="src/favicon-16x16.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="src/apple-touch-icon.png">
     <link rel="canonical" href="https://singaseongj.github.io/logforeverything.html">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/tailwindcss/2.2.19/tailwind.min.css" rel="stylesheet">
+    <style>
+        .home-button {
+            position: fixed;
+            top: 10px;
+            left: 10px;
+            background-color: #4CAF50;
+            color: #fff;
+            padding: 8px 12px;
+            border-radius: 4px;
+            text-decoration: none;
+            font-weight: bold;
+            z-index: 1000;
+        }
+        .home-button:hover {
+            background-color: #45a049;
+        }
+    </style>
 </head>
 <body class="bg-gray-100 font-sans leading-normal tracking-normal">
+    <a href="index.html" class="home-button">Home</a>
     <div class="container mx-auto p-8">
         <header class="mb-8">
             <h1 class="text-4xl font-bold text-gray-800 mb-2">Privacy Policy</h1>

--- a/privacy_policy.html
+++ b/privacy_policy.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>개인정보처리방침</title>
+    <link rel="icon" type="image/png" sizes="32x32" href="src/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="src/favicon-16x16.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="src/apple-touch-icon.png">
     <link rel="stylesheet" href="style.css">
     <style>
         .privacy-policy {
@@ -17,9 +20,25 @@
             border-radius: 8px;
             background-color: #f9f9f9;
         }
+        .home-button {
+            position: fixed;
+            top: 10px;
+            left: 10px;
+            background-color: #4CAF50;
+            color: #fff;
+            padding: 8px 12px;
+            border-radius: 4px;
+            text-decoration: none;
+            font-weight: bold;
+            z-index: 1000;
+        }
+        .home-button:hover {
+            background-color: #45a049;
+        }
     </style>
 </head>
 <body>
+    <a href="index.html" class="home-button">Home</a>
     <header>
         <h1>SingaseongApp 개인정보 처리방침</h1>
     </header>

--- a/privacy_policy_gs.html
+++ b/privacy_policy_gs.html
@@ -4,9 +4,30 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Privacy Policy - Gridlock Shooter</title>
+    <link rel="icon" type="image/png" sizes="32x32" href="src/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="src/favicon-16x16.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="src/apple-touch-icon.png">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/tailwindcss/2.2.19/tailwind.min.css" rel="stylesheet">
+    <style>
+        .home-button {
+            position: fixed;
+            top: 10px;
+            left: 10px;
+            background-color: #4CAF50;
+            color: #fff;
+            padding: 8px 12px;
+            border-radius: 4px;
+            text-decoration: none;
+            font-weight: bold;
+            z-index: 1000;
+        }
+        .home-button:hover {
+            background-color: #45a049;
+        }
+    </style>
 </head>
 <body class="bg-gray-100 font-sans leading-normal tracking-normal">
+    <a href="index.html" class="home-button">Home</a>
     <div class="container mx-auto p-8">
         <header class="mb-8">
             <h1 class="text-4xl font-bold text-gray-800 mb-2">Privacy Policy</h1>

--- a/privacy_policy_ms.html
+++ b/privacy_policy_ms.html
@@ -4,9 +4,30 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Privacy Policy - Manage Students</title>
+    <link rel="icon" type="image/png" sizes="32x32" href="src/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="src/favicon-16x16.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="src/apple-touch-icon.png">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/tailwindcss/2.2.19/tailwind.min.css" rel="stylesheet">
+    <style>
+        .home-button {
+            position: fixed;
+            top: 10px;
+            left: 10px;
+            background-color: #4CAF50;
+            color: #fff;
+            padding: 8px 12px;
+            border-radius: 4px;
+            text-decoration: none;
+            font-weight: bold;
+            z-index: 1000;
+        }
+        .home-button:hover {
+            background-color: #45a049;
+        }
+    </style>
 </head>
 <body class="bg-gray-100 font-sans leading-normal tracking-normal">
+    <a href="index.html" class="home-button">Home</a>
     <div class="container mx-auto p-8">
         <header class="mb-8">
             <h1 class="text-4xl font-bold text-gray-800 mb-2">Privacy Policy</h1>

--- a/privacy_policy_ms_kr.html
+++ b/privacy_policy_ms_kr.html
@@ -4,9 +4,30 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>개인정보처리방침 - 학생 관리</title>
+    <link rel="icon" type="image/png" sizes="32x32" href="src/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="src/favicon-16x16.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="src/apple-touch-icon.png">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/tailwindcss/2.2.19/tailwind.min.css" rel="stylesheet">
+    <style>
+        .home-button {
+            position: fixed;
+            top: 10px;
+            left: 10px;
+            background-color: #4CAF50;
+            color: #fff;
+            padding: 8px 12px;
+            border-radius: 4px;
+            text-decoration: none;
+            font-weight: bold;
+            z-index: 1000;
+        }
+        .home-button:hover {
+            background-color: #45a049;
+        }
+    </style>
 </head>
 <body class="bg-gray-100 font-sans leading-normal tracking-normal">
+    <a href="index.html" class="home-button">Home</a>
     <div class="container mx-auto p-8">
         <header class="mb-8">
             <h1 class="text-4xl font-bold text-gray-800 mb-2">개인정보처리방침</h1>

--- a/seongsigan/dongsin1-2.html
+++ b/seongsigan/dongsin1-2.html
@@ -3,6 +3,9 @@
 <head>
   <meta charset="UTF-8" />
   <title>1-2반 2학기 시간표</title>
+  <link rel="icon" type="image/png" sizes="32x32" href="../src/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="../src/favicon-16x16.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="../src/apple-touch-icon.png">
   <style>
     h2 {
       text-align: center;
@@ -65,9 +68,25 @@
     .subject-지구과학   { background: #dbe7fa; }
     .subject-진로       { background: #fff4e5; }
     .subject-창체       { background: #f0f0f0; }
+    .home-button {
+      position: fixed;
+      top: 10px;
+      left: 10px;
+      background-color: #4CAF50;
+      color: #fff;
+      padding: 8px 12px;
+      border-radius: 4px;
+      text-decoration: none;
+      font-weight: bold;
+      z-index: 1000;
+    }
+    .home-button:hover {
+      background-color: #45a049;
+    }
   </style>
 </head>
 <body>
+  <a href="../index.html" class="home-button">Home</a>
   <h2>1-2반 2학기 시간표</h2>
   <table>
     <thead>

--- a/seongsigan/readme.html
+++ b/seongsigan/readme.html
@@ -4,6 +4,9 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>SeongSigan - 개요</title>
+  <link rel="icon" type="image/png" sizes="32x32" href="../src/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="../src/favicon-16x16.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="../src/apple-touch-icon.png">
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles/main.css" />
   <style>
@@ -29,9 +32,25 @@
       padding: 10px;
       overflow-x: auto;
     }
+    .home-button {
+      position: fixed;
+      top: 10px;
+      left: 10px;
+      background-color: #4CAF50;
+      color: #fff;
+      padding: 8px 12px;
+      border-radius: 4px;
+      text-decoration: none;
+      font-weight: bold;
+      z-index: 1000;
+    }
+    .home-button:hover {
+      background-color: #45a049;
+    }
   </style>
 </head>
 <body>
+  <a href="../index.html" class="home-button">Home</a>
   <header>
     <h1>SeongSigan Demo - 프로젝트 개요</h1>
   </header>

--- a/seongsigan/seongsigan.html
+++ b/seongsigan/seongsigan.html
@@ -4,11 +4,32 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>SeongSigan</title>
+  <link rel="icon" type="image/png" sizes="32x32" href="../src/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="../src/favicon-16x16.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="../src/apple-touch-icon.png">
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
   <link rel="stylesheet" href="styles/main.css">
+  <style>
+    .home-button {
+      position: fixed;
+      top: 10px;
+      left: 10px;
+      background-color: #4CAF50;
+      color: #fff;
+      padding: 8px 12px;
+      border-radius: 4px;
+      text-decoration: none;
+      font-weight: bold;
+      z-index: 1000;
+    }
+    .home-button:hover {
+      background-color: #45a049;
+    }
+  </style>
 </head>
 <body>
+  <a href="../index.html" class="home-button">Home</a>
   <header class="app-bar">
     <h1 class="logo">SeongSigan <span id="backendStatus" class="status" aria-label="백엔드 상태" title="Backend status"></span></h1>
     <select id="teacherSelect" aria-label="선생님 선택"></select>

--- a/src/template.html
+++ b/src/template.html
@@ -4,9 +4,30 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title data-i18n="title">데일리 주식 리포트 자동화</title>
+  <link rel="icon" type="image/png" sizes="32x32" href="src/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="src/favicon-16x16.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="src/apple-touch-icon.png">
   <link rel="stylesheet" href="stocks.css">
+  <style>
+    .home-button {
+      position: fixed;
+      top: 10px;
+      left: 10px;
+      background-color: #4CAF50;
+      color: #fff;
+      padding: 8px 12px;
+      border-radius: 4px;
+      text-decoration: none;
+      font-weight: bold;
+      z-index: 1000;
+    }
+    .home-button:hover {
+      background-color: #45a049;
+    }
+  </style>
 </head>
 <body>
+  <a href="index.html" class="home-button">Home</a>
   <h1 data-i18n="title">데일리 주식 리포트 자동화</h1>
   <p id="currentDate"><span id="datePrefix" data-i18n="today">오늘:</span> {{CURRENT_DATE}}</p>
   

--- a/stocks.html
+++ b/stocks.html
@@ -8,10 +8,28 @@
   <link rel="icon" type="image/png" sizes="16x16" href="src/favicon-16x16.png">
   <link rel="apple-touch-icon" sizes="180x180" href="src/apple-touch-icon.png">
   <link rel="stylesheet" href="stocks.css">
+  <style>
+    .home-button {
+      position: fixed;
+      top: 10px;
+      left: 10px;
+      background-color: #4CAF50;
+      color: #fff;
+      padding: 8px 12px;
+      border-radius: 4px;
+      text-decoration: none;
+      font-weight: bold;
+      z-index: 1000;
+    }
+    .home-button:hover {
+      background-color: #45a049;
+    }
+  </style>
 </head>
 <body>
+  <a href="index.html" class="home-button">Home</a>
   <h1 data-i18n="title">데일리 주식 리포트 자동화</h1>
-  <p id="currentDate"><span id="datePrefix" data-i18n="today">오늘:</span> 2025년 8월 8일</p>
+  <p id="currentDate"><span id="datePrefix" data-i18n="today">오늘:</span> 2025년 8월 14일</p>
   
   <div id="debugInfo" class="debug" style="display: none;">
     <h4>디버그 정보:</h4>
@@ -44,7 +62,7 @@
 
   <section id="portfolioRecommendations">
     <h2 data-i18n="portfolioRecs">포트폴리오 추천</h2>
-    <div id="recommendations"><div class="portfolio-group"><h3>KOSPI 안전주</h3><ul><li>삼성전자</li><li>SK하이닉스</li><li>삼성바이오로직스</li><li>현대차</li><li>POSCO홀딩스</li></ul></div><div class="portfolio-group"><h3>KOSPI 공격주</h3><ul><li>효성중공업</li><li>HD현대일렉트릭</li><li>BGF리테일</li><li>두산에너빌리티</li><li>한화에어로스페이스</li></ul></div><div class="portfolio-group"><h3>KOSDAQ 안전주</h3><ul><li>에코프로비엠</li><li>셀트리온헬스케어</li><li>천보</li><li>리노공업</li><li>박셀바이오</li></ul></div><div class="portfolio-group"><h3>KOSDAQ 공격주</h3><ul><li>알테오젠</li><li>펩트론</li><li>레인보우로보틱스</li><li>지아이이노베이션</li><li>에이프로젠</li></ul></div><div class="portfolio-group"><h3>NASDAQ 안전주</h3><ul><li>Microsoft</li><li>Apple</li><li>NVIDIA</li><li>Amazon</li><li>Meta Platforms</li></ul></div><div class="portfolio-group"><h3>NASDAQ 공격주</h3><ul><li>Super Micro Computer</li><li>Palantir</li><li>Arm Holdings</li><li>Micron Technology</li><li>UiPath</li></ul></div><div class="portfolio-group"><h3>S&P 500 안전주</h3><ul><li>Berkshire Hathaway (B)</li><li>Microsoft</li><li>Johnson & Johnson</li><li>Procter & Gamble</li><li>Visa</li></ul></div><div class="portfolio-group"><h3>S&P 500 공격주</h3><ul><li>Palantir</li><li>Super Micro Computer</li><li>Eli Lilly</li><li>Uber Technologies</li><li>NRG Energy</li></ul></div></div>
+    <div id="recommendations"><div class="portfolio-group"><h3>KOSPI 안전주</h3><ul><li>POSCO홀딩스</li><li>NAVER</li><li>카카오</li><li>SK하이닉스</li><li>삼성전자</li></ul></div><div class="portfolio-group"><h3>KOSPI 공격주</h3><ul><li>BGF리테일</li><li>POSCO퓨처엠</li><li>한화에어로스페이스</li><li>HD현대일렉트릭</li><li>두산에너빌리티</li></ul></div><div class="portfolio-group"><h3>KOSDAQ 안전주</h3><ul><li>JYP엔터테인먼트</li><li>리노공업</li><li>천보</li><li>카카오게임즈</li><li>엘앤에프</li></ul></div><div class="portfolio-group"><h3>KOSDAQ 공격주</h3><ul><li>레고켐바이오</li><li>HLB</li><li>지아이이노베이션</li><li>펩트론</li><li>한미반도체</li></ul></div><div class="portfolio-group"><h3>NASDAQ 안전주</h3><ul><li>NVIDIA</li><li>Alphabet</li><li>Amazon</li><li>Meta Platforms</li><li>Apple</li></ul></div><div class="portfolio-group"><h3>NASDAQ 공격주</h3><ul><li>UiPath</li><li>Super Micro Computer</li><li>Palantir</li><li>Micron Technology</li><li>Arm Holdings</li></ul></div><div class="portfolio-group"><h3>S&P 500 안전주</h3><ul><li>Visa</li><li>Johnson & Johnson</li><li>Procter & Gamble</li><li>Coca-Cola</li><li>Berkshire Hathaway (B)</li></ul></div><div class="portfolio-group"><h3>S&P 500 공격주</h3><ul><li>Uber Technologies</li><li>CrowdStrike</li><li>ServiceNow</li><li>NRG Energy</li><li>Eli Lilly</li></ul></div></div>
     <div id="portfolioUpdated" class="last-updated"></div>
   </section>
   

--- a/stocks_ex.html
+++ b/stocks_ex.html
@@ -4,6 +4,9 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>한국 시장 종목 선정 로직</title>
+  <link rel="icon" type="image/png" sizes="32x32" href="src/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="src/favicon-16x16.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="src/apple-touch-icon.png">
   <style>
     /* 기본 스타일 */
     body {
@@ -50,6 +53,21 @@
     ul li {
       margin-bottom: 0.5rem;
     }
+    .home-button {
+      position: fixed;
+      top: 10px;
+      left: 10px;
+      background-color: #4CAF50;
+      color: #fff;
+      padding: 8px 12px;
+      border-radius: 4px;
+      text-decoration: none;
+      font-weight: bold;
+      z-index: 1000;
+    }
+    .home-button:hover {
+      background-color: #45a049;
+    }
 
     /* 모바일 반응형 */
     @media (max-width: 600px) {
@@ -72,6 +90,7 @@
   </style>
 </head>
 <body>
+  <a href="index.html" class="home-button">Home</a>
   <div class="container">
     <h1>📊 한국 시장 종목 선정 로직 상세 설명</h1>
     

--- a/voice-hotkey/index.html
+++ b/voice-hotkey/index.html
@@ -4,13 +4,34 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>voice to keys</title>
+  <link rel="icon" type="image/png" sizes="32x32" href="../src/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="../src/favicon-16x16.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="../src/apple-touch-icon.png">
   <link rel="stylesheet" href="styles.css">
   <script type="module" src="keymap.js"></script>
   <script type="module" src="llm.js"></script>
   <script type="module" src="stt.js"></script>
   <script type="module" src="app.js"></script>
+  <style>
+    .home-button {
+      position: fixed;
+      top: 10px;
+      left: 10px;
+      background-color: #4CAF50;
+      color: #fff;
+      padding: 8px 12px;
+      border-radius: 4px;
+      text-decoration: none;
+      font-weight: bold;
+      z-index: 1000;
+    }
+    .home-button:hover {
+      background-color: #45a049;
+    }
+  </style>
 </head>
 <body>
+  <a href="../index.html" class="home-button">Home</a>
   <header class="top-bar">
     <div class="title-block">
       <h1>voice to keys</h1>


### PR DESCRIPTION
## Summary
- Restore favicon links in stock report template and every HTML page
- Extend fixed "Home" button to nested pages like SeongSigan and voice-hotkey for consistent navigation

## Testing
- `OFFLINE=1 node src/build.js`
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_689d46516ca4832ab7e39cf8446620b4