### PR TITLE
ci: add offline test and autofix jobs

### DIFF
--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -7,7 +7,45 @@ name: Daily Stock Report Build
   schedule:
     - cron: '0 1,6,11,15,20 * * *'  # 00/05/10/15/20 KST
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 코드 체크아웃
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Node.js 설정
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: 의존성 설치
+        run: npm ci
+
+      - name: "Run offline build"
+        env:
+          FINNHUB_API_KEY: demo
+          FMP_KEY: demo
+          ALPHA_VANTAGE_KEY: demo
+          TWELVEDATA_API_KEY: demo
+          OFFLINE: 1
+        run: |
+          set -Eeo pipefail
+          node fetchStockInfo.js --refresh-pools --force
+          node src/build.js
+
+      - name: "Validate recommendations.json"
+        run: |
+          set -Eeo pipefail
+          node -e "const fs=require('fs');const f='recommendations.json';fs.accessSync(f);JSON.parse(fs.readFileSync(f,'utf8'));"
+
+      - name: Run tests
+        run: node tests/apple_association.test.js
+
   build-and-deploy:
+    needs: test
     environment:
       name: production
       url: https://singaseongj.github.io
@@ -186,3 +224,35 @@ jobs:
           publish_branch: gh-pages
           publish_dir: ./
           # force_orphan: true  # optional
+
+  autofix:
+    if: github.repository == 'singaseongj/singaseongj.github.io'
+    needs: test
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: 코드 체크아웃
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+        with:
+          fetch-depth: 0
+
+      - name: "Guard autofix: remove tracked secrets"
+        shell: bash
+        run: |
+          set -Eeo pipefail
+          candidates="$(git ls-files -z |
+            tr '\0' '\n' |
+            grep -E '(^|/)\\.env($|\\.)|\\.pem$|\\.key$|(^|/)credentials\\.json$|_creds\\.')"
+          offenders="$(printf '%s\n' "$candidates" |
+            grep -Ev '(^|/)\\.env\\.example$|\\.example($|\\.|/)|\\.sample($|\\.|/)|\\.template($|\\.|/)')"
+          if [ -n "$offenders" ]; then
+            echo "$offenders" | xargs -r git rm -f --cached
+          fi
+
+      - name: Commit guard fixes
+        uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403 # v5
+        with:
+          commit_message: "chore: remove tracked secret files"
+          add_options: '-A'
+          skip_dirty_check: true


### PR DESCRIPTION
## Summary
- ignore sample env files in secret guard
- add demo-mode test job and commit-based autofix

## Testing
- `node tests/apple_association.test.js`
- `yamllint .github/workflows/daily-build.yml`


------
https://chatgpt.com/codex/tasks/task_b_68a07cb582e4832aa22c2b6ecb32bb79