### PR TITLE
chore: clean up stock recs workflow

### DIFF
--- a/.github/workflows/stock-recs.yml
+++ b/.github/workflows/stock-recs.yml
@@ -2,7 +2,7 @@
 # yamllint disable rule:line-length
 name: Build & Publish Stock Recommendations
 
-'on':
+on:
   workflow_dispatch:
   schedule:
     # Every 5 hours (cron is UTC; cadence doesn't depend on timezone)
@@ -99,10 +99,10 @@ jobs:
       - name: "Build recommendations (deadline-aware)"
         run: |
           if [ -f "src/index.js" ]; then
-            echo "→ Running modular entry (src/index.js)"
+            echo "Running modular entry (src/index.js)"
             timeout 60 node src/index.js --refresh-pools --force
           else
-            echo "→ Running single-file (fetchStockInfo.js)"
+            echo "Running single-file (fetchStockInfo.js)"
             timeout 60 node fetchStockInfo.js --refresh-pools --force --delay=120
           fi
 


### PR DESCRIPTION
## Summary
- simplify workflow configuration to use standard `on` key
- streamline module selection logs during recommendation builds

## Testing
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68a09655454c832a9af3ef3d5034560d