### PR TITLE
Use transparent return icon for home links

### DIFF
--- a/appdownload.html
+++ b/appdownload.html
@@ -34,24 +34,22 @@
             transform: scale(1.05);
         }
         .home-button {
-            position: fixed;
-            top: 10px;
-            left: 10px;
-            background-color: #4CAF50;
-            color: #fff;
-            padding: 8px 12px;
-            border-radius: 4px;
-            text-decoration: none;
-            font-weight: bold;
-            z-index: 1000;
-        }
-        .home-button:hover {
-            background-color: #45a049;
-        }
+      position: fixed;
+      top: 10px;
+      left: 10px;
+      text-decoration: none;
+      font-size: 24px;
+      color: #000;
+      opacity: 0.6;
+      z-index: 1000;
+    }
+    .home-button:hover {
+      opacity: 1;
+    }
     </style>
 </head>
 <body>
-    <a href="index.html" class="home-button">Home</a>
+    <a href="index.html" class="home-button" aria-label="Home">&#x21A9;</a>
     <h1>Manage Students App</h1>
     <p>Download our app from your device's app store</p>
     <p>플레이스토어 또는 앱스토어에서 다운로드하세요.</p>

--- a/appdownloadGS.html
+++ b/appdownloadGS.html
@@ -34,24 +34,22 @@
             transform: scale(1.05);
         }
         .home-button {
-            position: fixed;
-            top: 10px;
-            left: 10px;
-            background-color: #4CAF50;
-            color: #fff;
-            padding: 8px 12px;
-            border-radius: 4px;
-            text-decoration: none;
-            font-weight: bold;
-            z-index: 1000;
-        }
-        .home-button:hover {
-            background-color: #45a049;
-        }
+      position: fixed;
+      top: 10px;
+      left: 10px;
+      text-decoration: none;
+      font-size: 24px;
+      color: #000;
+      opacity: 0.6;
+      z-index: 1000;
+    }
+    .home-button:hover {
+      opacity: 1;
+    }
     </style>
 </head>
 <body>
-    <a href="index.html" class="home-button">Home</a>
+    <a href="index.html" class="home-button" aria-label="Home">&#x21A9;</a>
     <h1>Gridlock Shooter</h1>
     <p>Download our app from your device's app store</p>
     <p>플레이스토어 또는 앱스토어에서 다운로드하세요.</p>

--- a/appdownloadLFE.html
+++ b/appdownloadLFE.html
@@ -34,24 +34,22 @@
             transform: scale(1.05);
         }
         .home-button {
-            position: fixed;
-            top: 10px;
-            left: 10px;
-            background-color: #4CAF50;
-            color: #fff;
-            padding: 8px 12px;
-            border-radius: 4px;
-            text-decoration: none;
-            font-weight: bold;
-            z-index: 1000;
-        }
-        .home-button:hover {
-            background-color: #45a049;
-        }
+      position: fixed;
+      top: 10px;
+      left: 10px;
+      text-decoration: none;
+      font-size: 24px;
+      color: #000;
+      opacity: 0.6;
+      z-index: 1000;
+    }
+    .home-button:hover {
+      opacity: 1;
+    }
     </style>
 </head>
 <body>
-    <a href="index.html" class="home-button">Home</a>
+    <a href="index.html" class="home-button" aria-label="Home">&#x21A9;</a>
     <h1>Log for Everything</h1>
     <p>Download our app from your device's app store</p>
     <p>플레이스토어 또는 앱스토어에서 다운로드하세요.</p>

--- a/cardbenefitapp.html
+++ b/cardbenefitapp.html
@@ -10,24 +10,22 @@
     <link href="https://cdnjs.cloudflare.com/ajax/libs/tailwindcss/2.2.19/tailwind.min.css" rel="stylesheet">
     <style>
         .home-button {
-            position: fixed;
-            top: 10px;
-            left: 10px;
-            background-color: #4CAF50;
-            color: #fff;
-            padding: 8px 12px;
-            border-radius: 4px;
-            text-decoration: none;
-            font-weight: bold;
-            z-index: 1000;
-        }
-        .home-button:hover {
-            background-color: #45a049;
-        }
+      position: fixed;
+      top: 10px;
+      left: 10px;
+      text-decoration: none;
+      font-size: 24px;
+      color: #000;
+      opacity: 0.6;
+      z-index: 1000;
+    }
+    .home-button:hover {
+      opacity: 1;
+    }
     </style>
 </head>
 <body class="bg-gray-100 font-sans leading-normal tracking-normal">
