### PR TITLE
feat: expose news and naver API keys

### DIFF
--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -62,6 +62,9 @@ jobs:
       ALPHA_VANTAGE_KEY: ${{ secrets.ALPHA_VANTAGE_KEY }}  # optional
       FINNHUB_API_KEY: ${{ secrets.FINNHUB_API_KEY }}         # optional
       TWELVEDATA_API_KEY: ${{ secrets.TWELVEDATA_API_KEY }}   # optional
+      NEWSAPI_KEY: ${{ secrets.NEWSAPI_KEY }}
+      NAVER_CLIENT_ID: ${{ secrets.NAVER_CLIENT_ID }}
+      NAVER_CLIENT_SECRET: ${{ secrets.NAVER_CLIENT_SECRET }}
       GLOBAL_BUDGET_MS: 90000
       MAX_CONCURRENCY: 2
       REQ_TIMEOUT_MS: 5000

--- a/.github/workflows/pools-test.yml
+++ b/.github/workflows/pools-test.yml
@@ -38,11 +38,17 @@ jobs:
           ALPHA_VANTAGE_KEY: ${{ secrets.ALPHA_VANTAGE_KEY }}
           FINNHUB_API_KEY: ${{ secrets.FINNHUB_API_KEY }}
           TWELVEDATA_API_KEY: ${{ secrets.TWELVEDATA_API_KEY }}
+          NEWSAPI_KEY: ${{ secrets.NEWSAPI_KEY }}
+          NAVER_CLIENT_ID: ${{ secrets.NAVER_CLIENT_ID }}
+          NAVER_CLIENT_SECRET: ${{ secrets.NAVER_CLIENT_SECRET }}
         run: |
           echo "FMP_KEY len=${#FMP_KEY}"
           echo "ALPHA_VANTAGE_KEY len=${#ALPHA_VANTAGE_KEY}"
           echo "FINNHUB_API_KEY len=${#FINNHUB_API_KEY}"
           echo "TWELVEDATA_API_KEY len=${#TWELVEDATA_API_KEY}"
+          echo "NEWSAPI_KEY len=${#NEWSAPI_KEY}"
+          echo "NAVER_CLIENT_ID len=${#NAVER_CLIENT_ID}"
+          echo "NAVER_CLIENT_SECRET len=${#NAVER_CLIENT_SECRET}"
 
       - name: Build trend-aware pools
         env:
@@ -50,6 +56,9 @@ jobs:
           ALPHA_VANTAGE_KEY: ${{ secrets.ALPHA_VANTAGE_KEY }}
           FINNHUB_API_KEY: ${{ secrets.FINNHUB_API_KEY }}
           TWELVEDATA_API_KEY: ${{ secrets.TWELVEDATA_API_KEY }}
+          NEWSAPI_KEY: ${{ secrets.NEWSAPI_KEY }}
+          NAVER_CLIENT_ID: ${{ secrets.NAVER_CLIENT_ID }}
+          NAVER_CLIENT_SECRET: ${{ secrets.NAVER_CLIENT_SECRET }}
           # Demo-friendly throttles; adjust if you have paid tiers
           GLOBAL_BUDGET_MS: 90000
           MAX_CONCURRENCY: 2
@@ -67,6 +76,9 @@ jobs:
           ALPHA_VANTAGE_KEY: ${{ secrets.ALPHA_VANTAGE_KEY }}
           FINNHUB_API_KEY: ${{ secrets.FINNHUB_API_KEY }}
           TWELVEDATA_API_KEY: ${{ secrets.TWELVEDATA_API_KEY }}
+          NEWSAPI_KEY: ${{ secrets.NEWSAPI_KEY }}
+          NAVER_CLIENT_ID: ${{ secrets.NAVER_CLIENT_ID }}
+          NAVER_CLIENT_SECRET: ${{ secrets.NAVER_CLIENT_SECRET }}
           POOLS_TTL_MS: 86400000
         run: |
           node fetchStockInfo.js --refresh-pools --force

