### PR TITLE
Adjust fx-ticker typography

### DIFF
--- a/src/template.html
+++ b/src/template.html
@@ -28,9 +28,9 @@
     background-color: #000;
     color: yellow;
     font-weight: bold;
-    font-size: 1.3em;
+    font-size: 1.0em;
     height: 1.5em;
-    line-height: 1.5em;
+    line-height: 1.1em;
     overflow: hidden;
     position: relative;
     box-sizing: border-box;

--- a/stocks.html
+++ b/stocks.html
@@ -28,9 +28,9 @@
     background-color: #000;
     color: yellow;
     font-weight: bold;
-    font-size: 1.3em;
+    font-size: 1.0em;
     height: 1.5em;
-    line-height: 1.5em;
+    line-height: 1.1em;
     overflow: hidden;
     position: relative;
     box-sizing: border-box;


### PR DESCRIPTION
## Summary
- Set fx-ticker font size to 1.0em and line height to 1.1em in template and generated stock page.

## Testing
- `OFFLINE=1 node src/build.js`
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_689f48450384832aa07885b0f0c92a64