-    <a href="index.html" class="home-button">Home</a>
+    <a href="index.html" class="home-button" aria-label="Home">&#x21A9;</a>
     <div class="container mx-auto p-8">
         <header class="mb-8">
             <h1 class="text-4xl font-bold text-gray-800 mb-2">Privacy Policy</h1>

--- a/logforeverything.html
+++ b/logforeverything.html
@@ -11,24 +11,22 @@
     <link href="https://cdnjs.cloudflare.com/ajax/libs/tailwindcss/2.2.19/tailwind.min.css" rel="stylesheet">
     <style>
         .home-button {
-            position: fixed;
-            top: 10px;
-            left: 10px;
-            background-color: #4CAF50;
-            color: #fff;
-            padding: 8px 12px;
-            border-radius: 4px;
-            text-decoration: none;
-            font-weight: bold;
-            z-index: 1000;
-        }
-        .home-button:hover {
-            background-color: #45a049;
-        }
+      position: fixed;
+      top: 10px;
+      left: 10px;
+      text-decoration: none;
+      font-size: 24px;
+      color: #000;
+      opacity: 0.6;
+      z-index: 1000;
+    }
+    .home-button:hover {
+      opacity: 1;
+    }
     </style>
 </head>
 <body class="bg-gray-100 font-sans leading-normal tracking-normal">
-    <a href="index.html" class="home-button">Home</a>
+    <a href="index.html" class="home-button" aria-label="Home">&#x21A9;</a>
     <div class="container mx-auto p-8">
         <header class="mb-8">
             <h1 class="text-4xl font-bold text-gray-800 mb-2">Privacy Policy</h1>

--- a/privacy_policy.html
+++ b/privacy_policy.html
@@ -21,24 +21,22 @@
             background-color: #f9f9f9;
         }
         .home-button {
-            position: fixed;
-            top: 10px;
-            left: 10px;
-            background-color: #4CAF50;
-            color: #fff;
-            padding: 8px 12px;
-            border-radius: 4px;
-            text-decoration: none;
-            font-weight: bold;
-            z-index: 1000;
-        }
-        .home-button:hover {
-            background-color: #45a049;
-        }
+      position: fixed;
+      top: 10px;
+      left: 10px;
+      text-decoration: none;
+      font-size: 24px;
+      color: #000;
+      opacity: 0.6;
+      z-index: 1000;
+    }
+    .home-button:hover {
+      opacity: 1;
+    }
     </style>
 </head>
 <body>
-    <a href="index.html" class="home-button">Home</a>
+    <a href="index.html" class="home-button" aria-label="Home">&#x21A9;</a>
     <header>
         <h1>SingaseongApp 개인정보 처리방침</h1>
     </header>

--- a/privacy_policy_gs.html
+++ b/privacy_policy_gs.html
@@ -10,24 +10,22 @@
     <link href="https://cdnjs.cloudflare.com/ajax/libs/tailwindcss/2.2.19/tailwind.min.css" rel="stylesheet">
     <style>
         .home-button {
-            position: fixed;
-            top: 10px;
-            left: 10px;
-            background-color: #4CAF50;
-            color: #fff;
-            padding: 8px 12px;
-            border-radius: 4px;
-            text-decoration: none;
-            font-weight: bold;
-            z-index: 1000;
-        }
-        .home-button:hover {
-            background-color: #45a049;
-        }
+      position: fixed;
+      top: 10px;
+      left: 10px;
+      text-decoration: none;
+      font-size: 24px;
+      color: #000;
+      opacity: 0.6;
+      z-index: 1000;
+    }
+    .home-button:hover {
+      opacity: 1;
+    }
     </style>
 </head>
 <body class="bg-gray-100 font-sans leading-normal tracking-normal">
-    <a href="index.html" class="home-button">Home</a>
+    <a href="index.html" class="home-button" aria-label="Home">&#x21A9;</a>
     <div class="container mx-auto p-8">
         <header class="mb-8">
             <h1 class="text-4xl font-bold text-gray-800 mb-2">Privacy Policy</h1>

