### PR TITLE
refactor: streamline stock markets

### DIFF
--- a/fetchStockInfo.js
+++ b/fetchStockInfo.js
@@ -134,7 +134,7 @@ async function loadPools() {
   return {
     KOSPI: { safe: ['삼성전자'], aggressive: ['POSCO퓨처엠'] },
     KOSDAQ: { safe: ['셀트리온헬스케어'], aggressive: ['에코프로비엠'] },
-    NASDAQ: { safe: ['Apple','Microsoft'], aggressive: ['NVIDIA'] },
+    'NASDAQ 100': { safe: ['Apple','Microsoft'], aggressive: ['NVIDIA'] },
     'S&P 500': { safe: ['Berkshire Hathaway (B)'], aggressive: ['Eli Lilly'] }
   };
 }

--- a/pools.json
+++ b/pools.json
@@ -2,81 +2,49 @@
   "KOSPI": {
     "safe": [
       "삼성전자",
-      "LG화학",
       "SK하이닉스",
-      "POSCO홀딩스",
-      "네이버"
+      "삼성바이오로직스",
+      "현대차",
+      "POSCO홀딩스"
     ],
     "aggressive": [
-      "삼성전자",
-      "LG화학",
-      "SK하이닉스",
-      "POSCO홀딩스",
-      "네이버"
+      "POSCO퓨처엠",
+      "두산에너빌리티",
+      "카카오",
+      "네이버",
+      "LG화학"
     ]
   },
   "KOSDAQ": {
     "safe": [
+      "셀트리온헬스케어",
+      "에코프로비엠",
+      "리노공업",
       "JYP엔터테인먼트",
-      "펄어비스",
-      "아이오케이",
-      "CJ ENM",
-      "삼성전자"
+      "천보"
     ],
     "aggressive": [
-      "JYP엔터테인먼트",
-      "펄어비스",
-      "아이오케이",
-      "CJ ENM",
-      "삼성전자"
-    ]
-  },
-  "NASDAQ": {
-    "safe": [
-      "NVIDIA",
-      "Apple",
-      "Amazon",
-      "Microsoft",
-      "Alphabet"
-    ],
-    "aggressive": [
-      "NVIDIA",
-      "Apple",
-      "Amazon",
-      "Microsoft",
-      "Alphabet"
+      "알테오젠",
+      "레인보우로보틱스",
+      "HLB",
+      "펩트론",
+      "펄어비스"
     ]
   },
   "S&P 500": {
     "safe": [
+      "Berkshire Hathaway (B)",
+      "Johnson & Johnson",
+      "Procter & Gamble",
+      "Visa",
+      "Coca-Cola"
+    ],
+    "aggressive": [
+      "Eli Lilly",
       "NVIDIA",
       "Amazon",
       "Microsoft",
-      "Apple",
-      "Meta Platforms"
-    ],
-    "aggressive": [
-      "NVIDIA",
-      "Amazon",
-      "Microsoft",
-      "Apple",
-      "Meta Platforms"
-    ]
-  },
-  "NYSE": {
-    "safe": [
-      "JPMorgan Chase",
-      "Visa",
-      "Coca-Cola",
-      "Procter & Gamble",
-      "Johnson & Johnson"
-    ],
-    "aggressive": [
-      "JPMorgan Chase",
-      "Visa",
-      "Coca-Cola",
-      "Procter & Gamble",
-      "Johnson & Johnson"
+      "Apple"
     ]
   },
   "NASDAQ 100": {
@@ -84,15 +52,15 @@
       "NVIDIA",
       "Microsoft",
       "Apple",
-      "AMD",
-      "Tesla"
+      "Amazon",
+      "Meta Platforms"
     ],
     "aggressive": [
-      "NVIDIA",
-      "Microsoft",
-      "Apple",
-      "AMD",
-      "Tesla"
+      "Tesla",
+      "Super Micro Computer",
+      "Palantir",
+      "Alphabet",
+      "Arm Holdings"
     ]
   }
 }

