### PR TITLE
Improve FX fetching and sector resolution

### DIFF
--- a/data/fx_rates.json
+++ b/data/fx_rates.json
@@ -1,11 +1,47 @@
 {
-  "base": "USD",
-  "timestamp": "2025-08-14T13:11:30+09:00",
-  "rates": {
-    "KRW": 0,
-    "JPY": 0,
-    "EUR": 0,
-    "CNY": 0,
-    "GBP": 0
-  }
+  "lastUpdated": "2025-08-14T13:25:00+09:00",
+  "items": [
+    {
+      "label": "1 USD",
+      "amount": 1,
+      "from": "USD",
+      "to": "KRW",
+      "krw": null
+    },
+    {
+      "label": "100 JPY",
+      "amount": 100,
+      "from": "JPY",
+      "to": "KRW",
+      "krw": null
+    },
+    {
+      "label": "1 EUR",
+      "amount": 1,
+      "from": "EUR",
+      "to": "KRW",
+      "krw": null
+    },
+    {
+      "label": "1 CNY",
+      "amount": 1,
+      "from": "CNY",
+      "to": "KRW",
+      "krw": null
+    },
+    {
+      "label": "1 GBP",
+      "amount": 1,
+      "from": "GBP",
+      "to": "KRW",
+      "krw": null
+    },
+    {
+      "label": "1 HKD",
+      "amount": 1,
+      "from": "HKD",
+      "to": "KRW",
+      "krw": null
+    }
+  ]
 }

--- a/fetchFxRates.js
+++ b/fetchFxRates.js
@@ -4,63 +4,105 @@ import path from 'node:path';
 import { nowKSTISO } from './utils/time.js';
 
 const OUT = path.resolve(process.cwd(), 'data', 'fx_rates.json');
-const API = 'https://api.exchangerate.host/latest?base=USD&symbols=KRW,JPY,EUR,CNY,GBP';
 
-async function ensureDir(p) {
-  const dir = path.dirname(p);
-  try { await fs.mkdir(dir, { recursive: true }); } catch {}
-}
+const YF = (symbols) =>
+  `https://query1.finance.yahoo.com/v7/finance/quote?symbols=${encodeURIComponent(symbols)}`;
 
