### PR TITLE
feat: load portfolio recs on client

### DIFF
--- a/src/build.js
+++ b/src/build.js
@@ -5,117 +5,29 @@ import { fileURLToPath } from 'node:url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const ROOT = path.resolve(__dirname, '..');           // repo root
+const ROOT = path.resolve(__dirname, '..');
 const TEMPLATE = path.join(ROOT, 'src', 'template.html');
-const RECS = path.join(ROOT, 'recommendations.json');
 const OUT_HTML = path.join(ROOT, 'stocks.html');
 
 function log(...a){ console.log('[build]', ...a); }
-function warn(...a){ console.warn('[build:warn]', ...a); }
 function fail(msg, err){
   console.error('[build:error]', msg);
   if (err) console.error(err.stack || err.message || err);
   process.exit(1);
 }
 
-async function readJson(fp){
-  try {
-    const raw = await fs.readFile(fp, 'utf8');
-    return JSON.parse(raw);
-  } catch (e) {
-    fail(`Unable to read/parse JSON at ${fp}`, e);
-  }
-}
-
-function normItem(it){
-  // Accept "Apple" or { name: "Apple", sector: "Tech" }
-  if (typeof it === 'string') return { name: it };
-  if (it && typeof it === 'object') {
-    const name = String(it.name ?? '').trim();
-    const sector = it.sector ? String(it.sector).trim() : '';
-    return name ? { name, sector } : null;
-  }
-  return null;
-}
-
-function normBucket(arr){
-  if (!Array.isArray(arr)) return [];
-  const out = [];
-  for (const it of arr) {
-    const n = normItem(it);
-    if (n) out.push(n);
-  }
-  return out;
-}
-
-function normalizeRecs(data){
-  if (!data || typeof data !== 'object') {
-    throw new Error('recommendations.json is not an object');
-  }
-  const result = {};
-  for (const [market, val] of Object.entries(data)) {
-    if (market === 'lastUpdated') { result.lastUpdated = val; continue; }
-    const safe = normBucket(val?.safe);
-    const aggressive = normBucket(val?.aggressive);
-    result[market] = { safe, aggressive };
-  }
-  return result;
-}
-
-function renderSections(recs, lang='ko'){
-  const label = (key)=> key === 'safe'
-    ? (lang==='ko' ? '안전주' : 'Safe Picks')
-    : (lang==='ko' ? '공격주' : 'Aggressive Picks');
-
-  const markets = Object.keys(recs).filter(k => k !== 'lastUpdated');
-  const parts = [];
-
-  for (const m of markets) {
-    const group = recs[m] || { safe: [], aggressive: [] };
-    for (const bucket of ['safe', 'aggressive']) {
-      const items = (group[bucket] || []).map(it => {
-        const sec = it.sector ? `<span class="sector">${it.sector}</span>` : '';
-        return `<li>${it.name}${sec}</li>`;
-      }).join('');
-      parts.push(
-        `<div class="portfolio-group"><h3>${m} ${label(bucket)}</h3><ul>${items}</ul></div>`
-      );
-    }
-  }
-  return parts.join('\n');
-}
-
 async function main(){
   log('Start build');
 
-  // 1) Read inputs
-  const [tpl, recsRaw] = await Promise.all([
-    fs.readFile(TEMPLATE, 'utf8').catch(e=>fail(`Cannot read template: ${TEMPLATE}`, e)),
-    readJson(RECS)
-  ]);
+  const tpl = await fs.readFile(TEMPLATE, 'utf8').catch(e=>fail(`Cannot read template: ${TEMPLATE}`, e));
 
-  // 2) Normalize recs
-  let recs;
-  try {
-    recs = normalizeRecs(recsRaw);
-  } catch (e) {
-    // Show a helpful preview
-    const preview = JSON.stringify(recsRaw, null, 2).slice(0, 600);
-    warn('Raw recommendations preview (truncated 600 chars):\n' + preview);
-    fail('Failed to normalize recommendations.json', e);
-  }
-
-  // 3) Render
   const dateStr = new Date().toLocaleDateString('ko-KR', { year:'numeric', month:'long', day:'numeric' });
-  const sections = renderSections(recs, 'ko');
+  const html = tpl.replace('{{CURRENT_DATE}}', dateStr);
 
-  let html = tpl.replace('{{CURRENT_DATE}}', dateStr);
-  html = html.replace('{{PORTFOLIO_SECTIONS}}', sections);
-
-  // 4) Write out
   await fs.writeFile(OUT_HTML, html, 'utf8').catch(e=>fail(`Cannot write ${OUT_HTML}`, e));
 
   log('Build complete →', OUT_HTML);
 }
 
 main().catch(e=>fail('Unhandled error in build', e));