--- a/recommendations.json
+++ b/recommendations.json
@@ -2,56 +2,52 @@
   "KOSDAQ": {
     "safe": [
       {
-        "name": "CJ ENM",
-        "sector": "Communication Services"
-      },
-      {
         "name": "JYP엔터테인먼트",
         "sector": "Communication Services"
       },
       {
-        "name": "삼성전자",
-        "sector": "Technology"
+        "name": "리노공업",
+        "sector": "Industrials"
       },
       {
-        "name": "아이오케이",
-        "sector": "Technology"
+        "name": "셀트리온헬스케어",
+        "sector": "Healthcare"
       },
       {
-        "name": "펄어비스",
-        "sector": "Communication Services"
+        "name": "에코프로비엠",
+        "sector": "Materials"
+      },
+      {
+        "name": "천보",
+        "sector": "Industrials"
       }
     ],
     "aggressive": [
       {
-        "name": "CJ ENM",
-        "sector": "Communication Services"
+        "name": "HLB",
+        "sector": "Healthcare"
       },
       {
-        "name": "JYP엔터테인먼트",
-        "sector": "Communication Services"
+        "name": "레인보우로보틱스",
+        "sector": "Industrials"
       },
       {
-        "name": "삼성전자",
-        "sector": "Technology"
-      },
-      {
-        "name": "아이오케이",
-        "sector": "Technology"
+        "name": "알테오젠",
+        "sector": "Healthcare"
       },
       {
         "name": "펄어비스",
         "sector": "Communication Services"
+      },
+      {
+        "name": "펩트론",
+        "sector": "Healthcare"
       }
     ]
   },
   "KOSPI": {
     "safe": [
       {
-        "name": "LG화학",
-        "sector": "Materials"
-      },
-      {
         "name": "POSCO홀딩스",
         "sector": "Materials"
       },
@@ -60,12 +56,16 @@
         "sector": "Technology"
       },
       {
-        "name": "네이버",
-        "sector": "Communication Services"
+        "name": "삼성바이오로직스",
+        "sector": "Healthcare"
       },
       {
         "name": "삼성전자",
         "sector": "Technology"
+      },
+      {
+        "name": "현대차",
+        "sector": "Consumer Discretionary"
       }
     ],
     "aggressive": [
@@ -74,78 +74,36 @@
         "sector": "Materials"
       },
       {
-        "name": "POSCO홀딩스",
+        "name": "POSCO퓨처엠",
         "sector": "Materials"
-      },
-      {
-        "name": "SK하이닉스",
-        "sector": "Technology"
       },
       {
         "name": "네이버",
         "sector": "Communication Services"
       },
       {
-        "name": "삼성전자",
-        "sector": "Technology"
-      }
-    ]
-  },
-  "NASDAQ": {
-    "safe": [
+        "name": "두산에너빌리티",
+        "sector": "Industrials"
+      },
       {
-        "name": "Alphabet",
+        "name": "카카오",
         "sector": "Communication Services"
-      },
-      {
-        "name": "Amazon",
-        "sector": "Consumer Discretionary"
-      },
-      {
-        "name": "Apple",
-        "sector": "Technology"
-      },
-      {
-        "name": "Microsoft",
-        "sector": "Technology"
-      },
-      {
-        "name": "NVIDIA",
-        "sector": "Technology"
-      }
-    ],
-    "aggressive": [
-      {
-        "name": "Alphabet",
-        "sector": "Communication Services"
-      },
-      {
-        "name": "Amazon",
-        "sector": "Consumer Discretionary"
-      },
-      {
-        "name": "Apple",
-        "sector": "Technology"
-      },
-      {
-        "name": "Microsoft",
-        "sector": "Technology"
-      },
-      {
-        "name": "NVIDIA",
-        "sector": "Technology"
       }
     ]
   },
   "NASDAQ 100": {
     "safe": [
       {
-        "name": "AMD",
-        "sector": null
+        "name": "Amazon",
+        "sector": "Consumer Discretionary"
       },
       {
         "name": "Apple",
         "sector": "Technology"
+      },
+      {
+        "name": "Meta Platforms",
+        "sector": "Communication Services"
       },
       {
         "name": "Microsoft",
@@ -154,102 +112,52 @@
       {
         "name": "NVIDIA",
         "sector": "Technology"
-      },
-      {
-        "name": "Tesla",
-        "sector": "Consumer Discretionary"
       }
     ],
     "aggressive": [
       {
-        "name": "AMD",
-        "sector": null
+        "name": "Alphabet",
+        "sector": "Communication Services"
       },
       {
-        "name": "Apple",
+        "name": "Arm Holdings",
         "sector": "Technology"
       },
       {
-        "name": "Microsoft",
+        "name": "Palantir",
         "sector": "Technology"
       },
       {
-        "name": "NVIDIA",
+        "name": "Super Micro Computer",
         "sector": "Technology"
       },
       {
         "name": "Tesla",
         "sector": "Consumer Discretionary"
-      }
-    ]
-  },
-  "NYSE": {
-    "safe": [
-      {
-        "name": "Coca-Cola",
-        "sector": "Consumer Staples"
-      },
-      {
-        "name": "Johnson & Johnson",
-        "sector": "Healthcare"
-      },
-      {
-        "name": "JPMorgan Chase",
-        "sector": "Financial Services"
-      },
-      {
-        "name": "Procter & Gamble",
-        "sector": "Consumer Staples"
-      },
-      {
-        "name": "Visa",
-        "sector": "Financial Services"
-      }
-    ],
-    "aggressive": [
-      {
-        "name": "Coca-Cola",
-        "sector": "Consumer Staples"
-      },
-      {
-        "name": "Johnson & Johnson",
-        "sector": "Healthcare"
-      },
-      {
-        "name": "JPMorgan Chase",
-        "sector": "Financial Services"
-      },
-      {
-        "name": "Procter & Gamble",
-        "sector": "Consumer Staples"
-      },
-      {
-        "name": "Visa",
-        "sector": "Financial Services"
       }
     ]
   },
   "S&P 500": {
     "safe": [
       {
-        "name": "Amazon",
-        "sector": "Consumer Discretionary"
+        "name": "Berkshire Hathaway (B)",
+        "sector": "Financial Services"
       },
       {
-        "name": "Apple",
-        "sector": "Technology"
+        "name": "Coca-Cola",
+        "sector": "Consumer Staples"
       },
       {
-        "name": "Meta Platforms",
-        "sector": "Communication Services"
+        "name": "Johnson & Johnson",
+        "sector": "Healthcare"
       },
       {
-        "name": "Microsoft",
-        "sector": "Technology"
+        "name": "Procter & Gamble",
+        "sector": "Consumer Staples"
       },
       {
-        "name": "NVIDIA",
-        "sector": "Technology"
+        "name": "Visa",
+        "sector": "Financial Services"
       }
     ],
     "aggressive": [
@@ -262,8 +170,8 @@
         "sector": "Technology"
       },
       {
-        "name": "Meta Platforms",
-        "sector": "Communication Services"
+        "name": "Eli Lilly",
+        "sector": "Healthcare"
       },
       {
         "name": "Microsoft",
@@ -275,5 +183,5 @@
       }
     ]
   },