--- a/privacy_policy_ms.html
+++ b/privacy_policy_ms.html
@@ -10,24 +10,22 @@
     <link href="https://cdnjs.cloudflare.com/ajax/libs/tailwindcss/2.2.19/tailwind.min.css" rel="stylesheet">
     <style>
         .home-button {
-            position: fixed;
-            top: 10px;
-            left: 10px;
-            background-color: #4CAF50;
-            color: #fff;
-            padding: 8px 12px;
-            border-radius: 4px;
-            text-decoration: none;
-            font-weight: bold;
-            z-index: 1000;
-        }
-        .home-button:hover {
-            background-color: #45a049;
-        }
+      position: fixed;
+      top: 10px;
+      left: 10px;
+      text-decoration: none;
+      font-size: 24px;
+      color: #000;
+      opacity: 0.6;
+      z-index: 1000;
+    }
+    .home-button:hover {
+      opacity: 1;
+    }
     </style>
 </head>
 <body class="bg-gray-100 font-sans leading-normal tracking-normal">
-    <a href="index.html" class="home-button">Home</a>
+    <a href="index.html" class="home-button" aria-label="Home">&#x21A9;</a>
     <div class="container mx-auto p-8">
         <header class="mb-8">
             <h1 class="text-4xl font-bold text-gray-800 mb-2">Privacy Policy</h1>

--- a/privacy_policy_ms_kr.html
+++ b/privacy_policy_ms_kr.html
@@ -10,24 +10,22 @@
     <link href="https://cdnjs.cloudflare.com/ajax/libs/tailwindcss/2.2.19/tailwind.min.css" rel="stylesheet">
     <style>
         .home-button {
-            position: fixed;
-            top: 10px;
-            left: 10px;
-            background-color: #4CAF50;
-            color: #fff;
-            padding: 8px 12px;
-            border-radius: 4px;
-            text-decoration: none;
-            font-weight: bold;
-            z-index: 1000;
-        }
-        .home-button:hover {
-            background-color: #45a049;
-        }
+      position: fixed;
+      top: 10px;
+      left: 10px;
+      text-decoration: none;
+      font-size: 24px;
+      color: #000;
+      opacity: 0.6;
+      z-index: 1000;
+    }
+    .home-button:hover {
+      opacity: 1;
+    }
     </style>
 </head>
 <body class="bg-gray-100 font-sans leading-normal tracking-normal">
-    <a href="index.html" class="home-button">Home</a>
+    <a href="index.html" class="home-button" aria-label="Home">&#x21A9;</a>
     <div class="container mx-auto p-8">
         <header class="mb-8">
             <h1 class="text-4xl font-bold text-gray-800 mb-2">개인정보처리방침</h1>

--- a/seongsigan/dongsin1-2.html
+++ b/seongsigan/dongsin1-2.html
@@ -72,21 +72,19 @@
       position: fixed;
       top: 10px;
       left: 10px;
-      background-color: #4CAF50;
-      color: #fff;
-      padding: 8px 12px;
-      border-radius: 4px;
       text-decoration: none;
-      font-weight: bold;
+      font-size: 24px;
+      color: #000;
+      opacity: 0.6;
       z-index: 1000;
     }
     .home-button:hover {
-      background-color: #45a049;
+      opacity: 1;
     }
   </style>
 </head>
 <body>
-  <a href="../index.html" class="home-button">Home</a>
+  <a href="../index.html" class="home-button" aria-label="Home">&#x21A9;</a>
   <h2>1-2반 2학기 시간표</h2>
   <table>
     <thead>

--- a/seongsigan/readme.html
+++ b/seongsigan/readme.html
@@ -36,21 +36,19 @@
       position: fixed;
       top: 10px;
       left: 10px;
-      background-color: #4CAF50;
-      color: #fff;
-      padding: 8px 12px;
-      border-radius: 4px;
       text-decoration: none;
-      font-weight: bold;
+      font-size: 24px;
+      color: #000;
+      opacity: 0.6;
       z-index: 1000;
     }
     .home-button:hover {
-      background-color: #45a049;
+      opacity: 1;
     }
   </style>
 </head>
 <body>
-  <a href="../index.html" class="home-button">Home</a>
+  <a href="../index.html" class="home-button" aria-label="Home">&#x21A9;</a>
   <header>
     <h1>SeongSigan Demo - 프로젝트 개요</h1>
   </header>

--- a/seongsigan/seongsigan.html
+++ b/seongsigan/seongsigan.html
@@ -15,21 +15,19 @@
       position: fixed;
       top: 10px;
       left: 10px;
-      background-color: #4CAF50;
-      color: #fff;
-      padding: 8px 12px;
-      border-radius: 4px;
       text-decoration: none;
-      font-weight: bold;
+      font-size: 24px;
+      color: #000;
+      opacity: 0.6;
       z-index: 1000;
     }
     .home-button:hover {
-      background-color: #45a049;
+      opacity: 1;
     }
   </style>
 </head>
 <body>