+

--- a/src/template.html
+++ b/src/template.html
@@ -86,8 +86,9 @@
 
   <section id="portfolioRecommendations">
     <h2 data-i18n="portfolioRecs">포트폴리오 추천</h2>
-    {{PORTFOLIO_SECTIONS}}
+    <div id="recommendations"><p class="error" style="display:none"></p></div>
     <div id="portfolioUpdated" class="last-updated"></div>
+    <noscript>자바스크립트를 활성화하면 추천 종목이 표시됩니다.</noscript>
   </section>
   
   <script>
@@ -349,8 +350,6 @@
   }
 
     // 추천 종목 로드
-    const ENDPOINT = 'https://script.google.com/macros/s/AKfycbzgzE7psPX5rfMLsDprAy8jmYqwUphiKuzCDUc2ji3-dRKWSgIhb1O4Kgnrg7zk1FCyrA/exec';
-
     const FULL_NAME_MAP = {
       'AMD': 'Advanced Micro Devices',
       'Meta': 'Meta Platforms',
@@ -358,57 +357,29 @@
       'HMM': 'Hyundai Merchant Marine'
     };
 
-    async function loadLocalRecs() {
-      try {
-        const res = await fetch('recommendations.json');
-        if (!res.ok) throw new Error('HTTP ' + res.status);
-        return await res.json();
-      } catch (e) {
-        console.warn('Local recommendations load failed', e);
-        return null;
-      }
-    }
-
-    function mergeWithFallback(remote, local) {
-      if (!local) return remote;
-      const result = { ...remote };
-      for (const m of Object.keys(local)) {
-        if (!result[m]) result[m] = local[m];
-        else {
-          for (const bucket of ['safe', 'aggressive']) {
-            const items = result[m]?.[bucket];
-            if (!Array.isArray(items) || items.every(it => !it.name)) {
-              result[m][bucket] = local[m][bucket];
-            }
-          }
-        }
-      }
-      return result;
-    }
-
     async function fetchRecs() {
-      const local = await loadLocalRecs();
-      let data = local;
+      let data = null;
       try {
-        const url = ENDPOINT + '?_=' + Date.now();
-        const res = await fetch(url);
+        // cache-buster to avoid stale GH-Pages content
+        const res = await fetch('recommendations.json?_=' + Date.now(), { cache: 'no-store' });
         if (!res.ok) throw new Error('HTTP ' + res.status);
-        const remote = await res.json();
-        data = mergeWithFallback(remote, local);
-        console.log('Recommendations (remote):', remote);
+        data = await res.json();
       } catch (err) {
         console.error('Failed to load recommendations:', err);
       }
-      if (local) {
-        data = local;
-      }
+
+      const container = document.getElementById('recommendations');
+      if (!container) return;
+
       if (data) {
         render(data);
       } else {
-        const container = document.getElementById('recommendations');
-        if (container) {
-          container.innerHTML = `<p class="error">${translations[currentLang].recsError}</p>`;
-        }
+        const p = container.querySelector('.error') || document.createElement('p');
+        p.className = 'error';
+        p.textContent = translations[currentLang].recsError;
+        p.style.display = 'block';
+        container.innerHTML = '';
+        container.appendChild(p);
       }
     }
 

--- a/stocks.html
+++ b/stocks.html
@@ -86,15 +86,9 @@
 
   <section id="portfolioRecommendations">
     <h2 data-i18n="portfolioRecs">포트폴리오 추천</h2>