-  "lastUpdated": "2025-08-17T11:53:35+09:00"
+  "lastUpdated": "2025-08-17T14:20:50+09:00"
 }

--- a/src/template.html
+++ b/src/template.html
@@ -61,11 +61,11 @@
   </div>
   
   <div id="summary">
-    <p data-i18n="summary">이 페이지는 KOSPI, KOSDAQ, NYSE, S&P 500, NASDAQ 100 시장을 분석하여 추천 종목을 제공합니다.</p>
+    <p data-i18n="summary">이 페이지는 KOSPI, KOSDAQ, S&P 500, NASDAQ 100 시장을 분석하여 추천 종목을 제공합니다.</p>
     <ul>
       <li><strong>KOSPI:</strong> <span data-i18n="kospiDesc">국내 대형 우량주 위주</span></li>
       <li><strong>KOSDAQ:</strong> <span data-i18n="kosdaqDesc">성장 잠재력 높은 중소형주</span></li>
-      <li><strong>NYSE:</strong> <span data-i18n="nyseDesc">뉴욕 증권거래소 상장 종목 전체를 반영한 지수</span></li>
+      <!-- NYSE description removed -->
       <li><strong>S&P 500:</strong> <span data-i18n="spDesc">미국 대표 대형주 지수</span></li>
       <li><strong>NASDAQ 100:</strong> <span data-i18n="nasdaqDesc">나스닥 상장 비금융 대형주 100종목으로 기술주 비중 높음</span></li>
     </ul>
