### PR TITLE
chore: harden secret guard

### DIFF
--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -41,9 +41,33 @@ jobs:
           fetch-depth: 0
 
       - name: "Guard: no secrets in code/logs"
+        shell: bash
         run: |
           set -e
-          ! git grep -nE 'FINNHUB_API_KEY|TWELVEDATA_API_KEY|ALPHA_VANTAGE_KEY|FMP_KEY'
+          echo "== scanning for hardcoded secrets =="
+          pattern_assign='(api|token|secret)[[:space:]]*[:=][[:space:]]*["'"'"'][A-Za-z0-9_-]{12,}["'"'"']'
+          pattern_echo='echo[[:space:]]+.*\$\{?(FINNHUB_API_KEY|TWELVEDATA_API_KEY|ALPHA_VANTAGE_KEY|FMP_KEY)\}?'
+          if grep -RInE "$pattern_assign" \
+              --exclude-dir=.git \
+              --exclude-dir=workflows \
+              --exclude=README \
+              --exclude=*.md \
+              --exclude=*.yml \
+              --exclude=*.yaml .; then
+            echo '❌ Hardcoded secret detected'
+            exit 1
+          fi
+          if grep -RInE "$pattern_echo" \
+              --exclude-dir=.git \
+              --exclude-dir=workflows \
+              --exclude=README \
+              --exclude=*.md \
+              --exclude=*.yml \
+              --exclude=*.yaml .; then
+            echo '❌ Echoing secret env vars detected'
+            exit 1
+          fi
+          echo '✅ no secrets found'
 
       - name: "Guard: no env/key files"
         run: |


### PR DESCRIPTION
## Summary
- strengthen secret guard in daily-build workflow
- scan for hardcoded tokens or secret echos while excluding docs and workflow files

## Testing
- `node tests/apple_association.test.js`
- `bash /tmp/guard_run.sh`
- `echo 'my_api = "ABCDEFGHIJKL"' > temp_secret.js; bash /tmp/guard_run.sh || true`
- `echo 'echo $FINNHUB_API_KEY' > temp_echo.sh; bash /tmp/guard_run.sh || true`

------
https://chatgpt.com/codex/tasks/task_b_68a05cc3adac832a81db148fe6d7aaba