-  <a href="../index.html" class="home-button">Home</a>
+  <a href="../index.html" class="home-button" aria-label="Home">&#x21A9;</a>
   <header class="app-bar">
     <h1 class="logo">SeongSigan <span id="backendStatus" class="status" aria-label="백엔드 상태" title="Backend status"></span></h1>
     <select id="teacherSelect" aria-label="선생님 선택"></select>

--- a/src/template.html
+++ b/src/template.html
@@ -13,16 +13,14 @@
       position: fixed;
       top: 10px;
       left: 10px;
-      background-color: #4CAF50;
-      color: #fff;
-      padding: 8px 12px;
-      border-radius: 4px;
       text-decoration: none;
-      font-weight: bold;
+      font-size: 24px;
+      color: #000;
+      opacity: 0.6;
       z-index: 1000;
     }
     .home-button:hover {
-      background-color: #45a049;
+      opacity: 1;
     }
   </style>
   <style>
@@ -52,7 +50,7 @@
   </style>
 </head>
 <body>
-  <a href="index.html" class="home-button">Home</a>
+  <a href="index.html" class="home-button" aria-label="Home">&#x21A9;</a>
   <h1 data-i18n="title">데일리 주식 리포트 자동화</h1>
   <p id="currentDate"><span id="datePrefix" data-i18n="today">오늘:</span> {{CURRENT_DATE}}</p>
   

--- a/stocks.html
+++ b/stocks.html
@@ -13,16 +13,14 @@
       position: fixed;
       top: 10px;
       left: 10px;
-      background-color: #4CAF50;
-      color: #fff;
-      padding: 8px 12px;
-      border-radius: 4px;
       text-decoration: none;
-      font-weight: bold;
+      font-size: 24px;
+      color: #000;
+      opacity: 0.6;
       z-index: 1000;
     }
     .home-button:hover {
-      background-color: #45a049;
+      opacity: 1;
     }
   </style>
   <style>
@@ -52,7 +50,7 @@
   </style>
 </head>
 <body>
-  <a href="index.html" class="home-button">Home</a>
+  <a href="index.html" class="home-button" aria-label="Home">&#x21A9;</a>
   <h1 data-i18n="title">데일리 주식 리포트 자동화</h1>
   <p id="currentDate"><span id="datePrefix" data-i18n="today">오늘:</span> 2025년 8월 14일</p>
   

--- a/stocks_ex.html
+++ b/stocks_ex.html
@@ -57,16 +57,14 @@
       position: fixed;
       top: 10px;
       left: 10px;
-      background-color: #4CAF50;
-      color: #fff;
-      padding: 8px 12px;
-      border-radius: 4px;
       text-decoration: none;
-      font-weight: bold;
+      font-size: 24px;
+      color: #000;
+      opacity: 0.6;
       z-index: 1000;
     }
     .home-button:hover {
-      background-color: #45a049;
+      opacity: 1;
     }
 
     /* 모바일 반응형 */
@@ -90,7 +88,7 @@
   </style>
 </head>
 <body>
-  <a href="index.html" class="home-button">Home</a>
+  <a href="index.html" class="home-button" aria-label="Home">&#x21A9;</a>
   <div class="container">
     <h1>📊 한국 시장 종목 선정 로직 상세 설명</h1>
     

--- a/voice-hotkey/index.html
+++ b/voice-hotkey/index.html
@@ -17,21 +17,19 @@
       position: fixed;
       top: 10px;
       left: 10px;
-      background-color: #4CAF50;
-      color: #fff;
-      padding: 8px 12px;
-      border-radius: 4px;
       text-decoration: none;
-      font-weight: bold;
+      font-size: 24px;
+      color: #000;
+      opacity: 0.6;
       z-index: 1000;
     }
     .home-button:hover {
-      background-color: #45a049;
+      opacity: 1;
     }
   </style>
 </head>
 <body>
-  <a href="../index.html" class="home-button">Home</a>
+  <a href="../index.html" class="home-button" aria-label="Home">&#x21A9;</a>
   <header class="top-bar">
     <div class="title-block">
       <h1>voice to keys</h1>


### PR DESCRIPTION
## Summary
- replace green "Home" buttons with a minimal return arrow icon at 40% transparency on secondary pages
- update template and rebuild stocks page to use new home icon

## Testing
- `node src/build.js`
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_689dc56fef48832a81c630ad0ca7f536