### PR TITLE
ci: remove env file guard steps

### DIFF
--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -94,28 +94,6 @@ jobs:
           fi
           echo "✅ No hardcoded secrets found."
 
-      - name: "Guard: no env/key files (allow examples)"
-        shell: bash
-        run: |
-          set -Eeo pipefail
-
-          # 1) Gather candidates that LOOK like secret files
-          candidates="$(git ls-files -z \
-            | tr '\\0' '\\n' \
-            | grep -E '(^|/)\\.env($|\\.)|\\.pem$|\\.key$|(^|/)credentials\\.json$|_creds\\.')"
-
-          # 2) Drop safe templates/examples (incl. exact .env.example)
-          offenders="$(printf '%s\n' "$candidates" \
-            | grep -Ev '(^|/)\\.env\\.example$|\\.example($|\\.|/)|\\.sample($|\\.|/)|\\.template($|\\.|/)')"
-
-          if [ -n "$offenders" ]; then
-            echo "$offenders"
-            echo "❌ remove secret files"
-            exit 1
-          fi
-
-          echo "✅ no secret files tracked"
-
       - name: Node.js 설정
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:

--- a/.github/workflows/stock-recs.yml
+++ b/.github/workflows/stock-recs.yml
@@ -70,26 +70,11 @@ jobs:
           fi
           echo "✅ No hardcoded secrets found."
 
-      - name: "Guard: no env/key files (allow examples)"
-        shell: bash
-        run: |
-          set -Eeo pipefail
-          offenders="$(git ls-files -z \
-            | tr '\\0' '\\n' \
-            | grep -E '(^|/)\\.env($|\\.)|\\.pem$|\\.key$|(^|/)credentials\\.json$|_creds\\.' \
-            | grep -Ev '\\.example($|\\.)|\\.sample($|\\.)|\\.template($|\\.)|(^|/)\\.env\\.example($|\\.)')"
-          if [ -n "${offenders}" ]; then
-            echo "${offenders}"
-            echo "❌ remove secret files"
-            exit 1
-          fi
-          echo "✅ no secret files tracked"
-
-      - name: Setup Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
-        with:
-          node-version: '20'
-          cache: 'npm'
+        - name: Setup Node
+          uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+          with:
+            node-version: '20'
+            cache: 'npm'
 
       - name: Install deps
         run: npm ci


### PR DESCRIPTION
## Summary
- remove `Guard: no env/key files` steps from daily-build and stock-recs workflows
- clean up indentation for the setup step in stock recommendations workflow

## Testing
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68a089deb254832a81e14ebb40146be0