### PR TITLE
Improve FX ticker styling and speed

### DIFF
--- a/src/template.html
+++ b/src/template.html
@@ -31,18 +31,18 @@
     color: yellow;
     font-weight: bold;
     font-size: 1.3em;
-    padding: 8px 0;
+    height: 1.8em;
+    line-height: 1.8em;
     overflow: hidden;
     position: relative;
-    height: 2em;
-    line-height: calc(2em - 16px);
     box-sizing: border-box;
   }
   .fx-ticker .fx-track {
     display: inline-block;
     white-space: nowrap;
     padding-left: 100%;
-    animation: ticker-loop 100s linear infinite;
+    line-height: inherit;
+    animation: ticker-loop 80s linear infinite;
   }
   .fx-item { margin: 0 .6rem; }
   .fx-time { opacity: .75; margin-left: .85rem; font-size: .9em; }
@@ -553,7 +553,7 @@
         line.style.animation = 'none';
         afterFonts.then(() => {
           void line.offsetWidth;
-          line.style.animation = 'ticker-loop 100s linear infinite';
+          line.style.animation = 'ticker-loop 80s linear infinite';
         });
       });
   }

--- a/stocks.html
+++ b/stocks.html
@@ -31,18 +31,18 @@
     color: yellow;
     font-weight: bold;
     font-size: 1.3em;
-    padding: 8px 0;
+    height: 1.8em;
+    line-height: 1.8em;
     overflow: hidden;
     position: relative;
-    height: 2em;
-    line-height: calc(2em - 16px);
     box-sizing: border-box;
   }
   .fx-ticker .fx-track {
     display: inline-block;
     white-space: nowrap;
     padding-left: 100%;
-    animation: ticker-loop 100s linear infinite;
+    line-height: inherit;
+    animation: ticker-loop 80s linear infinite;
   }
   .fx-item { margin: 0 .6rem; }
   .fx-time { opacity: .75; margin-left: .85rem; font-size: .9em; }
@@ -560,7 +560,7 @@
         line.style.animation = 'none';
         afterFonts.then(() => {
           void line.offsetWidth;
-          line.style.animation = 'ticker-loop 100s linear infinite';
+          line.style.animation = 'ticker-loop 80s linear infinite';
         });
       });
   }


### PR DESCRIPTION
## Summary
- refine FX ticker banner to 1.8em height with matching line-height for centered text
- speed up FX ticker scroll animation to 80s and keep single-line looping

## Testing
- `node src/build.js`
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_689dc0427078832ab8b9623c92d19018