### PR TITLE
feat: dynamic pools and trend-based generator

### DIFF
--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -14,8 +14,8 @@ jobs:
       TZ: Asia/Seoul  # make timestamps consistent with KST
       FMP_KEY: ${{ secrets.FMP_KEY }}                 # optional
       ALPHA_VANTAGE_KEY: ${{ secrets.ALPHA_VANTAGE_KEY }}  # optional
-      FINNHUB_KEY: ${{ secrets.FINNHUB_KEY }}         # optional
-      TWELVEDATA_KEY: ${{ secrets.TWELVEDATA_KEY }}   # optional
+      FINNHUB_API_KEY: ${{ secrets.FINNHUB_API_KEY }}         # optional
+      TWELVEDATA_API_KEY: ${{ secrets.TWELVEDATA_API_KEY }}   # optional
 
     concurrency:
       group: daily-stock-report
@@ -50,6 +50,9 @@ jobs:
         shell: bash
 
       - name: Build trend-aware pools
+        env:
+          FINNHUB_API_KEY: ${{ secrets.FINNHUB_API_KEY }}
+          TWELVEDATA_API_KEY: ${{ secrets.TWELVEDATA_API_KEY }}
         run: node tools/buildPoolsTrendy.js || true
 
       - name: Build recommendations (primary path)

--- a/.github/workflows/stock-recs.yml
+++ b/.github/workflows/stock-recs.yml
@@ -31,8 +31,8 @@ jobs:
       # Optional: API keys for your other steps if you integrate them later
       FMP_KEY: ${{ secrets.FMP_KEY }}
       ALPHA_VANTAGE_KEY: ${{ secrets.ALPHA_VANTAGE_KEY }}
-      FINNHUB_KEY: ${{ secrets.FINNHUB_KEY }}
-      TWELVEDATA_KEY: ${{ secrets.TWELVEDATA_KEY }}
+      FINNHUB_API_KEY: ${{ secrets.FINNHUB_API_KEY }}
+      TWELVEDATA_API_KEY: ${{ secrets.TWELVEDATA_API_KEY }}
 
     steps:
       - name: Checkout
@@ -50,16 +50,22 @@ jobs:
       - name: Install deps
         run: npm ci
 
+      - name: Build trend-aware pools
+        env:
+          FINNHUB_API_KEY: ${{ secrets.FINNHUB_API_KEY }}
+          TWELVEDATA_API_KEY: ${{ secrets.TWELVEDATA_API_KEY }}
+        run: node tools/buildPoolsTrendy.js || true
+
       # If you're still on single-file (fetchStockInfo.js), this just works.
       # If you split into modules, it runs src/index.js instead.
       - name: Build recommendations (deadline-aware)
         run: |
           if [ -f "src/index.js" ]; then
             echo "→ Running modular entry (src/index.js)"
-            timeout 60 node src/index.js --force
+            timeout 60 node src/index.js --refresh-pools --force
           else
             echo "→ Running single-file (fetchStockInfo.js)"
-            timeout 60 node fetchStockInfo.js --force --delay=120
+            timeout 60 node fetchStockInfo.js --refresh-pools --force --delay=120
           fi
 
       # Add a validator (from earlier) at tools/validate-recs.js

--- a/feedback.json
+++ b/feedback.json
@@ -3,6 +3,6 @@
   "weights": {},
   "decay": {
     "half_life_days": 14,
-    "last_decay_ts": "2025-08-16T01:21:14.787Z"
+    "last_decay_ts": null
   }
 }

--- a/fetchStockInfo.js
+++ b/fetchStockInfo.js
@@ -1,5 +1,5 @@
 // fetchStockInfo.js — improved version with fallbacks and KOSDAQ stocks
-import fs, { writeFile, rename } from 'fs/promises';
+import fs, { writeFile, rename, readFile } from 'fs/promises';
 import { existsSync } from 'fs';
 import path from 'node:path';
 import { nowKSTISO } from './utils/time.js';
@@ -11,11 +11,10 @@ const FORCE = ARGS.has('--force');
 const SKIP_FRESH = ARGS.has('--skip-fresh');
 const DELAY_ARG = Number((process.argv.find(a => a.startsWith('--delay=')) || '').split('=')[1]);
 const CACHE_FILE = path.resolve(process.cwd(), 'ticker-cache.json');
