### PR TITLE
feat: add live FX marquee ticker

### DIFF
--- a/src/template.html
+++ b/src/template.html
@@ -24,6 +24,33 @@
     .home-button:hover {
       background-color: #45a049;
     }
+    .fx-ticker {
+      overflow: hidden;
+      background: #1f2937;
+      color: #f8fafc;
+      white-space: nowrap;
+      font-size: 0.9rem;
+      margin-top: 10px;
+    }
+    .fx-ticker__inner {
+      display: flex;
+      width: max-content;
+      animation: fx-scroll 40s linear infinite;
+    }
+    .fx-ticker__inner span {
+      padding: 0.5rem 1.5rem;
+      flex-shrink: 0;
+    }
+    @keyframes fx-scroll {
+      0% { transform: translateX(0); }
+      100% { transform: translateX(-50%); }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .fx-ticker__inner {
+        animation: none;
+        transform: none;
+      }
+    }
   </style>
 </head>
 <body>
@@ -490,6 +517,9 @@
     <button id="btnEn">English</button>
   </div>
   <div id="visitCounts" style="text-align:center;margin-top:20px;font-size:0.8rem;color:#64748b;"></div>
+  <div class="fx-ticker" role="marquee" aria-label="Live foreign exchange rates" aria-live="polite">
+    <div class="fx-ticker__inner" id="fx-ticker-content"></div>
+  </div>
   <script>
     (async function() {
       try {
@@ -500,6 +530,34 @@
         updateVisitCounts();
       } catch (err) {
         console.error('Visit count failed', err);
+      }
+    })();
+  </script>
+  <script>
+    (async function() {
+      const currencies = [
+        { code: 'USD', amount: 1 },
+        { code: 'JPY', amount: 100 },
+        { code: 'EUR', amount: 1 },
+        { code: 'CNY', amount: 1 },
+        { code: 'GBP', amount: 1 },
+        { code: 'HKD', amount: 1 }
+      ];
+      const formatter = new Intl.NumberFormat('ko-KR', { maximumFractionDigits: 0 });
+      try {
+        const results = await Promise.all(
+          currencies.map(async ({ code, amount }) => {
+            const res = await fetch(`https://api.frankfurter.app/latest?amount=${amount}&from=${code}&to=KRW`);
+            const data = await res.json();
+            return `${amount} ${code} → ${formatter.format(data.rates.KRW)}원`;
+          })
+        );
+        const timestamp = new Date().toLocaleString('ko-KR', { timeZone: 'Asia/Seoul' });
+        const text = results.join(' • ') + ` • ${timestamp} KST`;
+        const track = document.getElementById('fx-ticker-content');
+        track.innerHTML = `<span>${text}</span><span aria-hidden="true">${text}</span>`;
+      } catch (err) {
+        console.error('FX ticker failed', err);
       }
     })();
   </script>

--- a/stocks.html
+++ b/stocks.html
@@ -24,6 +24,33 @@
     .home-button:hover {
       background-color: #45a049;
     }
+    .fx-ticker {
+      overflow: hidden;
+      background: #1f2937;
+      color: #f8fafc;
+      white-space: nowrap;
+      font-size: 0.9rem;
+      margin-top: 10px;
+    }
+    .fx-ticker__inner {
+      display: flex;
+      width: max-content;
+      animation: fx-scroll 40s linear infinite;
+    }
+    .fx-ticker__inner span {
+      padding: 0.5rem 1.5rem;
+      flex-shrink: 0;
+    }
+    @keyframes fx-scroll {
+      0% { transform: translateX(0); }
+      100% { transform: translateX(-50%); }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .fx-ticker__inner {
+        animation: none;
+        transform: none;
+      }
+    }
   </style>
 </head>
 <body>
@@ -490,6 +517,9 @@
     <button id="btnEn">English</button>
   </div>
   <div id="visitCounts" style="text-align:center;margin-top:20px;font-size:0.8rem;color:#64748b;"></div>
+  <div class="fx-ticker" role="marquee" aria-label="Live foreign exchange rates" aria-live="polite">
+    <div class="fx-ticker__inner" id="fx-ticker-content"></div>
+  </div>
   <script>
     (async function() {
       try {
@@ -500,6 +530,34 @@
         updateVisitCounts();
       } catch (err) {
         console.error('Visit count failed', err);
+      }
+    })();
+  </script>
+  <script>
+    (async function() {
+      const currencies = [
+        { code: 'USD', amount: 1 },
+        { code: 'JPY', amount: 100 },
+        { code: 'EUR', amount: 1 },
+        { code: 'CNY', amount: 1 },
+        { code: 'GBP', amount: 1 },
+        { code: 'HKD', amount: 1 }
+      ];
+      const formatter = new Intl.NumberFormat('ko-KR', { maximumFractionDigits: 0 });
+      try {
+        const results = await Promise.all(
+          currencies.map(async ({ code, amount }) => {
+            const res = await fetch(`https://api.frankfurter.app/latest?amount=${amount}&from=${code}&to=KRW`);
+            const data = await res.json();
+            return `${amount} ${code} → ${formatter.format(data.rates.KRW)}원`;
+          })
+        );
+        const timestamp = new Date().toLocaleString('ko-KR', { timeZone: 'Asia/Seoul' });
+        const text = results.join(' • ') + ` • ${timestamp} KST`;
+        const track = document.getElementById('fx-ticker-content');
+        track.innerHTML = `<span>${text}</span><span aria-hidden="true">${text}</span>`;
+      } catch (err) {
+        console.error('FX ticker failed', err);
       }
     })();
   </script>


### PR DESCRIPTION
## Summary
- add styled marquee ticker below visit counter on stocks page
- fetch USD, JPY, EUR, CNY, GBP, HKD rates against KRW from Frankfurter API and display KST timestamp
- respect reduced motion preferences and duplicate ticker text for seamless scrolling

## Testing
- `node src/build.js`
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_689d502ccfbc832a8bf77072fea1501e