### PR TITLE
feat: improve trending sources and UI feedback

### DIFF
--- a/src/sources/yahoo.js
+++ b/src/sources/yahoo.js
@@ -1,11 +1,17 @@
 import { TICKER_MAP } from '../maps.js';
 
 export async function yahooTrending(region = 'US', count = 60) {
-  if (region === 'US') return ['MSFT','AAPL','NVDA','AMZN','META'];
-  return ['005930.KS','000660.KS','035420.KS'];
+  if (region === 'NYSE') return ['BRK-B','JNJ','PG','V','KO'];
+  if (region === 'NASDAQ') return ['AAPL','MSFT','NVDA','AMZN','META'];
+  if (region === 'NASDAQ 100') return ['AAPL','MSFT','NVDA','AMD','TSLA'];
+  if (region === 'KR') return ['005930.KS','000660.KS','035420.KS','035720.KS','051910.KS'];
+  // default to US if unknown
+  return ['AAPL','MSFT','NVDA','AMZN','META'];
 }
 
 export async function yahooPredefined(scrId = 'day_gainers', count = 60) {
+  if (scrId === 'day_gainers_nyse') return ['V','KO','JPM'];
+  if (scrId === 'day_gainers_nasdaq100') return ['AMD','TSLA','PEP'];
   return ['TSLA','NFLX','SMCI'];
 }
 

--- a/src/template.html
+++ b/src/template.html
@@ -86,6 +86,7 @@
 
   <section id="portfolioRecommendations">
     <h2 data-i18n="portfolioRecs">포트폴리오 추천</h2>
+    <div id="loading" class="loading" style="display:none">Loading data…</div>
     <div id="recommendations"><p class="error" style="display:none"></p></div>
     <div id="portfolioUpdated" class="last-updated"></div>
     <noscript>자바스크립트를 활성화하면 추천 종목이 표시됩니다.</noscript>
@@ -113,6 +114,7 @@
         recsError: '추천 데이터를 불러오지 못했습니다.',
         safe: '안전주',
         aggressive: '공격주',
+        pickNote: '안전주는 변동성이 낮고 최근 수익률이 안정적인 종목, 공격주는 모멘텀과 거래대금이 높은 종목입니다.',
         updated: '업데이트: ',
         visitsToday: '오늘 방문: {daily} | 총 방문: {total}'
       },
@@ -136,6 +138,7 @@
         recsError: 'Failed to load recommendations.',
         safe: 'Safe Picks',
         aggressive: 'Aggressive Picks',
+        pickNote: 'Safe Picks emphasise consistent performance and lower volatility; Aggressive Picks highlight higher momentum and volume.',
         updated: 'Updated: ',
         visitsToday: 'Visits today: {daily} | Total: {total}'
       }
@@ -358,28 +361,37 @@
     };
 
     async function fetchRecs() {
+      const loading = document.getElementById('loading');
+      if (loading) loading.style.display = 'block';
       let data = null;
+      const container = document.getElementById('recommendations');
       try {
         // cache-buster to avoid stale GH-Pages content
         const res = await fetch('recommendations.json?_=' + Date.now(), { cache: 'no-store' });
         if (!res.ok) throw new Error('HTTP ' + res.status);
         data = await res.json();
+        if (container && data) {
+          render(data);
+        } else if (container) {
+          const p = container.querySelector('.error') || document.createElement('p');
+          p.className = 'error';
+          p.textContent = translations[currentLang].recsError;
+          p.style.display = 'block';
+          container.innerHTML = '';
+          container.appendChild(p);
+        }
       } catch (err) {
         console.error('Failed to load recommendations:', err);
-      }
-
-      const container = document.getElementById('recommendations');
-      if (!container) return;
-
-      if (data) {
-        render(data);
-      } else {
-        const p = container.querySelector('.error') || document.createElement('p');
-        p.className = 'error';
-        p.textContent = translations[currentLang].recsError;
-        p.style.display = 'block';
-        container.innerHTML = '';
-        container.appendChild(p);
+        if (container) {
+          const p = container.querySelector('.error') || document.createElement('p');
+          p.className = 'error';
+          p.textContent = translations[currentLang].recsError;
+          p.style.display = 'block';
+          container.innerHTML = '';
+          container.appendChild(p);
+        }
+      } finally {
+        if (loading) loading.style.display = 'none';
       }
     }
 
@@ -405,6 +417,7 @@
           const label = bucket === 'safe' ? translations[currentLang].safe : translations[currentLang].aggressive;
           html.push(`<div class="portfolio-group"><h3>${m} ${label}</h3><ul>${items}</ul></div>`);
         }
+        html.push(`<small class="tooltip">${translations[currentLang].pickNote}</small>`);
       }
       container.innerHTML = html.join('');
       const upd = document.getElementById('portfolioUpdated');