-const POOLS_FILE = path.resolve(process.cwd(), 'pools.json');
-const POOLS_CACHE_FILE = path.resolve(process.cwd(), 'pools-cache.json');
-const DEFAULT_POOLS_TTL_HOURS = 24;
-const TTL_ARG = Number((process.argv.find(a => a.startsWith('--pools-ttl=')) || '').split('=')[1]);
-const POOLS_TTL_MS = (Number.isFinite(TTL_ARG) && TTL_ARG > 0 ? TTL_ARG : DEFAULT_POOLS_TTL_HOURS) * 60 * 60 * 1000;
+const POOLS_PATH = path.resolve(process.cwd(), 'pools.json');
+const POOLS_CACHE = path.resolve(process.cwd(), 'pools-cache.json');
+const POOLS_TTL_MS = Number(process.env.POOLS_TTL_MS || 24 * 60 * 60 * 1000); // default 24h
+const POOLS_URL = process.env.POOLS_URL || ''; // optional remote JSON endpoint
 const REFRESH_POOLS = ARGS.has('--refresh-pools');
 
 const sleep = ms => new Promise(r => setTimeout(r, ms));
@@ -88,97 +87,56 @@ function pickDeterministic(arr, k, seed) {
   return a.slice(0, k);
 }
 
-// Embedded fallback pools used when external files are unavailable
-const POOLS_FALLBACK = {
-  KOSPI: {
-    safe: ['삼성전자', 'SK하이닉스', '현대차', 'POSCO홀딩스', 'LG화학', 'NAVER', '카카오', '기아', 'LG전자', '삼성SDI'],
-    aggressive: ['HD현대일렉트릭', '두산에너빌리티', '한화에어로스페이스', 'POSCO퓨처엠', 'BGF리테일', '에코프로', '삼성바이오로직스', '셀트리온']
-  },
-  KOSDAQ: {
-    safe: ['셀트리온헬스케어', 'JYP엔터테인먼트', '펄어비스', '아이오케이', 'CJ ENM'],
-    aggressive: ['에코프로비엠', '천보', '리노공업', '알테오젠', '레인보우로보틱스', 'HLB', '지아이이노베이션', '펩트론']
-  },
-  NASDAQ: {
-    safe: ['Microsoft', 'Apple', 'NVIDIA', 'Amazon', 'Meta Platforms', 'Alphabet', 'Tesla', 'Netflix'],
-    aggressive: ['Super Micro Computer', 'Palantir', 'Arm Holdings', 'Micron Technology', 'UiPath', 'CrowdStrike', 'MongoDB', 'Snowflake']
-  },
-  'S&P 500': {
-    safe: ['Berkshire Hathaway (B)', 'Johnson & Johnson', 'Procter & Gamble', 'Visa', 'Coca-Cola', 'JPMorgan Chase', 'UnitedHealth'],
-    aggressive: ['Eli Lilly', 'Uber Technologies', 'NRG Energy', 'CrowdStrike', 'ServiceNow', 'Moderna', 'Zoom']
-  }
-};
-
-function validatePoolsSchema(pools) {
-  const markets = ['KOSPI', 'KOSDAQ', 'NASDAQ', 'S&P 500'];
-  if (typeof pools !== 'object' || pools === null) return false;
-  for (const m of markets) {
-    const b = pools[m];
-    if (!b || !Array.isArray(b.safe) || !Array.isArray(b.aggressive)) return false;
-    for (const bucket of ['safe', 'aggressive']) {
-      for (const item of b[bucket]) {
-        if (!(typeof item === 'string' || (item && typeof item === 'object'))) return false;
-      }
-    }
-  }
-  return true;
-}
-
 async function writeAtomically(dest, data) {
   const tmp = dest + '.tmp';
   await writeFile(tmp, data);
   await rename(tmp, dest);
 }
 