-const sleep = ms => new Promise(r => setTimeout(r, ms));
-async function fetchWithRetry(url, { retries = 3, base = 400 } = {}) {
-  let lastErr;
-  for (let i = 0; i <= retries; i++) {
-    try {
-      const res = await fetch(url, { headers: { 'User-Agent': 'Mozilla/5.0' } });
+const FR_USD = 'https://api.frankfurter.app/latest?from=USD&to=KRW,EUR,GBP,CNY,HKD';
+const FR_JPY = 'https://api.frankfurter.app/latest?from=JPY&to=KRW';
+
+const EH_USD = 'https://api.exchangerate.host/latest?base=USD&symbols=KRW,EUR,GBP,CNY,HKD';
+const EH_JPY = 'https://api.exchangerate.host/latest?base=JPY&symbols=KRW';
+
+const sleep = (ms)=>new Promise(r=>setTimeout(r,ms));
+async function get(url,{retries=3,base=400}={}) {
+  let err;
+  for (let i=0;i<=retries;i++){
+    try{
+      const res = await fetch(url,{headers:{'User-Agent':'Mozilla/5.0','Accept':'application/json'}});
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       return await res.json();
-    } catch (e) {
-      lastErr = e;
-      if (i < retries) await sleep(base * 2 ** i);
-    }
+    }catch(e){ err=e; if(i<retries) await sleep(base*2**i); }
   }
-  throw lastErr;
+  throw err;
 }
 
-async function main() {
-  await ensureDir(OUT);
-  let data;
-  try {
-    const j = await fetchWithRetry(API);
-    const rates = j?.rates || {};
-    const out = {
-      base: 'USD',
-      timestamp: nowKSTISO(),
-      rates: {
-        KRW: Number(rates.KRW ?? 0),
-        JPY: Number(rates.JPY ?? 0),
-        EUR: Number(rates.EUR ?? 0),
-        CNY: Number(rates.CNY ?? 0),
-        GBP: Number(rates.GBP ?? 0),
-      }
-    };
-    await fs.writeFile(OUT, JSON.stringify(out, null, 2));
-    console.log(`FX: wrote ${OUT} at ${out.timestamp}`);
-    return;
-  } catch (err) {
-    console.warn('FX fetch failed:', err?.message || err);
-    if (existsSync(OUT)) {
-      console.warn('Keeping previous fx_rates.json');
-      return;
-    }
-    const fallback = {
-      base: 'USD',
-      timestamp: nowKSTISO(),
-      rates: { KRW: 0, JPY: 0, EUR: 0, CNY: 0, GBP: 0 }
-    };
-    await fs.writeFile(OUT, JSON.stringify(fallback, null, 2));
-    console.log('FX: wrote fallback fx_rates.json');
-  }
+function itemsFromRates(map) {
+  return [
+    { label:'1 USD',   amount:1,   from:'USD', to:'KRW', krw: map.USD_KRW ?? null },
+    { label:'100 JPY', amount:100, from:'JPY', to:'KRW', krw: map.JPY100_KRW ?? null },
+    { label:'1 EUR',   amount:1,   from:'EUR', to:'KRW', krw: map.EUR_KRW ?? null },
+    { label:'1 CNY',   amount:1,   from:'CNY', to:'KRW', krw: map.CNY_KRW ?? null },
+    { label:'1 GBP',   amount:1,   from:'GBP', to:'KRW', krw: map.GBP_KRW ?? null },
+    { label:'1 HKD',   amount:1,   from:'HKD', to:'KRW', krw: map.HKD_KRW ?? null },
+  ];
 }
 
-main().catch(e => { console.error(e); process.exit(1); });
+async function yahooProvider() {
+  // Yahoo currency pairs return KRW directly
+  const symbols = [
+    'USDKRW=X','JPYKRW=X','EURKRW=X','CNYKRW=X','GBPKRW=X','HKDKRW=X'
+  ].join(',');
+  const j = await get(YF(symbols));
+  const q = j?.quoteResponse?.result || [];
+  const by = Object.fromEntries(q.map(r => [r.symbol, r.regularMarketPrice]));
+  const map = {
+    USD_KRW: by['USDKRW=X'],
+    JPY100_KRW: by['JPYKRW=X'] ? by['JPYKRW=X']*100 : null,
+    EUR_KRW: by['EURKRW=X'],
+    CNY_KRW: by['CNYKRW=X'],
+    GBP_KRW: by['GBPKRW=X'],
+    HKD_KRW: by['HKDKRW=X'],
+  };
+  return itemsFromRates(map);
+}
+
+async function frankfurterProvider() {
+  const usd = await get(FR_USD);
+  const jpy = await get(FR_JPY);
+  const map = {
+    USD_KRW: usd?.rates?.KRW ?? null,
+    JPY100_KRW: jpy?.rates?.KRW ? jpy.rates.KRW*100 : null,
+    EUR_KRW: (usd?.rates?.KRW && usd?.rates?.EUR) ? usd.rates.KRW/usd.rates.EUR : null,
+    CNY_KRW: (usd?.rates?.KRW && usd?.rates?.CNY) ? usd.rates.KRW/usd.rates.CNY : null,
+    GBP_KRW: (usd?.rates?.KRW && usd?.rates?.GBP) ? usd.rates.KRW/usd.rates.GBP : null,
+    HKD_KRW: (usd?.rates?.KRW && usd?.rates?.HKD) ? usd.rates.KRW/usd.rates.HKD : null,
+  };
+  return itemsFromRates(map);
+}
+
+async function exchangerateHostProvider() {
+  const usd = await get(EH_USD);
+  const jpy = await get(EH_JPY);
+  const map = {
+    USD_KRW: usd?.rates?.KRW ?? null,
+    JPY100_KRW: jpy?.rates?.KRW ? jpy.rates.KRW*100 : null,
+    EUR_KRW: (usd?.rates?.KRW && usd?.rates?.EUR) ? usd.rates.KRW/usd.rates.EUR : null,
+    CNY_KRW: (usd?.rates?.KRW && usd?.rates?.CNY) ? usd.rates.KRW/usd.rates.CNY : null,
+    GBP_KRW: (usd?.rates?.KRW && usd?.rates?.GBP) ? usd.rates.KRW/usd.rates.GBP : null,
+    HKD_KRW: (usd?.rates?.KRW && usd?.rates?.HKD) ? usd.rates.KRW/usd.rates.HKD : null,
+  };
+  return itemsFromRates(map);
+}
+
+async function main(){
+  await fs.mkdir(path.dirname(OUT), { recursive:true });
+
+  let items = null;
+  const providers = [yahooProvider, frankfurterProvider, exchangerateHostProvider];
+  for (const p of providers) {
+    try { items = await p(); if (items.some(x=>typeof x.krw==='number')) break; } catch {}
+  }
+
+  if (!items) {
+    if (existsSync(OUT)) { console.warn('FX: all providers failed; keeping previous file'); return; }
+    items = itemsFromRates({}); // all nulls
+  }
+
+  const out = { lastUpdated: nowKSTISO(), items };
+  await fs.writeFile(OUT, JSON.stringify(out, null, 2));
+  console.log(`FX: wrote ${OUT} at ${out.lastUpdated}`);
+}
+
+main().catch(e=>{ console.error(e); process.exit(1); });
+

--- a/fetchStockInfo.js
+++ b/fetchStockInfo.js
@@ -255,7 +255,17 @@ async function yahooProfileEmbeddedSector(symbol) {
   let data;
   try { data = JSON.parse(jsonStr); }
   catch { throw new Error('root.App.main JSON parse error'); }
-  const sector = data?.context?.dispatcher?.stores?.QuoteSummaryStore?.assetProfile?.sector ?? null;
+  function findSector(obj) {
+    if (!obj || typeof obj !== 'object') return null;
+    if (typeof obj.sector === 'string') return obj.sector;
+    if (obj.assetProfile && typeof obj.assetProfile.sector === 'string') return obj.assetProfile.sector;
+    for (const v of Object.values(obj)) {
+      const found = findSector(v);
+      if (found) return found;
+    }
+    return null;
+  }
+  const sector = findSector(data);
   if (!sector) throw new Error('no sector in embedded JSON');
   return sector;
 }
@@ -345,8 +355,7 @@ async function fetchSectorByTicker(ticker, cache) {
 async function fetchSector(name, cache) {
   const ticker = await resolveTicker(name, cache);
   const sector = await fetchSectorByTicker(ticker, cache);
-  if (!sector) throw new Error(`Sector not found for ${name} (${ticker})`);
-  return sector;
+  return { sector, ticker };
 }
 
 // -------- Utility --------
@@ -407,9 +416,14 @@ async function tryFetchAndEnrich() {
         const prevSector = typeof entry === 'object' ? entry.sector ?? null : null;
 
         try {
-          const sector = await fetchSector(name, cache);
-          updated.push({ name, sector: sector ?? prevSector ?? null });
-          successCount++;
+          const { sector } = await fetchSector(name, cache);
+          if (!sector) {
+            console.warn(`[WARN] ${name}: sector not resolved`);
+            updated.push({ name, sector: prevSector ?? null });
+          } else {
+            updated.push({ name, sector });
+            successCount++;
+          }
         } catch (err) {
           console.error(`[WARN] ${name}: ${err.message}`);
           updated.push({ name, sector: prevSector ?? null });
@@ -428,7 +442,7 @@ async function tryFetchAndEnrich() {
     console.warn('[WARN] No sectors fetched');
   }
 
-  return data;
+  return { data, successCount };
 }
 
 async function main() {
@@ -445,12 +459,13 @@ async function main() {
   // Stale or forced: try heavy fetch/enrich
   let base = null;
   try {
-    base = await tryFetchAndEnrich(); // returns full recommendations object WITHOUT lastUpdated
-    const out = { ...base, lastUpdated: nowKSTISO() };
+    const { data, successCount } = await tryFetchAndEnrich();
+    if (successCount === 0) throw new Error('no sectors fetched');
+    const out = { ...data, lastUpdated: nowKSTISO() };
     await fs.writeFile(OUT_FILE, JSON.stringify(out, null, 2));
     console.log(`[FETCH] success at ${out.lastUpdated}`);
   } catch (e) {
-    console.warn('[FETCH] failed, using rotation fallback:', e?.message || e);
+    console.warn('[FETCH] failed or insufficient data, using rotation fallback:', e?.message || e);
     // Load previous if exists to preserve structure; else start empty
     let prev = null;
     try { prev = JSON.parse(await fs.readFile(OUT_FILE, 'utf8')); } catch {}


### PR DESCRIPTION
## Summary
- replace FX script with server-side chain (Yahoo -> Frankfurter -> exchangerate.host) writing data/fx_rates.json
- harden fetchStockInfo sector lookup using recursive Yahoo profile parsing, multi-provider fallbacks, and graceful rotation fallback

## Testing
- `node fetchFxRates.js`
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_689d645cb928832ab37b30e10aa3a349