--- a/stocks.css
+++ b/stocks.css
@@ -145,6 +145,13 @@ tr:hover {
   font-size: 0.85em;
 }
 
+.tooltip {
+  display: block;
+  color: #6b7280;
+  margin-top: 4px;
+  font-size: 0.85em;
+}
+
 .loading {
   text-align: center;
   color: #7f8c8d;

--- a/stocks.html
+++ b/stocks.html
@@ -53,7 +53,7 @@
 <body>
   <a href="index.html" class="home-button" aria-label="Home">&#x21A9;</a>
   <h1 data-i18n="title">데일리 주식 리포트 자동화</h1>
-  <p id="currentDate"><span id="datePrefix" data-i18n="today">오늘:</span> 2025년 8월 14일</p>
+  <p id="currentDate"><span id="datePrefix" data-i18n="today">오늘:</span> 2025년 8월 17일</p>
   
   <div id="debugInfo" class="debug" style="display: none;">
     <h4>디버그 정보:</h4>
@@ -86,6 +86,7 @@
 
   <section id="portfolioRecommendations">
     <h2 data-i18n="portfolioRecs">포트폴리오 추천</h2>
+    <div id="loading" class="loading" style="display:none">Loading data…</div>
     <div id="recommendations"><p class="error" style="display:none"></p></div>
     <div id="portfolioUpdated" class="last-updated"></div>
     <noscript>자바스크립트를 활성화하면 추천 종목이 표시됩니다.</noscript>
@@ -113,6 +114,7 @@
         recsError: '추천 데이터를 불러오지 못했습니다.',
         safe: '안전주',
         aggressive: '공격주',
+        pickNote: '안전주는 변동성이 낮고 최근 수익률이 안정적인 종목, 공격주는 모멘텀과 거래대금이 높은 종목입니다.',
         updated: '업데이트: ',
         visitsToday: '오늘 방문: {daily} | 총 방문: {total}'
       },
@@ -136,6 +138,7 @@
         recsError: 'Failed to load recommendations.',
         safe: 'Safe Picks',
         aggressive: 'Aggressive Picks',
+        pickNote: 'Safe Picks emphasise consistent performance and lower volatility; Aggressive Picks highlight higher momentum and volume.',
         updated: 'Updated: ',
         visitsToday: 'Visits today: {daily} | Total: {total}'
       }
@@ -358,28 +361,37 @@
     };
 
     async function fetchRecs() {
+      const loading = document.getElementById('loading');
+      if (loading) loading.style.display = 'block';
       let data = null;
+      const container = document.getElementById('recommendations');
       try {
         // cache-buster to avoid stale GH-Pages content
         const res = await fetch('recommendations.json?_=' + Date.now(), { cache: 'no-store' });
         if (!res.ok) throw new Error('HTTP ' + res.status);
         data = await res.json();
+        if (container && data) {
+          render(data);
+        } else if (container) {
+          const p = container.querySelector('.error') || document.createElement('p');
+          p.className = 'error';
+          p.textContent = translations[currentLang].recsError;
+          p.style.display = 'block';
+          container.innerHTML = '';
+          container.appendChild(p);
+        }
       } catch (err) {
         console.error('Failed to load recommendations:', err);
-      }
-
-      const container = document.getElementById('recommendations');
-      if (!container) return;
-
-      if (data) {
-        render(data);
-      } else {
-        const p = container.querySelector('.error') || document.createElement('p');
-        p.className = 'error';
-        p.textContent = translations[currentLang].recsError;
-        p.style.display = 'block';
-        container.innerHTML = '';
-        container.appendChild(p);
+        if (container) {
+          const p = container.querySelector('.error') || document.createElement('p');
+          p.className = 'error';
+          p.textContent = translations[currentLang].recsError;
+          p.style.display = 'block';
+          container.innerHTML = '';
+          container.appendChild(p);
+        }
+      } finally {
+        if (loading) loading.style.display = 'none';
       }
     }
 
@@ -405,6 +417,7 @@
           const label = bucket === 'safe' ? translations[currentLang].safe : translations[currentLang].aggressive;
           html.push(`<div class="portfolio-group"><h3>${m} ${label}</h3><ul>${items}</ul></div>`);
         }
+        html.push(`<small class="tooltip">${translations[currentLang].pickNote}</small>`);
       }
       container.innerHTML = html.join('');
       const upd = document.getElementById('portfolioUpdated');

--- a/tools/buildPoolsTrendy.js
+++ b/tools/buildPoolsTrendy.js
@@ -5,6 +5,7 @@
 
 import fs from 'fs/promises';
 import { yahooTrending, yahooPredefined } from '../src/sources/yahoo.js';
+import { TICKER_MAP } from '../src/maps.js';
 
 const FINNHUB = process.env.FINNHUB_API_KEY || '';
 const TWELVE = process.env.TWELVEDATA_API_KEY || '';
