### PR TITLE
chore: enforce refresh-pools policy

### DIFF
--- a/.github/scripts/check-refresh-pools.sh
+++ b/.github/scripts/check-refresh-pools.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+violations=0
+
+check_call() {
+  local file="$1"
+  local require_refresh="$2"   # true|false
+  local context
+  context="$(nl -ba "$file" | sed -n '1,500p')"
+
+  # naive checks: look for fetchStockInfo invocations in this file
+  mapfile -t lines < <(echo "$context" | grep -n 'node[^\n]*fetchStockInfo\.js' || true)
+  for ln in "${lines[@]}"; do
+    line_no="${ln%%:*}"
+    snippet="$(echo "$context" | sed -n "$((line_no-2)),$((line_no+2))p")"
+    has_refresh=$(echo "$snippet" | grep -q -- '--refresh-pools' && echo true || echo false)
+
+    if [ "$require_refresh" = true ] && [ "$has_refresh" = false ]; then
+      echo "❌ $file:$line_no expected --refresh-pools but not found"
+      echo "$snippet"
+      echo
+      violations=$((violations+1))
+    fi
+    if [ "$require_refresh" = false ] && [ "$has_refresh" = true ]; then
+      echo "❌ $file:$line_no should NOT force refresh for non-cron runs"
+      echo "$snippet"
+      echo
+      violations=$((violations+1))
+    fi
+  done
+}
+
+# Daily build must require refresh
+if [ -f ".github/workflows/daily-build.yml" ]; then
+  check_call ".github/workflows/daily-build.yml" true
+fi
+
+# Stock recs: we allow conditional logic; only flag if it unconditionally forces refresh.
+if [ -f ".github/workflows/stock-recs.yml" ]; then
+  # If the file contains a conditional branch using github.event_name == 'schedule', skip strict check.
+  if ! grep -q "github\.event_name.*schedule" ".github/workflows/stock-recs.yml"; then
+    # No condition → treat as non-cron default; should NOT be forcing refresh
+    check_call ".github/workflows/stock-recs.yml" false
+  fi
+fi
+
+if [ "$violations" -gt 0 ]; then
+  echo "Found $violations refresh-pools rule violation(s)."; exit 1
+else
+  echo "✅ refresh-pools usage complies with the rules."
+fi

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -15,6 +15,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Verify refresh-pools policy
+        run: bash .github/scripts/check-refresh-pools.sh
+
       - name: Node.js 설정
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
@@ -33,7 +36,7 @@ jobs:
           OFFLINE: 1
         run: |
           set -Eeo pipefail
-          node fetchStockInfo.js --force
+          node fetchStockInfo.js --refresh-pools --force
           node src/build.js
 
       - name: "Validate recommendations.json"
@@ -77,6 +80,9 @@ jobs:
         with:
           persist-credentials: true
           fetch-depth: 0
+
+      - name: Verify refresh-pools policy
+        run: bash .github/scripts/check-refresh-pools.sh
 
       - name: "Guard: no hardcoded secrets"
         shell: bash

--- a/.github/workflows/stock-recs.yml
+++ b/.github/workflows/stock-recs.yml
@@ -29,6 +29,7 @@ jobs:
       HARD_DEADLINE_MS: "55000"
       # GitHub often has flaky access to Naver; feel free to unset.
       SKIP_NAVER: "1"
+      IS_CRON: ${{ github.event_name == 'schedule' }}
 
       # Optional: hybrid remote cache (leave empty if not used)
       # REMOTE_URL: ${{ secrets.REMOTE_URL }}   # e.g. public GET or signed GET to last-good recommendations.json
@@ -53,6 +54,9 @@ jobs:
         with:
           persist-credentials: true
           fetch-depth: 0
+
+      - name: Verify refresh-pools policy
+        run: bash .github/scripts/check-refresh-pools.sh
 
       - name: "Guard: no hardcoded secrets"
         shell: bash
@@ -94,16 +98,23 @@ jobs:
           COVERAGE_MIN: ${{ env.COVERAGE_MIN }}
         run: node tools/buildPoolsTrendy.js || true
 
-      # If you're still on single-file (fetchStockInfo.js), this just works.
-      # If you split into modules, it runs src/index.js instead.
-      - name: "Build recommendations (deadline-aware)"
+      - name: Build recommendations (conditional refresh)
+        shell: bash
         run: |
-          if [ -f "src/index.js" ]; then
+          set -euo pipefail
+          if [ -f fetchStockInfo.js ]; then
+            if [ "${IS_CRON}" = "true" ]; then
+              echo "Cron run → using --refresh-pools"
+              timeout 60 node fetchStockInfo.js --refresh-pools --force --delay=120
+            else
+              echo "Non-cron run → no forced refresh"
+              timeout 60 node fetchStockInfo.js --force --delay=120
+            fi
+          elif [ -f src/index.js ]; then
             echo "Running modular entry (src/index.js)"
             timeout 60 node src/index.js --force
           else
-            echo "Running single-file (fetchStockInfo.js)"
-            timeout 60 node fetchStockInfo.js --force --delay=120
+            echo "No entrypoint found"; exit 1
           fi
 
       # Add a validator (from earlier) at tools/validate-recs.js
@@ -118,7 +129,13 @@ jobs:
           else
             echo "Rebuilding pools and recommendations..."
             node tools/buildPoolsTrendy.js || true
-            node fetchStockInfo.js --refresh-pools --force
+            if [ "${IS_CRON}" = "true" ]; then
+              echo "Cron run → using --refresh-pools"
+              node fetchStockInfo.js --refresh-pools --force
+            else
+              echo "Non-cron run → no forced refresh"
+              node fetchStockInfo.js --force
+            fi
             validate_json
           fi
 


### PR DESCRIPTION
## Summary
- add guard script to verify `--refresh-pools` usage
- always refresh pools in daily build
- refresh pools only on scheduled runs for stock recommendations

## Testing
- `bash .github/scripts/check-refresh-pools.sh`
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68a0af9bc3e4832a8e70d1b7177cb495