@@ -97,10 +97,10 @@
       ko: {
         title: '데일리 주식 리포트 자동화',
         today: '오늘:',
-        summary: '이 페이지는 KOSPI, KOSDAQ, NYSE, S&P 500, NASDAQ 100 시장을 분석하여 추천 종목을 제공합니다.',
+        summary: '이 페이지는 KOSPI, KOSDAQ, S&P 500, NASDAQ 100 시장을 분석하여 추천 종목을 제공합니다.',
         kospiDesc: '국내 대형 우량주 위주',
         kosdaqDesc: '성장 잠재력 높은 중소형주',
-        nyseDesc: '뉴욕 증권거래소 상장 종목 전체를 반영한 지수',
+        // nyseDesc: '뉴욕 증권거래소 상장 종목 전체를 반영한 지수', // removed: site no longer covers NYSE
         spDesc: '미국 대표 대형주 지수',
         nasdaqDesc: '나스닥 상장 비금융 대형주 100종목으로 기술주 비중 높음',
         toggleDebug: '디버그 모드 토글',
@@ -121,10 +121,10 @@
       en: {
         title: 'Daily Stock Report Automation',
         today: 'Today:',
-        summary: 'This page analyzes KOSPI, KOSDAQ, NYSE, S&P 500 and NASDAQ 100 markets to provide recommended stocks.',
+        summary: 'This page analyzes KOSPI, KOSDAQ, S&P 500 and NASDAQ 100 markets to provide recommended stocks.',
         kospiDesc: 'Domestic large-cap stocks',
         kosdaqDesc: 'High growth potential small and mid-caps',
-        nyseDesc: 'Index reflecting all NYSE listings',
+        // nyseDesc: 'Index reflecting all NYSE listings', // removed: site no longer covers NYSE
         spDesc: 'Major U.S. large-cap index',
         nasdaqDesc: 'Tech-heavy index of 100 non-financial NASDAQ stocks',
         toggleDebug: 'Toggle Debug Mode',
@@ -206,11 +206,12 @@
         console.warn('sample market data load failed', e);
       }
 
+      const FMP_KEY = 'demo';
       const indices = [
         { name: 'KOSPI', code: 'KOSPI', type: 'naver' },
         { name: 'KOSDAQ', code: 'KOSDAQ', type: 'naver' },
-        { name: 'S&P500', url: 'https://www.investing.com/indices/us-spx-500', type: 'invest' },
-        { name: 'NASDAQ100', url: 'https://www.investing.com/indices/nq-100', type: 'invest' },
+        { name: 'S&P500', symbol: '^GSPC', type: 'fmp' },
+        { name: 'NASDAQ100', symbol: '^NDX', type: 'fmp' },
       ];
 
       const rows = [];
@@ -230,18 +231,15 @@
               prevClose = ((info.nv - info.cv) / 100).toFixed(2);
               changePct = (info.cr >= 0 ? '+' : '') + info.cr.toFixed(2) + '%';
             }
