### PR TITLE
chore: harden workflows and redact tokens

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -30,13 +30,23 @@ jobs:
 
     steps:
       - name: 코드 체크아웃
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
         with:
           persist-credentials: true
           fetch-depth: 0
 
+      - name: Guard: no secrets in code/logs
+        run: |
+          set -e
+          ! git grep -nE 'FINNHUB_API_KEY|TWELVEDATA_API_KEY|ALPHA_VANTAGE_KEY|FMP_KEY'
+
+      - name: Guard: no env/key files
+        run: |
+          set -e
+          ! git ls-files | grep -E '\\.env(\\..*)?$|\\.pem$|\\.key$|_creds\\.|credentials\\.json$' || (echo "❌ remove secret files"; exit 1)
+
       - name: Node.js 설정
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
           cache: 'npm'
@@ -111,7 +121,7 @@ jobs:
           git diff --staged --name-only || true
 
       - name: Commit & push changes
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403 # v5
         with:
           commit_message: "chore: daily stock report update [skip ci]"
           file_pattern: |
@@ -135,7 +145,10 @@ jobs:
         run: git log -1 --name-only --pretty=fuller || true
 
       - name: GitHub Pages 배포
-        uses: peaceiris/actions-gh-pages@v4
+        environment:
+          name: production
+          url: https://singaseongj.github.io
+        uses: peaceiris/actions-gh-pages@e9c66a37f080288a11235e32cbe2dc5fb3a679cc # v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages

--- a/.github/workflows/stock-recs.yml
+++ b/.github/workflows/stock-recs.yml
@@ -43,13 +43,23 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
         with:
           persist-credentials: true
           fetch-depth: 0
 
+      - name: Guard: no secrets in code/logs
+        run: |
+          set -e
+          ! git grep -nE 'FINNHUB_API_KEY|TWELVEDATA_API_KEY|ALPHA_VANTAGE_KEY|FMP_KEY'
+
+      - name: Guard: no env/key files
+        run: |
+          set -e
+          ! git ls-files | grep -E '\\.env(\\..*)?$|\\.pem$|\\.key$|_creds\\.|credentials\\.json$' || (echo "❌ remove secret files"; exit 1)
+
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
           cache: 'npm'
@@ -109,7 +119,7 @@ jobs:
           node -e "console.log(require('./recommendations.json').mode || 'unknown')"
 
       - name: Commit & push changes
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403 # v5
         with:
           commit_message: "chore: stock recommendations update [skip ci]"
           file_pattern: |
@@ -134,7 +144,10 @@ jobs:
       # Optional: publish to GitHub Pages if your repo uses it
       - name: Deploy to GitHub Pages
         if: always()
-        uses: peaceiris/actions-gh-pages@v4
+        environment:
+          name: production
+          url: https://singaseongj.github.io
+        uses: peaceiris/actions-gh-pages@e9c66a37f080288a11235e32cbe2dc5fb3a679cc # v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages

--- a/tools/buildPoolsTrendy.js
+++ b/tools/buildPoolsTrendy.js
@@ -117,7 +117,8 @@ async function getJSON(url, headers = {}, retries = RETRIES, base = BACKOFF_BASE
       if (tripOnError(e)) throw lastErr;
       if (attempt < retries && budgetOk()) {
         const backoff = base * Math.pow(2, attempt);
-        console.log(`[net] retry ${attempt + 1}/${retries} in ${backoff}ms :: ${url}`);
+        const redacted = url.replace(/token=[^&]+/i, 'token=***').replace(/apikey=[^&]+/i, 'apikey=***');
+        console.log(`[net] retry ${attempt + 1}/${retries} in ${backoff}ms :: ${redacted}`);
         await new Promise(r => setTimeout(r, backoff));
         continue;
       }


### PR DESCRIPTION
## Summary
- pin third-party GitHub Actions and add secret guard steps
- require production environment approval for pages deploy
- redact API tokens from network retry logs

## Testing
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68a03c9d5db8832a914697b56107cb80