--- a/.github/workflows/stock-recs.yml
+++ b/.github/workflows/stock-recs.yml
@@ -40,6 +40,9 @@ jobs:
       ALPHA_VANTAGE_KEY: ${{ secrets.ALPHA_VANTAGE_KEY }}
       FINNHUB_API_KEY: ${{ secrets.FINNHUB_API_KEY }}
       TWELVEDATA_API_KEY: ${{ secrets.TWELVEDATA_API_KEY }}
+      NEWSAPI_KEY: ${{ secrets.NEWSAPI_KEY }}
+      NAVER_CLIENT_ID: ${{ secrets.NAVER_CLIENT_ID }}
+      NAVER_CLIENT_SECRET: ${{ secrets.NAVER_CLIENT_SECRET }}
       GLOBAL_BUDGET_MS: 90000
       MAX_CONCURRENCY: 2
       REQ_TIMEOUT_MS: 5000

--- a/src/news/apis.js
+++ b/src/news/apis.js
@@ -1,0 +1,45 @@
+const NEWSAPI_KEY = process.env.NEWSAPI_KEY || '';
+const NAVER_CLIENT_ID = process.env.NAVER_CLIENT_ID || '';
+const NAVER_CLIENT_SECRET = process.env.NAVER_CLIENT_SECRET || '';
+
+export async function fetchNews(topic) {
+  if (!NEWSAPI_KEY) return null;
+  try {
+    const url = `https://newsapi.org/v2/everything?q=${encodeURIComponent(topic)}&apiKey=${NEWSAPI_KEY}`;
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`NewsAPI HTTP ${res.status}`);
+    return await res.json();
+  } catch (err) {
+    console.warn('fetchNews failed', err.message);
+    return null;
+  }
+}
+
+export async function fetchNaverTrends(keyword) {
+  if (!NAVER_CLIENT_ID || !NAVER_CLIENT_SECRET) return null;
+  try {
+    const url = 'https://openapi.naver.com/v1/datalab/search';
+    const body = {
+      startDate: new Date(Date.now() - 30 * 24 * 3600 * 1000).toISOString().slice(0, 10),
+      endDate: new Date().toISOString().slice(0, 10),
+      timeUnit: 'date',
+      keywordGroups: [{ groupName: 'trend', keywords: [keyword] }]
+    };
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'X-Naver-Client-Id': NAVER_CLIENT_ID,
+        'X-Naver-Client-Secret': NAVER_CLIENT_SECRET,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(body)
+    });
+    if (!res.ok) throw new Error(`Naver API HTTP ${res.status}`);
+    return await res.json();
+  } catch (err) {
+    console.warn('fetchNaverTrends failed', err.message);
+    return null;
+  }
+}
+
+export { NEWSAPI_KEY, NAVER_CLIENT_ID, NAVER_CLIENT_SECRET };

--- a/src/news/fetchByTicker.js
+++ b/src/news/fetchByTicker.js
@@ -1,5 +1,6 @@
 import { aggregate } from './sentiment.js';
 import { TICKER_MAP } from '../maps.js';
+import { fetchNews, NEWSAPI_KEY } from './apis.js';
 
 export async function fetchByTicker(symbol, name){
   const out = { count:0, sentiment:null, top:null };
@@ -19,6 +20,11 @@ export async function fetchByTicker(symbol, name){
       const res = await fetch(url);
       const data = await res.json();
       const titles = Array.isArray(data) ? data.map(d=>d.headline) : [];
+      const agg = aggregate(titles, 'en');
+      return { count: titles.length, sentiment: agg.sentiment, top: agg.top };
+    } else if (NEWSAPI_KEY) {
+      const data = await fetchNews(name || symbol);
+      const titles = Array.isArray(data?.articles) ? data.articles.map(a => a.title) : [];
       const agg = aggregate(titles, 'en');
       return { count: titles.length, sentiment: agg.sentiment, top: agg.top };
     }


### PR DESCRIPTION
## Summary
- add helper to fetch NewsAPI and Naver DataLab data
- include NEWSAPI_KEY and Naver client credentials in workflows
- use NewsAPI as fallback source in ticker news fetcher

## Testing
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68a51268977c832a971db01c4c08138e