-          } else if (idx.type === 'invest') {
-            const res = await fetch(`https://api.allorigins.win/get?url=${encodeURIComponent(idx.url)}`);
-            const { contents } = await res.json();
-            const priceMatch = contents.match(/id="last_last"[^>]*>([0-9.,]+)/);
-            const prevMatch = contents.match(/Prev\.\s?Close[^0-9]*([0-9.,]+)/i);
-            if (priceMatch) price = priceMatch[1].replace(/,/g, '');
-            if (prevMatch) {
-              prevClose = prevMatch[1].replace(/,/g, '');
-              const current = parseFloat(price);
-              const previous = parseFloat(prevClose);
-              if (!isNaN(current) && !isNaN(previous)) {
-                const change = ((current - previous) / previous) * 100;
+          } else if (idx.type === 'fmp') {
+            const api = `https://financialmodelingprep.com/api/v3/quote/${encodeURIComponent(idx.symbol)}?apikey=${FMP_KEY}`;
+            const data = await (await fetch(api)).json();
+            const info = data && data[0];
+            if (info) {
+              price = String(info.price);
+              prevClose = String(info.previousClose);
+              const change = info.changesPercentage;
+              if (Number.isFinite(change)) {
                 changePct = (change >= 0 ? '+' : '') + change.toFixed(2) + '%';
               }
             }

--- a/stocks.html
+++ b/stocks.html
@@ -61,11 +61,11 @@
   </div>
   
   <div id="summary">
-    <p data-i18n="summary">이 페이지는 KOSPI, KOSDAQ, NYSE, S&P 500, NASDAQ 100 시장을 분석하여 추천 종목을 제공합니다.</p>
+    <p data-i18n="summary">이 페이지는 KOSPI, KOSDAQ, S&P 500, NASDAQ 100 시장을 분석하여 추천 종목을 제공합니다.</p>
     <ul>
       <li><strong>KOSPI:</strong> <span data-i18n="kospiDesc">국내 대형 우량주 위주</span></li>
       <li><strong>KOSDAQ:</strong> <span data-i18n="kosdaqDesc">성장 잠재력 높은 중소형주</span></li>
-      <li><strong>NYSE:</strong> <span data-i18n="nyseDesc">뉴욕 증권거래소 상장 종목 전체를 반영한 지수</span></li>
+      <!-- NYSE description removed -->
       <li><strong>S&P 500:</strong> <span data-i18n="spDesc">미국 대표 대형주 지수</span></li>
       <li><strong>NASDAQ 100:</strong> <span data-i18n="nasdaqDesc">나스닥 상장 비금융 대형주 100종목으로 기술주 비중 높음</span></li>
     </ul>
@@ -97,10 +97,10 @@
       ko: {
         title: '데일리 주식 리포트 자동화',
         today: '오늘:',
-        summary: '이 페이지는 KOSPI, KOSDAQ, NYSE, S&P 500, NASDAQ 100 시장을 분석하여 추천 종목을 제공합니다.',
+        summary: '이 페이지는 KOSPI, KOSDAQ, S&P 500, NASDAQ 100 시장을 분석하여 추천 종목을 제공합니다.',
         kospiDesc: '국내 대형 우량주 위주',
         kosdaqDesc: '성장 잠재력 높은 중소형주',
-        nyseDesc: '뉴욕 증권거래소 상장 종목 전체를 반영한 지수',
+        // nyseDesc: '뉴욕 증권거래소 상장 종목 전체를 반영한 지수', // removed: site no longer covers NYSE
         spDesc: '미국 대표 대형주 지수',
         nasdaqDesc: '나스닥 상장 비금융 대형주 100종목으로 기술주 비중 높음',
         toggleDebug: '디버그 모드 토글',
@@ -121,10 +121,10 @@
       en: {
         title: 'Daily Stock Report Automation',
         today: 'Today:',
-        summary: 'This page analyzes KOSPI, KOSDAQ, NYSE, S&P 500 and NASDAQ 100 markets to provide recommended stocks.',
+        summary: 'This page analyzes KOSPI, KOSDAQ, S&P 500 and NASDAQ 100 markets to provide recommended stocks.',
         kospiDesc: 'Domestic large-cap stocks',
         kosdaqDesc: 'High growth potential small and mid-caps',
-        nyseDesc: 'Index reflecting all NYSE listings',
+        // nyseDesc: 'Index reflecting all NYSE listings', // removed: site no longer covers NYSE
         spDesc: 'Major U.S. large-cap index',
         nasdaqDesc: 'Tech-heavy index of 100 non-financial NASDAQ stocks',
         toggleDebug: 'Toggle Debug Mode',
@@ -206,11 +206,12 @@
         console.warn('sample market data load failed', e);
       }
 
+      const FMP_KEY = 'demo';
       const indices = [
         { name: 'KOSPI', code: 'KOSPI', type: 'naver' },
         { name: 'KOSDAQ', code: 'KOSDAQ', type: 'naver' },
-        { name: 'S&P500', url: 'https://www.investing.com/indices/us-spx-500', type: 'invest' },
-        { name: 'NASDAQ100', url: 'https://www.investing.com/indices/nq-100', type: 'invest' },
+        { name: 'S&P500', symbol: '^GSPC', type: 'fmp' },
+        { name: 'NASDAQ100', symbol: '^NDX', type: 'fmp' },
       ];
 
       const rows = [];
@@ -230,18 +231,15 @@
               prevClose = ((info.nv - info.cv) / 100).toFixed(2);
               changePct = (info.cr >= 0 ? '+' : '') + info.cr.toFixed(2) + '%';
             }
-          } else if (idx.type === 'invest') {
-            const res = await fetch(`https://api.allorigins.win/get?url=${encodeURIComponent(idx.url)}`);
-            const { contents } = await res.json();
-            const priceMatch = contents.match(/id="last_last"[^>]*>([0-9.,]+)/);
-            const prevMatch = contents.match(/Prev\.\s?Close[^0-9]*([0-9.,]+)/i);
-            if (priceMatch) price = priceMatch[1].replace(/,/g, '');
-            if (prevMatch) {
-              prevClose = prevMatch[1].replace(/,/g, '');
-              const current = parseFloat(price);
-              const previous = parseFloat(prevClose);
-              if (!isNaN(current) && !isNaN(previous)) {
-                const change = ((current - previous) / previous) * 100;
+          } else if (idx.type === 'fmp') {
+            const api = `https://financialmodelingprep.com/api/v3/quote/${encodeURIComponent(idx.symbol)}?apikey=${FMP_KEY}`;
+            const data = await (await fetch(api)).json();
+            const info = data && data[0];
+            if (info) {
+              price = String(info.price);
+              prevClose = String(info.previousClose);
+              const change = info.changesPercentage;
+              if (Number.isFinite(change)) {
                 changePct = (change >= 0 ? '+' : '') + change.toFixed(2) + '%';
               }
             }

--- a/tools/buildPoolsTrendy.js
+++ b/tools/buildPoolsTrendy.js
@@ -20,8 +20,7 @@ try {
   trendingCache = JSON.parse(await fs.readFile(TRENDING_CACHE_FILE, 'utf8'));
 } catch {}
 
-// Include NYSE and NASDAQ 100 so all markets get pools
-const MARKETS = ["KOSPI","KOSDAQ","NASDAQ","S&P 500","NYSE","NASDAQ 100"];
+const MARKETS = ["KOSPI", "KOSDAQ", "S&P 500", "NASDAQ 100"];
 const PICK_COUNT = 5;
 
 // ---- flags
@@ -114,27 +113,19 @@ async function getTrendingNamesForMarket(market) {
   if (OFFLINE) return trendingCache[market] || [];
   let tickers = [];
   try {
-    if (market === 'KOSPI' || market === 'KOSDAQ') {
-      tickers = await yahooTrending('KR');
-    } else if (market === 'NYSE') {
+    if (market === 'KOSPI') {
+      tickers = (await yahooTrending('KR')).filter(t => /\.KS$/.test(t));
+    } else if (market === 'KOSDAQ') {
+      tickers = (await yahooTrending('KR')).filter(t => /\.KQ$/.test(t));
+    } else if (market === 'S&P 500') {
       tickers = [
-        ...(await yahooTrending('NYSE')),
-        ...(await yahooPredefined('day_gainers_nyse'))
+        ...(await yahooTrending('US')),
+        ...(await yahooPredefined('day_gainers'))
       ];
     } else if (market === 'NASDAQ 100') {
       tickers = [
         ...(await yahooTrending('NASDAQ 100')),
         ...(await yahooPredefined('day_gainers_nasdaq100'))
-      ];
-    } else if (market === 'NASDAQ') {
-      tickers = [
-        ...(await yahooTrending('NASDAQ')),
-        ...(await yahooPredefined('day_gainers'))
-      ];
-    } else {
-      tickers = [
-        ...(await yahooTrending('US')),
-        ...(await yahooPredefined('day_gainers'))
       ];
     }
   } catch (e) {


### PR DESCRIPTION
## Summary
- drop NYSE and generic NASDAQ from daily stock report, updating template copy and translations
- rework pool builder and fallback logic to focus on KOSPI, KOSDAQ, S&P 500 and NASDAQ 100
- regenerate pools and recommendations using refreshed scripts and FMP index data

## Testing
- `node src/build.js`
- `node fetchStockInfo.js --refresh-pools --force`
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68a165eb38dc832ab29a1d5e2485a47d