-    <div class="portfolio-group"><h3>KOSPI 안전주</h3><ul><li>현대차</li><li>SK하이닉스</li><li>삼성전자</li><li>LG화학</li><li>카카오</li></ul></div>
-<div class="portfolio-group"><h3>KOSPI 공격주</h3><ul><li>BGF리테일</li><li>한화에어로스페이스</li><li>HD현대일렉트릭</li><li>두산에너빌리티</li><li>POSCO퓨처엠</li></ul></div>
-<div class="portfolio-group"><h3>KOSDAQ 안전주</h3><ul></ul></div>
-<div class="portfolio-group"><h3>KOSDAQ 공격주</h3><ul></ul></div>
-<div class="portfolio-group"><h3>NASDAQ 안전주</h3><ul><li>Meta Platforms</li><li>Amazon</li><li>NVIDIA</li><li>Microsoft</li><li>Alphabet</li></ul></div>
-<div class="portfolio-group"><h3>NASDAQ 공격주</h3><ul><li>Super Micro Computer</li><li>Arm Holdings</li><li>Palantir</li><li>Micron Technology</li><li>UiPath</li></ul></div>
-<div class="portfolio-group"><h3>S&P 500 안전주</h3><ul><li>Coca-Cola</li><li>Johnson & Johnson</li><li>Berkshire Hathaway (B)</li><li>Procter & Gamble</li><li>Visa</li></ul></div>
-<div class="portfolio-group"><h3>S&P 500 공격주</h3><ul><li>Uber Technologies</li><li>Eli Lilly</li><li>CrowdStrike</li><li>NRG Energy</li><li>ServiceNow</li></ul></div>
+    <div id="recommendations"><p class="error" style="display:none"></p></div>
     <div id="portfolioUpdated" class="last-updated"></div>
+    <noscript>자바스크립트를 활성화하면 추천 종목이 표시됩니다.</noscript>
   </section>
   
   <script>
@@ -356,8 +350,6 @@
   }
 
     // 추천 종목 로드
-    const ENDPOINT = 'https://script.google.com/macros/s/AKfycbzgzE7psPX5rfMLsDprAy8jmYqwUphiKuzCDUc2ji3-dRKWSgIhb1O4Kgnrg7zk1FCyrA/exec';
-
     const FULL_NAME_MAP = {
       'AMD': 'Advanced Micro Devices',
       'Meta': 'Meta Platforms',
@@ -365,57 +357,29 @@
       'HMM': 'Hyundai Merchant Marine'
     };
 
-    async function loadLocalRecs() {
-      try {
-        const res = await fetch('recommendations.json');
-        if (!res.ok) throw new Error('HTTP ' + res.status);
-        return await res.json();
-      } catch (e) {
-        console.warn('Local recommendations load failed', e);
-        return null;
-      }
-    }
-
-    function mergeWithFallback(remote, local) {
-      if (!local) return remote;
-      const result = { ...remote };
-      for (const m of Object.keys(local)) {
-        if (!result[m]) result[m] = local[m];
-        else {
-          for (const bucket of ['safe', 'aggressive']) {
-            const items = result[m]?.[bucket];
-            if (!Array.isArray(items) || items.every(it => !it.name)) {
-              result[m][bucket] = local[m][bucket];
-            }
-          }
-        }
-      }
-      return result;
-    }
-
     async function fetchRecs() {
-      const local = await loadLocalRecs();
-      let data = local;
+      let data = null;
       try {
-        const url = ENDPOINT + '?_=' + Date.now();
-        const res = await fetch(url);
+        // cache-buster to avoid stale GH-Pages content
+        const res = await fetch('recommendations.json?_=' + Date.now(), { cache: 'no-store' });
         if (!res.ok) throw new Error('HTTP ' + res.status);
-        const remote = await res.json();
-        data = mergeWithFallback(remote, local);
-        console.log('Recommendations (remote):', remote);
+        data = await res.json();
       } catch (err) {
         console.error('Failed to load recommendations:', err);
       }
-      if (local) {
-        data = local;
-      }
+
+      const container = document.getElementById('recommendations');
+      if (!container) return;
+
       if (data) {
         render(data);
       } else {
-        const container = document.getElementById('recommendations');
-        if (container) {
-          container.innerHTML = `<p class="error">${translations[currentLang].recsError}</p>`;
-        }
+        const p = container.querySelector('.error') || document.createElement('p');
+        p.className = 'error';
+        p.textContent = translations[currentLang].recsError;
+        p.style.display = 'block';
+        container.innerHTML = '';
+        container.appendChild(p);
       }
     }
 


### PR DESCRIPTION
## Summary
- render stock portfolio recommendations purely on the client by fetching `recommendations.json` with cache busting and showing a fallback message when unavailable
- streamline build step to simply copy the template without injecting portfolio data

## Testing
- `node src/build.js`
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_689e037de78c832abf2b8915bf9d1b5d