### PR TITLE
ci: avoid failing guard steps on unset vars

### DIFF
--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -43,7 +43,7 @@ jobs:
       - name: "Guard: no hardcoded secrets"
         shell: bash
         run: |
-          set -euo pipefail
+          set -Eeo pipefail
           # Fail on likely secret assignments in source code (exclude workflows/docs)
           if git grep -nI -E '(?i)(api[_-]?key|token|secret)\s*[:=]\s*["'\''][A-Za-z0-9_\-]{12,}["'\'']' -- \
               ':!README.md' ':!.github/workflows/**' ':!**/*.yml' ':!**/*.yaml' ':!**/*.md'; then
@@ -59,7 +59,7 @@ jobs:
       - name: "Guard: no env/key files (allow examples)"
         shell: bash
         run: |
-          set -euo pipefail
+          set -Eeo pipefail
 
           # 1) Gather candidates that LOOK like secret files
           candidates="$(git ls-files -z \

--- a/.github/workflows/stock-recs.yml
+++ b/.github/workflows/stock-recs.yml
@@ -57,7 +57,7 @@ jobs:
       - name: "Guard: no hardcoded secrets"
         shell: bash
         run: |
-          set -euo pipefail
+          set -Eeo pipefail
           # Fail on likely secret assignments in source code (exclude workflows/docs)
           if git grep -nI -E '(?i)(api[_-]?key|token|secret)\s*[:=]\s*["'\''][A-Za-z0-9_\-]{12,}["'\'']' -- \
               ':!README.md' ':!.github/workflows/**' ':!**/*.yml' ':!**/*.yaml' ':!**/*.md'; then
@@ -73,7 +73,7 @@ jobs:
       - name: "Guard: no env/key files (allow examples)"
         shell: bash
         run: |
-          set -euo pipefail
+          set -Eeo pipefail
           offenders="$(git ls-files -z \
             | tr '\\0' '\\n' \
             | grep -E '(^|/)\\.env($|\\.)|\\.pem$|\\.key$|(^|/)credentials\\.json$|_creds\\.' \


### PR DESCRIPTION
## Summary
- prevent guard steps from exiting on unset env variables

## Testing
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68a075134978832aa35fe85d3787c467