### PR TITLE
feat: speed up fx ticker

### DIFF
--- a/src/template.html
+++ b/src/template.html
@@ -26,33 +26,38 @@
     }
   </style>
   <style>
-  /* FX ticker (black background, yellow text, fully visible) */
-  .fx-ticker {
-    position: relative;
+  /* FX ticker (seamless twin-tracks, bold, compact) */
+  .fx-ticker{
+    position: relative;           /* or fixed if you already use fixed */
+    /* if you use fixed, keep: bottom: 8px; left: 0; width: 100%; */
     overflow: hidden;
     white-space: nowrap;
-    background: #000;
-    color: #ffeb3b;
-    /* extra vertical padding so text isn't cut */
-    padding: 0.8rem 0 1.2rem;
-    /* gap below ticker so it’s not flush with the bottom */
-    margin-bottom: 18px;
-    font-size: 1rem;
-    line-height: 1.8;
+    background:#000;
+    color:#ffd400;                /* yellow */
+    font-weight:700;              /* bold text */
+    font-size:0.95rem;
+    line-height:1.35;             /* taller line to avoid clipping */
+    padding:6px 0;                /* reduced top/bottom space */
+    border-top:1px solid rgba(255,255,255,.08);
+    -webkit-font-smoothing:antialiased;
   }
-  .fx-track {
-    position: absolute;
-    top: 0;
-    left: 0;
-    white-space: nowrap;
-    will-change: transform;
+  .fx-track{
+    position:absolute;
+    top:0;
+    left:0;
+    white-space:nowrap;
+    will-change:transform;
+    display:inline-block;
   }
-  .fx-item { margin: 0 .75rem; }
-  .fx-time { opacity: .85; margin-left: 1rem; font-size: .9em; }
-  /* distance is controlled by --fx-distance set from JS */
-  @keyframes fx-left {
-    from { transform: translateX(0); }
-    to   { transform: translateX(calc(-1 * var(--fx-distance, 100%))); }
+  .fx-track.b{ left:100%; }
+  .fx-item{ margin:0 .6rem; }     /* slightly tighter spacing */
+  .fx-time{ opacity:.7; margin-left:.75rem; font-size:.9em; }
+  @keyframes fx-left{
+    from{ transform:translateX(0); }
+    to  { transform:translateX(-100%); }
+  }
+  @media (prefers-reduced-motion: reduce){
+    .fx-track{ animation:none !important; }
   }
   </style>
 </head>
@@ -521,9 +526,9 @@
   </div>
   <div id="visitCounts" style="text-align:center;margin-top:20px;font-size:0.8rem;color:#64748b;"></div>
   <!-- FX ticker (below view count) -->
-  <div id="fx-ticker" class="fx-ticker" aria-live="polite" style="min-height: 2.2em;">
-    <div id="fx-a" class="fx-track"></div>
-    <div id="fx-b" class="fx-track" aria-hidden="true"></div>
+  <div id="fx-ticker" class="fx-ticker" aria-live="polite">
+    <div id="fx-a" class="fx-track a"></div>
+    <div id="fx-b" class="fx-track b" aria-hidden="true"></div>
   </div>
   <script>
     (async function() {
@@ -566,38 +571,22 @@ document.addEventListener('DOMContentLoaded', async function () {
     const stampText = stampRaw ? new Date(stampRaw).toLocaleString('ko-KR') : '';
     const stamp = stampText ? `<span class="fx-time">업데이트 ${stampText}</span>` : '';
 
-    // a visible spacer between loops, plus an extra fixed-width gap
-    const dotGap = '<span class="fx-item" aria-hidden="true">•</span>';
-    const gapPx = 120; // <— tune this to make the “space before repeat” bigger/smaller
-    const gapSpan = `<span class="fx-item" aria-hidden="true" style="display:inline-block;width:${gapPx}px"></span>`;
-
-    const line = parts.join(' • ') + dotGap + stamp + gapSpan;
+    // build one line with a compact spacer and timestamp
+    const gap = '<span class="fx-item" aria-hidden="true">•</span>';
+    const line = parts.join(' • ') + gap + stamp;
 
     a.innerHTML = line;
     b.innerHTML = line;
 
-    // let layout settle, then measure
-    await new Promise(requestAnimationFrame);
-    await new Promise(requestAnimationFrame);
+    // compute duration based on content width (pixels per second)
+    await Promise.resolve(); // allow layout
+    const pxPerSec = 200;                  // faster scroll (increase = faster)
+    const w = a.scrollWidth;
+    const dur = Math.max(8, Math.round(w / pxPerSec));
 
-    const contentWidth = a.scrollWidth;     // width of one full line
-    const distance = contentWidth + gapPx;  // animate across content + gap
-    const dur = 120;                        // seconds per full loop
-
-    // position tracks: B starts immediately to the right of A (with the same gap)
-    a.style.left = '0px';
-    b.style.left = distance + 'px';
-
-    // set CSS distance so keyframes use the exact pixels
-    a.style.setProperty('--fx-distance', distance + 'px');
-    b.style.setProperty('--fx-distance', distance + 'px');
-
-    const anim = `fx-left ${dur}s linear infinite`;
-    a.style.animation = anim;
-    b.style.animation = anim;
-
-    // offset B by half cycle so the stream is seamless
-    b.style.animationDelay = (dur / 2) + 's';
+    // start animations (leave as-is otherwise)
+    a.style.animation = `fx-left ${dur}s linear infinite`;
+    b.style.animation = `fx-left ${dur}s linear infinite`;
   } catch (e) {
     console.warn('FX load error:', e);
     if (a) a.textContent = '환율 정보를 불러올 수 없습니다';

--- a/stocks.html
+++ b/stocks.html
@@ -26,33 +26,38 @@
     }
   </style>
   <style>
-  /* FX ticker (black background, yellow text, fully visible) */
-  .fx-ticker {
-    position: relative;
+  /* FX ticker (seamless twin-tracks, bold, compact) */
+  .fx-ticker{
+    position: relative;           /* or fixed if you already use fixed */
+    /* if you use fixed, keep: bottom: 8px; left: 0; width: 100%; */
     overflow: hidden;
     white-space: nowrap;
-    background: #000;
-    color: #ffeb3b;
-    /* extra vertical padding so text isn't cut */
-    padding: 0.8rem 0 1.2rem;
-    /* gap below ticker so it’s not flush with the bottom */
-    margin-bottom: 18px;
-    font-size: 1rem;
-    line-height: 1.8;
+    background:#000;
+    color:#ffd400;                /* yellow */
+    font-weight:700;              /* bold text */
+    font-size:0.95rem;
+    line-height:1.35;             /* taller line to avoid clipping */
+    padding:6px 0;                /* reduced top/bottom space */
+    border-top:1px solid rgba(255,255,255,.08);
+    -webkit-font-smoothing:antialiased;
   }
-  .fx-track {
-    position: absolute;
-    top: 0;
-    left: 0;
-    white-space: nowrap;
-    will-change: transform;
+  .fx-track{
+    position:absolute;
+    top:0;
+    left:0;
+    white-space:nowrap;
+    will-change:transform;
+    display:inline-block;
   }
-  .fx-item { margin: 0 .75rem; }
-  .fx-time { opacity: .85; margin-left: 1rem; font-size: .9em; }
-  /* distance is controlled by --fx-distance set from JS */
-  @keyframes fx-left {
-    from { transform: translateX(0); }
-    to   { transform: translateX(calc(-1 * var(--fx-distance, 100%))); }
+  .fx-track.b{ left:100%; }
+  .fx-item{ margin:0 .6rem; }     /* slightly tighter spacing */
+  .fx-time{ opacity:.7; margin-left:.75rem; font-size:.9em; }
+  @keyframes fx-left{
+    from{ transform:translateX(0); }
+    to  { transform:translateX(-100%); }
+  }
+  @media (prefers-reduced-motion: reduce){
+    .fx-track{ animation:none !important; }
   }
   </style>
 </head>
@@ -528,9 +533,9 @@
   </div>
   <div id="visitCounts" style="text-align:center;margin-top:20px;font-size:0.8rem;color:#64748b;"></div>
   <!-- FX ticker (below view count) -->
-  <div id="fx-ticker" class="fx-ticker" aria-live="polite" style="min-height: 2.2em;">
-    <div id="fx-a" class="fx-track"></div>
-    <div id="fx-b" class="fx-track" aria-hidden="true"></div>
+  <div id="fx-ticker" class="fx-ticker" aria-live="polite">
+    <div id="fx-a" class="fx-track a"></div>
+    <div id="fx-b" class="fx-track b" aria-hidden="true"></div>
   </div>
   <script>
     (async function() {
@@ -573,38 +578,22 @@ document.addEventListener('DOMContentLoaded', async function () {
     const stampText = stampRaw ? new Date(stampRaw).toLocaleString('ko-KR') : '';
     const stamp = stampText ? `<span class="fx-time">업데이트 ${stampText}</span>` : '';
 
-    // a visible spacer between loops, plus an extra fixed-width gap
-    const dotGap = '<span class="fx-item" aria-hidden="true">•</span>';
-    const gapPx = 120; // <— tune this to make the “space before repeat” bigger/smaller
-    const gapSpan = `<span class="fx-item" aria-hidden="true" style="display:inline-block;width:${gapPx}px"></span>`;
-
-    const line = parts.join(' • ') + dotGap + stamp + gapSpan;
+    // build one line with a compact spacer and timestamp
+    const gap = '<span class="fx-item" aria-hidden="true">•</span>';
+    const line = parts.join(' • ') + gap + stamp;
 
     a.innerHTML = line;
     b.innerHTML = line;
 
-    // let layout settle, then measure
-    await new Promise(requestAnimationFrame);
-    await new Promise(requestAnimationFrame);
+    // compute duration based on content width (pixels per second)
+    await Promise.resolve(); // allow layout
+    const pxPerSec = 200;                  // faster scroll (increase = faster)
+    const w = a.scrollWidth;
+    const dur = Math.max(8, Math.round(w / pxPerSec));
 
-    const contentWidth = a.scrollWidth;     // width of one full line
-    const distance = contentWidth + gapPx;  // animate across content + gap
-    const dur = 120;                        // seconds per full loop
-
-    // position tracks: B starts immediately to the right of A (with the same gap)
-    a.style.left = '0px';
-    b.style.left = distance + 'px';
-
-    // set CSS distance so keyframes use the exact pixels
-    a.style.setProperty('--fx-distance', distance + 'px');
-    b.style.setProperty('--fx-distance', distance + 'px');
-
-    const anim = `fx-left ${dur}s linear infinite`;
-    a.style.animation = anim;
-    b.style.animation = anim;
-
-    // offset B by half cycle so the stream is seamless
-    b.style.animationDelay = (dur / 2) + 's';
+    // start animations (leave as-is otherwise)
+    a.style.animation = `fx-left ${dur}s linear infinite`;
+    b.style.animation = `fx-left ${dur}s linear infinite`;
   } catch (e) {
     console.warn('FX load error:', e);
     if (a) a.textContent = '환율 정보를 불러올 수 없습니다';


### PR DESCRIPTION
## Summary
- replace FX ticker CSS with compact bold twin-track style
- reduce FX ticker gap and accelerate scroll speed to 200px/s

## Testing
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_689d9ccee740832abab255e00f3a75e6