@@ -12,6 +13,12 @@ const TWELVE = process.env.TWELVEDATA_API_KEY || '';
 const POOLS_FILE = 'pools.json';
 const METRICS_FILE = 'pools-metrics.json';
 const FEEDBACK_FILE = 'feedback.json';
+const TRENDING_CACHE_FILE = 'trending-cache.json';
+
+let trendingCache = {};
+try {
+  trendingCache = JSON.parse(await fs.readFile(TRENDING_CACHE_FILE, 'utf8'));
+} catch {}
 
 // Include NYSE and NASDAQ 100 so all markets get pools
 const MARKETS = ["KOSPI","KOSDAQ","NASDAQ","S&P 500","NYSE","NASDAQ 100"];
@@ -77,8 +84,8 @@ Object.assign(NAME_TO_SYMBOL, {
 
 // Build reverse lookup to convert tickers back to display names
 const SYMBOL_TO_NAME = {};
-for (const [n, s] of Object.entries(NAME_TO_SYMBOL)) {
-  SYMBOL_TO_NAME[s] = n;
+for (const [name, symbol] of Object.entries({ ...NAME_TO_SYMBOL, ...TICKER_MAP })) {
+  SYMBOL_TO_NAME[symbol] = name;
 }
 
 function nameToSymbol(name){
@@ -104,20 +111,42 @@ function toTwelveSymbol(sym) {
 
 // Fetch trending tickers and convert them to display names
 async function getTrendingNamesForMarket(market) {
+  if (OFFLINE) return trendingCache[market] || [];
   let tickers = [];
-  if (market === 'KOSPI' || market === 'KOSDAQ') {
-    tickers = await yahooTrending('KR');
-  } else {
-    tickers = [
-      ...(await yahooTrending('US')),
-      ...(await yahooPredefined('day_gainers'))
-    ];
+  try {
+    if (market === 'KOSPI' || market === 'KOSDAQ') {
+      tickers = await yahooTrending('KR');
+    } else if (market === 'NYSE') {
+      tickers = [
+        ...(await yahooTrending('NYSE')),
+        ...(await yahooPredefined('day_gainers_nyse'))
+      ];
+    } else if (market === 'NASDAQ 100') {
+      tickers = [
+        ...(await yahooTrending('NASDAQ 100')),
+        ...(await yahooPredefined('day_gainers_nasdaq100'))
+      ];
+    } else if (market === 'NASDAQ') {
+      tickers = [
+        ...(await yahooTrending('NASDAQ')),
+        ...(await yahooPredefined('day_gainers'))
+      ];
+    } else {
+      tickers = [
+        ...(await yahooTrending('US')),
+        ...(await yahooPredefined('day_gainers'))
+      ];
+    }
+  } catch (e) {
+    console.warn(`[buildPools] trending unavailable for ${market}:`, e.message);
+    return trendingCache[market] || [];
   }
   const names = new Set();
   for (const t of tickers) {
-    names.add(SYMBOL_TO_NAME[t] || t);
+    const name = SYMBOL_TO_NAME[t] || t;
+    names.add(name);
   }
-  return [...names];
+  return Array.from(names);
 }
 
 const REQ_TIMEOUT_MS = Number(process.env.REQ_TIMEOUT_MS || (DEMO_MODE ? 5000 : 8000));
@@ -360,6 +389,8 @@ async function main(){
       .map(x => typeof x === 'string' ? x : x.name)
       .filter(Boolean);
     const extraNames = await getTrendingNamesForMarket(market);
+    trendingCache[market] = extraNames;
+    await fs.writeFile(TRENDING_CACHE_FILE, JSON.stringify(trendingCache, null, 2));
     const names = Array.from(new Set([...baseNames, ...extraNames]));
     console.log(`[buildPools] market=${market} names=${names.length}`);
     if (names.length === 0) continue;

--- a/trending-cache.json
+++ b/trending-cache.json
@@ -1,0 +1,8 @@
+{
+  "KOSPI": [],
+  "KOSDAQ": [],
+  "NASDAQ": [],
+  "S&P 500": [],
+  "NYSE": [],
+  "NASDAQ 100": []
+}


### PR DESCRIPTION
## Summary
- Distinguish NYSE, NASDAQ, NASDAQ 100, and KR trending lists and add new day gainer presets for Yahoo sources
- Build pool name lookup from the full ticker map, cache trending names for offline fallback, and write cache file
- Show loading indicator and explain safe vs. aggressive picks with tooltips on the stocks page

## Testing
- `node tests/apple_association.test.js`
- `node src/build.js`
- `node tools/buildPoolsTrendy.js --offline`

------
https://chatgpt.com/codex/tasks/task_b_68a122c7eee0832ab039700cd0b95057