### PR TITLE
chore: align pool build step env vars

### DIFF
--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -58,8 +58,17 @@ jobs:
 
       - name: Build trend-aware pools
         env:
+          FMP_KEY: ${{ secrets.FMP_KEY }}
+          ALPHA_VANTAGE_KEY: ${{ secrets.ALPHA_VANTAGE_KEY }}
           FINNHUB_API_KEY: ${{ secrets.FINNHUB_API_KEY }}
           TWELVEDATA_API_KEY: ${{ secrets.TWELVEDATA_API_KEY }}
+          GLOBAL_BUDGET_MS: ${{ env.GLOBAL_BUDGET_MS }}
+          MAX_CONCURRENCY: ${{ env.MAX_CONCURRENCY }}
+          REQ_TIMEOUT_MS: ${{ env.REQ_TIMEOUT_MS }}
+          RETRIES: ${{ env.RETRIES }}
+          BACKOFF_BASE_MS: ${{ env.BACKOFF_BASE_MS }}
+          CIRCUIT_MAX_ERRORS: ${{ env.CIRCUIT_MAX_ERRORS }}
+          COVERAGE_MIN: ${{ env.COVERAGE_MIN }}
         run: node tools/buildPoolsTrendy.js || true
 
       - name: Build recommendations (primary path)

--- a/.github/workflows/stock-recs.yml
+++ b/.github/workflows/stock-recs.yml
@@ -59,8 +59,17 @@ jobs:
 
       - name: Build trend-aware pools
         env:
+          FMP_KEY: ${{ secrets.FMP_KEY }}
+          ALPHA_VANTAGE_KEY: ${{ secrets.ALPHA_VANTAGE_KEY }}
           FINNHUB_API_KEY: ${{ secrets.FINNHUB_API_KEY }}
           TWELVEDATA_API_KEY: ${{ secrets.TWELVEDATA_API_KEY }}
+          GLOBAL_BUDGET_MS: ${{ env.GLOBAL_BUDGET_MS }}
+          MAX_CONCURRENCY: ${{ env.MAX_CONCURRENCY }}
+          REQ_TIMEOUT_MS: ${{ env.REQ_TIMEOUT_MS }}
+          RETRIES: ${{ env.RETRIES }}
+          BACKOFF_BASE_MS: ${{ env.BACKOFF_BASE_MS }}
+          CIRCUIT_MAX_ERRORS: ${{ env.CIRCUIT_MAX_ERRORS }}
+          COVERAGE_MIN: ${{ env.COVERAGE_MIN }}
         run: node tools/buildPoolsTrendy.js || true
 
       # If you're still on single-file (fetchStockInfo.js), this just works.


### PR DESCRIPTION
## Summary
- ensure trend-aware pool build uses all API keys and throttle settings in daily build workflow
- mirror env vars for trend-aware pool build in stock recommendations workflow

## Testing
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68a01996c8d0832a91cfcd00519d3329