+async function loadJsonSafe(p) { try { return JSON.parse(await readFile(p, 'utf8')); } catch { return null; } }
+async function isFresh(p, ttlMs) { try { const s = await fs.stat(p); return (Date.now() - s.mtimeMs) < ttlMs; } catch { return false; } }
+
+function validatePoolsSchema(pools) {
+  if (!pools || typeof pools !== 'object') throw new Error('pools not object');
+  for (const [m, b] of Object.entries(pools)) {
+    if (!b || !Array.isArray(b.safe) || !Array.isArray(b.aggressive)) {
+      throw new Error(`invalid pools schema at ${m}`);
+    }
+  }
+}
+
+async function fetchPoolsRemote() {
+  if (!POOLS_URL) return null;
+  try {
+    const res = await fetchWithRetry(POOLS_URL, { headers: HEADERS_JSON });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const j = await res.json();
+    validatePoolsSchema(j);
+    await writeAtomically(POOLS_CACHE, JSON.stringify(j, null, 2));
+    return j;
+  } catch (e) {
+    console.warn('[POOLS] Remote fetch failed:', e.message);
+    return null;
+  }
+}
+
 async function loadPools() {
-  const url = process.env.POOLS_URL;
-  const now = Date.now();
-
-  if (url) {
-    let cache;
-    try {
-      cache = JSON.parse(await fs.readFile(POOLS_CACHE_FILE, 'utf8'));
-    } catch {}
-
-    const cacheFresh = cache?.fetchedAt && (now - Date.parse(cache.fetchedAt) < POOLS_TTL_MS);
-    if (REFRESH_POOLS || !cacheFresh) {
-      try {
-        const res = await fetchWithRetry(url, {}, { retries: 2, base: 500 });
-        const json = await res.json();
-        if (validatePoolsSchema(json)) {
-          await writeAtomically(POOLS_CACHE_FILE, JSON.stringify({ fetchedAt: new Date().toISOString(), pools: json }, null, 2));
-          return json;
-        } else {
-          console.warn('[POOLS] Remote schema invalid');
-        }
-      } catch (e) {
-        console.warn('[POOLS] Remote fetch failed:', e.message);
-      }
-    }
-    if (cacheFresh && validatePoolsSchema(cache.pools)) return cache.pools;
+  if (POOLS_URL && (REFRESH_POOLS || !(await isFresh(POOLS_CACHE, POOLS_TTL_MS)))) {
+    const remote = await fetchPoolsRemote();
+    if (remote) return remote;
   }
+  const cached = await loadJsonSafe(POOLS_CACHE);
+  if (cached) { try { validatePoolsSchema(cached); return cached; } catch {} }
+  const local = await loadJsonSafe(POOLS_PATH);
+  if (local) { validatePoolsSchema(local); return local; }
 
-  if (existsSync(POOLS_CACHE_FILE)) {
-    try {
-      const cache = JSON.parse(await fs.readFile(POOLS_CACHE_FILE, 'utf8'));
-      if (cache?.fetchedAt && (now - Date.parse(cache.fetchedAt) < POOLS_TTL_MS) && validatePoolsSchema(cache.pools)) {
-        return cache.pools;
-      }
-    } catch (e) {
-      console.warn('[POOLS] Failed reading cache:', e.message);
-    }
-  }
-
-  if (existsSync(POOLS_FILE)) {
-    try {
-      const local = JSON.parse(await fs.readFile(POOLS_FILE, 'utf8'));
-      if (validatePoolsSchema(local)) return local;
-    } catch (e) {
-      console.warn('[POOLS] Failed reading pools.json:', e.message);
-    }
-  }
-
-  console.warn('[POOLS] Falling back to embedded pools');
-  return POOLS_FALLBACK;
+  // Embedded last-resort fallback — (optional) keep a tiny minimal set
+  return {
+    KOSPI: { safe: ['삼성전자'], aggressive: ['POSCO퓨처엠'] },
+    KOSDAQ: { safe: ['셀트리온헬스케어'], aggressive: ['에코프로비엠'] },
+    NASDAQ: { safe: ['Apple','Microsoft'], aggressive: ['NVIDIA'] },
+    'S&P 500': { safe: ['Berkshire Hathaway (B)'], aggressive: ['Eli Lilly'] }
+  };
 }
 
 function rotateFromPools(pools, prevData) {
@@ -516,13 +474,14 @@ function validateRecommendations(out) {
 }
 
 // Main data fetching function
-async function tryFetchAndEnrich(pools) {
+async function tryFetchAndEnrich() {
+  const POOLS = await loadPools();
   const seed = new Date().toLocaleDateString('sv-SE', { timeZone: 'Asia/Seoul' });
   const data = {};
   const log = {};
 
   // Select stocks for each market
-  for (const [market, buckets] of Object.entries(pools)) {
+  for (const [market, buckets] of Object.entries(POOLS)) {
     if (!hasAnyCandidates(buckets)) continue;
 
     data[market] = {};
@@ -614,10 +573,8 @@ async function main() {
     }
   }
 
-  const pools = await loadPools();
-
   try {
-    const { data, successCount } = await tryFetchAndEnrich(pools);
+    const { data, successCount } = await tryFetchAndEnrich();
 
     const sorted = sortData(data);
     let out = { ...sorted, lastUpdated: nowKSTISO() };
@@ -636,6 +593,7 @@ async function main() {
       prev = JSON.parse(await fs.readFile(OUT_FILE, 'utf8'));
     } catch {}
 
+    const pools = await loadPools();
     const rotated = sortData(rotateFromPools(pools, prev));
     let out = { ...rotated, lastUpdated: nowKSTISO() };
     pruneEmptyMarkets(out);

--- a/tools/buildPoolsTrendy.js
+++ b/tools/buildPoolsTrendy.js
@@ -1,186 +1,274 @@
-import fs from 'fs/promises';
-import path from 'node:path';
+// tools/buildPoolsTrendy.js
+// Builds trend-aware pools using Finnhub (primary) and TwelveData (fallback for quotes).
+// Writes: pools.json (names only) and pools-metrics.json (diagnostics).
+// Safe: if no API keys or endpoints fail, it logs and leaves pools.json unchanged.
 
-export function rank01(arr) {
-  const nums = arr.filter(v => v != null);
-  const min = Math.min(...nums, 0);
-  const max = Math.max(...nums, 0);
-  return arr.map(v => {
-    if (v == null || max === min) return 0;
-    return (v - min) / (max - min);
-  });
+import fs from 'fs/promises';
+
+const FINNHUB = process.env.FINNHUB_API_KEY || '';
+const TWELVE = process.env.TWELVEDATA_API_KEY || '';
+
+const POOLS_FILE = 'pools.json';
+const METRICS_FILE = 'pools-metrics.json';
+const FEEDBACK_FILE = 'feedback.json';
+
+const MARKETS = ["KOSPI","KOSDAQ","NASDAQ","S&P 500"];
+const PICK_COUNT = 5;
+
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+async function writeAtomic(p, data) {
+  const tmp = `${p}.tmp`;
+  await fs.writeFile(tmp, data);
+  await fs.rename(tmp, p);
 }
 
-export async function getJSON(url, headers = {}, retries = 2) {
-  for (let i = 0; i <= retries; i++) {
-    try {
+async function loadJson(p, fallback=null) {
+  try { return JSON.parse(await fs.readFile(p,'utf8')); } catch { return fallback; }
+}
+
+function rank01(values) {
+  // values: array of numbers (may include null). Return normalized map of idx -> 0..1 with null -> 0.
+  const arr = values.map(v => (Number.isFinite(v) ? v : null));
+  const nums = arr.filter(v => v !== null);
+  if (nums.length === 0) return values.map(_ => 0);
+  const min = Math.min(...nums), max = Math.max(...nums);
+  if (min === max) return values.map(v => (v === null ? 0 : 0.5));
+  return arr.map(v => (v === null ? 0 : (v - min) / (max - min)));
+}
+
+function clamp01(x){ return Math.max(0, Math.min(1, x)); }
+
+function todayYMD(offsetDays=0){
+  const d = new Date(Date.now() + offsetDays*86400000);
+  return d.toISOString().slice(0,10);
+}
+
+async function getJSON(url, headers={}, retries=3, base=500) {
+  let lastErr;
+  for (let a=0; a<=retries; a++){
+    try{
       const res = await fetch(url, { headers });
-      if (res.ok) return await res.json();
-    } catch {}
-    if (i < retries) await new Promise(r => setTimeout(r, 500 * (i + 1)));
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      return await res.json();
+    }catch(e){
+      lastErr = e;
+      if (a < retries){ await sleep(base * Math.pow(2,a)); }
+    }
+  }
+  throw lastErr;
+}
+
+// ---------- Data fetchers ----------
+
+// Finnhub candles (primary for quotes/vol)
+async function finnhubCandles(symbol){
+  const to = Math.floor(Date.now()/1000);
+  const from = to - 60*60*24*40; // ~40 days
+  const url = `https://finnhub.io/api/v1/stock/candle?symbol=${encodeURIComponent(symbol)}&resolution=D&from=${from}&to=${to}&token=${FINNHUB}`;
+  const j = await getJSON(url);
+  // j: { s: 'ok', c:[], v:[], t:[] }
+  if (j?.s !== 'ok') return null;
+  return j;
+}
+
+// TwelveData time series (fallback)
+async function twelveCandles(symbol){
+  const url = `https://api.twelvedata.com/time_series?symbol=${encodeURIComponent(symbol)}&interval=1day&outputsize=40&apikey=${TWELVE}`;
+  const j = await getJSON(url);
+  const data = j?.values;
+  if (!Array.isArray(data)) return null;
+  // Normalize to { c[], v[] } descending chronological order → reverse to oldest..newest
+  const closes = [], vols = [];
+  for (let i=data.length-1; i>=0; i--){
+    closes.push(Number(data[i].close));
+    vols.push(Number(data[i].volume || 0));
+  }
+  return { c: closes, v: vols };
+}
+
+async function getCandles(symbol){
+  if (FINNHUB){
+    const j = await finnhubCandles(symbol).catch(()=>null);
+    if (j) return { c: j.c, v: j.v };
+  }
+  if (TWELVE){
+    const j = await twelveCandles(symbol).catch(()=>null);
+    if (j) return j;
   }
   return null;
 }
 
-function log(...a) { console.log('[buildPools]', ...a); }
-
-async function writeAtomically(file, data) {
-  const tmp = file + '.tmp';
-  await fs.writeFile(tmp, data);
-  await fs.rename(tmp, file);
+// Finnhub company news count (72h)
+async function finnhubNewsCount(symbol){
+  const from = todayYMD(-3), to = todayYMD(0);
+  const url = `https://finnhub.io/api/v1/company-news?symbol=${encodeURIComponent(symbol)}&from=${from}&to=${to}&token=${FINNHUB}`;
+  const arr = await getJSON(url).catch(()=>null);
+  return Array.isArray(arr) ? arr.length : 0;
 }
 
-async function readJSON(p) {
-  try { return JSON.parse(await fs.readFile(p, 'utf8')); }
-  catch { return null; }
+// Finnhub earnings window ±10d
+async function finnhubRecentEarnings(symbol){
+  const from = todayYMD(-10), to = todayYMD(+10);
+  const url = `https://finnhub.io/api/v1/calendar/earnings?from=${from}&to=${to}&symbol=${encodeURIComponent(symbol)}&token=${FINNHUB}`;
+  const j = await getJSON(url).catch(()=>null);
+  const rows = j?.earningsCalendar || [];
+  return rows.some(x => (x.symbol || x.ticker) === symbol);
 }
 
-function clamp(v, lo = 0, hi = 1) { return Math.max(lo, Math.min(hi, v)); }
+// ---------- Metrics from candles ----------
+function computeMetrics(c, v){
+  // c: closes oldest..newest, v: volumes oldest..newest
+  if (!Array.isArray(c) || c.length < 21) return { ret5: null, ret20: null, vol20: null, turnover: null };
+  const n = c.length;
+  const ret5  = (c[n-1] - c[n-6]) / c[n-6] * 100;   // %
+  const ret20 = (c[n-1] - c[n-21]) / c[n-21] * 100; // %
+  // simple volatility: stdev of last 20 daily returns
+  const rets = [];
+  for (let i=n-20; i<n; i++){
+    const r = (c[i] - c[i-1]) / c[i-1];
+    rets.push(r);
+  }
+  const mean = rets.reduce((a,b)=>a+b,0)/rets.length;
+  const variance = rets.reduce((a,b)=>a+(b-mean)*(b-mean),0)/rets.length;
+  const vol20 = Math.sqrt(variance); // daily stdev
+  // turnover proxy: avg volume last 5 relative to last 20
+  const avg = (arr, s, e)=>arr.slice(s,e).reduce((a,b)=>a+b,0)/(e-s);
+  const v5 = avg(v, n-5, n), v20 = avg(v, n-20, n);
+  const turnover = v20 ? (v5 / v20) : null;
+  return { ret5, ret20, vol20, turnover };
+}
 
-async function loadUniverse(root, poolsPath) {
-  const uni = await readJSON(path.join(root, 'universe.json'));
-  if (uni) return uni;
-  const pools = await readJSON(poolsPath);
-  if (!pools) return null;
+// ---------- Universe & name→symbol mapping ----------
+/*
+  We will reuse your existing TICKER_MAP and Yahoo resolution inside fetchStockInfo.js for KR/US names.
+  For the pool generator, we only need NAMES. fetchStockInfo.js later resolves symbols when enriching.
+  So here we operate on names, and for Finnhub/TwelveData calls we TRY simple symbol = name if it looks like a ticker,
+  else skip candle/news/earnings (metrics become null). This keeps the generator resilient.
+*/
+
+// ---------- Feedback handling ----------
+function applyFeedback(scoresByName, feedback, market){
+  const weights = feedback?.weights?.[market] || {};
   const out = {};
-  for (const [m, b] of Object.entries(pools)) {
-    out[m] = Array.from(new Set([...(b.safe || []), ...(b.aggressive || [])]));
+  for (const [name, score] of Object.entries(scoresByName)){
+    const w = Number.isFinite(weights[name]) ? weights[name] : 0;
+    out[name] = clamp01(score + w);
   }
   return out;
 }
 
-async function loadFeedback(file) {
-  const fb = await readJSON(file);
-  if (fb) return fb;
-  return { version: 1, weights: {}, decay: { half_life_days: 14, last_decay_ts: new Date().toISOString() } };
-}
-
-async function maybeDecay(feedback, file) {
-  const now = Date.now();
-  const last = Date.parse(feedback.decay.last_decay_ts || 0);
-  const hl = feedback.decay.half_life_days || 14;
-  if (now - last > hl * 86400000) {
-    for (const m of Object.keys(feedback.weights)) {
-      for (const n of Object.keys(feedback.weights[m])) {
-        feedback.weights[m][n] *= 0.5;
-        if (Math.abs(feedback.weights[m][n]) < 1e-4) delete feedback.weights[m][n];
+function maybeDecayFeedback(feedback){
+  try{
+    const half = feedback?.decay?.half_life_days ?? 14;
+    const last = feedback?.decay?.last_decay_ts ? Date.parse(feedback.decay.last_decay_ts) : 0;
+    if (Date.now() - last < half*86400000) return feedback;
+    const f2 = JSON.parse(JSON.stringify(feedback));
+    for (const m of Object.keys(f2.weights||{})){
+      for (const k of Object.keys(f2.weights[m]||{})){
+        f2.weights[m][k] = Number(f2.weights[m][k]) * 0.5;
       }
-      if (Object.keys(feedback.weights[m]).length === 0) delete feedback.weights[m];
     }
-    feedback.decay.last_decay_ts = new Date().toISOString();
-  }
-  await writeAtomically(file, JSON.stringify(feedback, null, 2));
+    f2.decay = f2.decay || {};
+    f2.decay.last_decay_ts = new Date().toISOString();
+    return f2;
+  }catch{ return feedback; }
 }
 
-async function fetchSignals(tickers, env) {
-  const out = {};
-  const news = env.NEWS_API_URL
-    ? await getJSON(`${env.NEWS_API_URL}?tickers=${tickers.join(',')}`, env.NEWS_API_KEY ? { Authorization: env.NEWS_API_KEY } : {})
-    : null;
-  const quotes = env.QUOTES_API_URL
-    ? await getJSON(`${env.QUOTES_API_URL}?tickers=${tickers.join(',')}`, env.QUOTES_API_KEY ? { Authorization: env.QUOTES_API_KEY } : {})
-    : null;
-  const earnings = env.EARNINGS_API_URL
-    ? await getJSON(`${env.EARNINGS_API_URL}?tickers=${tickers.join(',')}`, env.EARNINGS_API_KEY ? { Authorization: env.EARNINGS_API_KEY } : {})
-    : null;
-  for (const t of tickers) {
-    out[t] = {
-      news: news?.[t] ?? 0,
-      ret5: quotes?.[t]?.ret_5d ?? 0,
-      ret20: quotes?.[t]?.ret_20d ?? 0,
-      turnover: quotes?.[t]?.turnover_z ?? 0,
-      vol: quotes?.[t]?.vol_20d ?? 0,
-      earnings: Array.isArray(earnings?.recent) ? earnings.recent.includes(t) : !!earnings?.[t]
-    };
+// ---------- Main ----------
+async function main(){
+  const pools = await loadJson(POOLS_FILE);
+  if (!pools){
+    console.log('[buildPools] No pools.json; nothing to do.');
+    process.exit(0);
   }
-  return out;
-}
-
-async function main() {
-  const root = process.cwd();
-  const poolsPath = path.join(root, 'pools.json');
-  const metricsPath = path.join(root, 'pools-metrics.json');
-  const feedbackPath = path.join(root, 'feedback.json');
-
-  const env = {
-    NEWS_API_URL: process.env.NEWS_API_URL,
-    NEWS_API_KEY: process.env.NEWS_API_KEY,
-    QUOTES_API_URL: process.env.QUOTES_API_URL,
-    QUOTES_API_KEY: process.env.QUOTES_API_KEY,
-    EARNINGS_API_URL: process.env.EARNINGS_API_URL,
-    EARNINGS_API_KEY: process.env.EARNINGS_API_KEY
-  };
-
-  if (!env.NEWS_API_URL && !env.QUOTES_API_URL && !env.EARNINGS_API_URL) {
-    log('No API endpoints configured; skipping generation');
-    await writeAtomically(metricsPath, JSON.stringify({ lastRun: new Date().toISOString(), note: 'skipped' }, null, 2));
-    const fb = await loadFeedback(feedbackPath);
-    await maybeDecay(fb, feedbackPath);
-    return;
+  if (!FINNHUB && !TWELVE){
+    console.log('[buildPools] No API endpoints configured; skipping generation');
+    process.exit(0);
   }
 
-  const universe = await loadUniverse(root, poolsPath);
-  if (!universe) {
-    log('No universe available; skipping');
-    await writeAtomically(metricsPath, JSON.stringify({ lastRun: new Date().toISOString(), note: 'no universe' }, null, 2));
-    const fb = await loadFeedback(feedbackPath);
-    await maybeDecay(fb, feedbackPath);
-    return;
-  }
+  const feedback = await loadJson(FEEDBACK_FILE, { version:1, weights:{}, decay:{ half_life_days:14, last_decay_ts:null }});
+  const metricsOut = {};
 
-  const whitelist = await readJSON(path.join(root, 'whitelist.json')) || {};
-  const blacklist = await readJSON(path.join(root, 'blacklist.json')) || {};
-  const feedback = await loadFeedback(feedbackPath);
+  for (const market of MARKETS){
+    const buckets = pools[market];
+    if (!buckets) continue;
+    const names = Array.from(new Set([...(buckets.safe||[]), ...(buckets.aggressive||[])].map(x => typeof x==='string'? x : x.name).filter(Boolean)));
+    if (names.length === 0) continue;
 
-  const metrics = {};
-  const pools = {};
+    // Fetch signals per "symbol" best-effort (names may not be symbols; we compute where possible)
+    const byName = {};
+    for (const name of names){
+      // Heuristic: if looks like a symbol (e.g., MSFT, AAPL, 005930.KS) use it; else skip API metrics (nulls)
+      const looksSymbol = /^[A-Z.\-]{1,7}(\.[A-Z]{1,3})?$/.test(name) || /^\d{6}\.K[QS]$/.test(name);
+      let c=null, v=null; let ret5=null, ret20=null, vol20=null, turnover=null; let news72=0; let earn=false;
 
-  for (const [market, tickers] of Object.entries(universe)) {
-    const sig = await fetchSignals(tickers, env);
-    const news = rank01(tickers.map(t => sig[t].news));
-    const r5 = rank01(tickers.map(t => sig[t].ret5));
-    const r20 = rank01(tickers.map(t => sig[t].ret20));
-    const turnover = rank01(tickers.map(t => sig[t].turnover));
-    const vol = rank01(tickers.map(t => sig[t].vol));
+      if (looksSymbol){
+        const candles = await getCandles(name).catch(()=>null);
+        if (candles){ c=candles.c; v=candles.v; }
+        if (c && v){ const m = computeMetrics(c,v); ret5=m.ret5; ret20=m.ret20; vol20=m.vol20; turnover=m.turnover; }
+        if (FINNHUB){ news72 = await finnhubNewsCount(name).catch(()=>0); earn = await finnhubRecentEarnings(name).catch(()=>false); }
+      }
+      byName[name] = { ret5, ret20, vol20, turnover, news72, earn };
+      await sleep(120); // gentle pacing
+    }
 
-    metrics[market] = {};
-    const scored = [];
-    tickers.forEach((t, i) => {
-      let score_safe = 0.35 * news[i] + 0.35 * r20[i] + 0.20 * r5[i] + 0.10 * (1 - vol[i]);
-      let score_aggr = 0.45 * news[i] + 0.35 * r5[i] + 0.20 * turnover[i];
-      if (sig[t].earnings) { score_safe += 0.10; score_aggr += 0.10; }
-      const weight = feedback.weights?.[market]?.[t] ?? 0;
-      score_safe = clamp(score_safe + weight);
-      score_aggr = clamp(score_aggr + weight);
-      metrics[market][t] = {
-        news: news[i], ret5: r5[i], ret20: r20[i], turnover: turnover[i], vol: vol[i], earnings: !!sig[t].earnings,
-        score_safe, score_aggr
-      };
-      scored.push({ t, score_safe, score_aggr });
+    // Normalize within market
+    const nRet5   = rank01(names.map(n => byName[n].ret5));
+    const nRet20  = rank01(names.map(n => byName[n].ret20));
+    const nTurn   = rank01(names.map(n => byName[n].turnover));
+    const nVol    = rank01(names.map(n => byName[n].vol20));   // higher vol = riskier
+    const nNews   = rank01(names.map(n => byName[n].news72));
+
+    // Scores
+    const scoreSafeRaw = {};
+    const scoreAggrRaw = {};
+    names.forEach((n, i) => {
+      const earnBonus = byName[n].earn ? 0.10 : 0;
+      const safe = 0.35*nNews[i] + 0.35*nRet20[i] + 0.20*nRet5[i] + 0.10*(1 - nVol[i]) + earnBonus;
+      const aggr = 0.45*nNews[i] + 0.35*nRet5[i]  + 0.20*nTurn[i]                        + earnBonus;
+      scoreSafeRaw[n] = clamp01(safe);
+      scoreAggrRaw[n] = clamp01(aggr);
     });
 
-    const blSet = new Set(blacklist[market] || []);
-    const safeSorted = scored.filter(s => !blSet.has(s.t)).sort((a,b)=>b.score_safe-a.score_safe).map(s=>s.t);
-    const aggrSorted = scored.filter(s => !blSet.has(s.t)).sort((a,b)=>b.score_aggr-a.score_aggr).map(s=>s.t);
+    // Apply feedback nudges
+    const scoreSafe = applyFeedback(scoreSafeRaw, feedback, market);
+    const scoreAggr = applyFeedback(scoreAggrRaw, feedback, market);
 
-    function applyLists(sorted, wl) {
-      const wlSet = new Set(wl);
-      const whitelisted = sorted.filter(n => wlSet.has(n));
-      const rest = sorted.filter(n => !wlSet.has(n));
-      return whitelisted.concat(rest).slice(0,5);
+    // Pick top K distinct names for each bucket
+    function topK(scores, k){
+      return Object.entries(scores).sort((a,b)=>b[1]-a[1]).slice(0,k).map(([n])=>n);
     }
+    const chosenSafe = topK(scoreSafe, PICK_COUNT);
+    const chosenAggr = topK(scoreAggr, PICK_COUNT);
 
     pools[market] = {
-      safe: applyLists(safeSorted, whitelist[market] || []),
-      aggressive: applyLists(aggrSorted, whitelist[market] || [])
+      safe: chosenSafe,
+      aggressive: chosenAggr
     };
+
+    metricsOut[market] = names.reduce((acc, n, i) => {
+      acc[n] = {
+        ret5: byName[n].ret5, ret20: byName[n].ret20, vol20: byName[n].vol20, turnover: byName[n].turnover,
+        news72h: byName[n].news72, recentEarnings: byName[n].earn,
+        norm: { ret5: nRet5[i], ret20: nRet20[i], vol20: nVol[i], turnover: nTurn[i], news72h: nNews[i] },
+        score: { safe: scoreSafe[n], aggressive: scoreAggr[n] }
+      };
+      return acc;
+    }, {});
   }
 
-  await writeAtomically(poolsPath, JSON.stringify(pools, null, 2));
-  await writeAtomically(metricsPath, JSON.stringify(metrics, null, 2));
-  await maybeDecay(feedback, feedbackPath);
+  // Decay feedback periodically
+  const decayed = maybeDecayFeedback(feedback);
+  if (decayed !== feedback){
+    await writeAtomic(FEEDBACK_FILE, JSON.stringify(decayed, null, 2));
+    console.log('[buildPools] feedback decayed');
+  }
+
+  // Write outputs
+  await writeAtomic(POOLS_FILE, JSON.stringify(pools, null, 2));
+  await writeAtomic(METRICS_FILE, JSON.stringify(metricsOut, null, 2));
+  console.log('[buildPools] wrote pools.json and pools-metrics.json');
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
-  main().catch(e => { console.error('[buildPools:error]', e); process.exit(0); });
-}
+main().catch(e => { console.error('[buildPools] failed:', e.message); process.exit(0); });


### PR DESCRIPTION
## Summary
- load stock pools dynamically with remote/cache/local fallbacks
- add trend-aware pool generator using Finnhub and TwelveData
- run generator before recommendations in both workflows and seed feedback

## Testing
- `node tests/apple_association.test.js`
- ⚠️ `FINNHUB_API_KEY=d2g00apr01qkv5nf4llgd2g00apr01qkv5lm0 TWELVEDATA_API_KEY=a0b6c3f6c8394dbab14fc002c4434a8e node tools/buildPoolsTrendy.js` (hung in container)
- ⚠️ `timeout 30 node fetchStockInfo.js --refresh-pools --force` (command terminated early)


------
https://chatgpt.com/codex/tasks/task_b_68a0031944c8832a92a08c193641dc02