### PR TITLE
Improve candle cache diagnostics and provider rotation

### DIFF
--- a/src/data/candles.js
+++ b/src/data/candles.js
@@ -13,9 +13,9 @@ const COOLOFF_MS = Number(process.env.COOLOFF_MS || 60000);
 const CACHE_DIR = path.join('data','cache','candles');
 
 const state = {
-  finnhub: { errors: 0, coolUntil: 0, count: 0, ok:0, err:0, 429:0 },
-  twelvedata: { errors: 0, coolUntil: 0, count: 0, ok:0, err:0, 429:0 },
-  fmp: { errors: 0, coolUntil: 0, count: 0, ok:0, err:0, 429:0 }
+  finnhub: { errors: 0, coolUntil: 0, count: 0, ok: 0, err: 0, '429': 0 },
+  twelvedata: { errors: 0, coolUntil: 0, count: 0, ok: 0, err: 0, '429': 0 },
+  fmp: { errors: 0, coolUntil: 0, count: 0, ok: 0, err: 0, '429': 0 }
 };
 
 function toTwelveSymbol(sym){
@@ -38,7 +38,11 @@ async function withCache(provider, symbol, ttl, fetcher){
     const txt = await fs.readFile(file, 'utf8');
     const data = JSON.parse(txt);
     if (age < ttl) return data;
-    fetcher().then(res => writeAtomic(file, JSON.stringify(res))).catch(()=>{});
+    fetcher()
+      .then(res => writeAtomic(file, JSON.stringify(res)))
+      .catch(e => {
+        if (process.env.DEBUG) console.warn('[cache] refresh failed:', e.message);
+      });
     return data;
   } catch {
     const data = await fetcher();

--- a/tools/buildPoolsTrendy.js
+++ b/tools/buildPoolsTrendy.js
@@ -305,6 +305,9 @@ async function main(){
   const universe = await buildUniverse(pools, { limitPerMarket: Number(process.env.UNIVERSE_LIMIT || 100) });
 
   for (const market of MARKETS){
+    if (Number.isFinite(MAX_PER_PROVIDER)) {
+      for (const s of Object.values(providerState)) s.count = 0;
+    }
     const buckets = pools[market];
     if (!buckets) continue;
     const names = universe[market] || [];


### PR DESCRIPTION
## Summary
- Quote 429 error counters and log background cache refresh failures when DEBUG is set
- Reset candle provider usage counts per market so `--max-per-provider` rotates fairly
- Confirmed stock template uses a single loading block and only parses recommendations JSON once

## Testing
- `node -e "require('fs').readFileSync('src/template.html');require('fs').readFileSync('stocks.html');console.log('ok')"`
- `node tools/buildPoolsTrendy.js --dry-run`
- `node tools/buildPoolsTrendy.js --dry-run`
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68a3e7eea464832a873acce5706bf51a