### PR TITLE
Integrate news and search popularity features into pool builder

### DIFF
--- a/src/news/apis.js
+++ b/src/news/apis.js
@@ -1,12 +1,15 @@
+import { withRetry } from '../util/limiter.js';
+
 const NEWSAPI_KEY = process.env.NEWSAPI_KEY || '';
 const NAVER_CLIENT_ID = process.env.NAVER_CLIENT_ID || '';
 const NAVER_CLIENT_SECRET = process.env.NAVER_CLIENT_SECRET || '';
+const UA = 'ddsciencehs-trender/1.0 (+github actions)';
 
 export async function fetchNews(topic) {
   if (!NEWSAPI_KEY) return null;
   try {
     const url = `https://newsapi.org/v2/everything?q=${encodeURIComponent(topic)}&apiKey=${NEWSAPI_KEY}`;
-    const res = await fetch(url);
+    const res = await withRetry(() => fetch(url, { headers: { 'User-Agent': UA } }));
     if (!res.ok) throw new Error(`NewsAPI HTTP ${res.status}`);
     return await res.json();
   } catch (err) {
@@ -25,15 +28,16 @@ export async function fetchNaverTrends(keyword) {
       timeUnit: 'date',
       keywordGroups: [{ groupName: 'trend', keywords: [keyword] }]
     };
-    const res = await fetch(url, {
+    const res = await withRetry(() => fetch(url, {
       method: 'POST',
       headers: {
         'X-Naver-Client-Id': NAVER_CLIENT_ID,
         'X-Naver-Client-Secret': NAVER_CLIENT_SECRET,
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
+        'User-Agent': UA
       },
       body: JSON.stringify(body)
-    });
+    }));
     if (!res.ok) throw new Error(`Naver API HTTP ${res.status}`);
     return await res.json();
   } catch (err) {

--- a/src/news/fetchByTicker.js
+++ b/src/news/fetchByTicker.js
@@ -1,23 +1,37 @@
 import { aggregate } from './sentiment.js';
 import { TICKER_MAP } from '../maps.js';
-import { fetchNews, NEWSAPI_KEY } from './apis.js';
+import { fetchNews, fetchNaverTrends, NEWSAPI_KEY } from './apis.js';
+import { withRetry } from '../util/limiter.js';
+
+const UA = 'ddsciencehs-trender/1.0 (+github actions)';
+
+async function naverPopularityScore(name) {
+  if (process.env.SKIP_NAVER === '1') return null;
+  const json = await fetchNaverTrends(name);
+  const series = json?.results?.[0]?.data || [];
+  const last = series.slice(-7).map(d => d.ratio || 0);
+  if (!last.length) return null;
+  const avg = last.reduce((a, b) => a + b, 0) / (7 * 100);
+  return Math.max(0, Math.min(1, avg));
+}
 
 export async function fetchByTicker(symbol, name){
-  const out = { count:0, sentiment:null, top:null };
+  const out = { count:0, sentiment:null, top:null, naverPopularity:null };
   try {
     if (/\.K[QS]$/.test(symbol)) {
       const query = encodeURIComponent(name || symbol);
       const url = `https://news.google.com/rss/search?q=${query}&hl=ko&gl=KR&ceid=KR:ko`;
-      const res = await fetch(url);
+      const res = await withRetry(() => fetch(url, { headers: { 'User-Agent': UA } }));
       const txt = await res.text();
       const titles = Array.from(txt.matchAll(/<title><!\[CDATA\[(.*?)\]\]><\/title>/g)).slice(1).map(m=>m[1]);
       const agg = aggregate(titles, 'kr');
-      return { count: titles.length, sentiment: agg.sentiment, top: agg.top };
+      const pop = await naverPopularityScore(name || symbol);
+      return { count: titles.length, sentiment: agg.sentiment, top: agg.top, naverPopularity: pop };
     } else if (process.env.FINNHUB_API_KEY) {
       const from = new Date(Date.now()-72*3600*1000).toISOString().slice(0,10);
       const to = new Date().toISOString().slice(0,10);
       const url = `https://finnhub.io/api/v1/company-news?symbol=${encodeURIComponent(symbol)}&from=${from}&to=${to}&token=${process.env.FINNHUB_API_KEY}`;
-      const res = await fetch(url);
+      const res = await withRetry(() => fetch(url, { headers: { 'User-Agent': UA } }));
       const data = await res.json();
       const titles = Array.isArray(data) ? data.map(d=>d.headline) : [];
       const agg = aggregate(titles, 'en');

--- a/src/util/limiter.js
+++ b/src/util/limiter.js
@@ -1,0 +1,13 @@
+export const sleep = ms => new Promise(r => setTimeout(r, ms));
+export async function withRetry(fn, { retries = 2, backoff = 400 } = {}) {
+  let err;
+  for (let i = 0; i <= retries; i++) {
+    try {
+      return await fn();
+    } catch (e) {
+      err = e;
+      await sleep(backoff * (i + 1));
+    }
+  }
+  throw err;
+}

--- a/tools/buildPoolsTrendy.js
+++ b/tools/buildPoolsTrendy.js
@@ -7,6 +7,7 @@ import fs from 'fs/promises';
 import { TICKER_MAP } from '../src/maps.js';
 import { getCandles, providerState } from '../src/data/candles.js';
 import { buildUniverse } from '../src/universe/index.js';
+import { buildNewsFeatures } from '../src/news/fetchByTicker.js';
 
 const FINNHUB = process.env.FINNHUB_API_KEY || '';
 const TWELVE = process.env.TWELVEDATA_API_KEY || '';
@@ -18,12 +19,23 @@ const FEEDBACK_FILE = 'feedback.json';
 const NEWS_FEATURES_FILE = 'data/news-features.json';
 
 const MARKETS = ["KOSPI", "KOSDAQ", "S&P 500", "NASDAQ 100"];
-const PICK_COUNT = 5;
+const PICK_COUNT = 12;
 
 let NEWS_FEATURES = {};
 try {
   NEWS_FEATURES = JSON.parse(await fs.readFile(NEWS_FEATURES_FILE, 'utf8'));
 } catch {}
+
+async function enrichWithNewsFeatures(symbols) {
+  const feats = await buildNewsFeatures(symbols);
+  try {
+    await fs.mkdir('data', { recursive: true });
+    await fs.writeFile(NEWS_FEATURES_FILE, JSON.stringify(feats, null, 2));
+  } catch (e) {
+    console.warn('Failed to persist news-features.json:', e.message);
+  }
+  return feats;
+}
 
 // ---- flags
 const ARGS = new Set(process.argv.slice(2));
@@ -180,6 +192,24 @@ function rank01(values) {
 
 function clamp01(x){ return Math.max(0, Math.min(1, x)); }
 
+function namesOnlyRank(universe, features) {
+  const out = {};
+  for (const m of MARKETS) {
+    const names = universe[m] || [];
+    const scored = names.map(n => {
+      const sym = nameToSymbol(n) || n;
+      const nf = features[sym] || {};
+      const count = Math.min(nf.count || 0, 30) / 30;
+      const sentiment = ((nf.sentiment ?? 0) + 1) / 2;
+      const pop = nf.naverPopularity ?? 0;
+      const score = count * 0.12 + (sentiment - 0.5) * 0.08 + (/\.K[QS]$/.test(sym) ? pop * 0.20 : 0);
+      return { name: n, score };
+    }).sort((a,b)=>b.score-a.score).map(s=>s.name);
+    out[m] = { safe: scored.slice(0, PICK_COUNT), aggressive: scored.slice(PICK_COUNT, PICK_COUNT*2) };
+  }
+  return out;
+}
+
 function todayYMD(offsetDays=0){
   const d = new Date(Date.now() + offsetDays*86400000);
   return d.toISOString().slice(0,10);
@@ -304,6 +334,15 @@ async function main(){
 
   const universe = await buildUniverse(pools, { limitPerMarket: Number(process.env.UNIVERSE_LIMIT || 100) });
 
+  const symbolSet = new Set();
+  for (const names of Object.values(universe)) {
+    for (const n of names) {
+      const sym = nameToSymbol(n);
+      if (sym) symbolSet.add(sym);
+    }
+  }
+  NEWS_FEATURES = await enrichWithNewsFeatures(Array.from(symbolSet));
+
   for (const market of MARKETS){
     if (Number.isFinite(MAX_PER_PROVIDER)) {
       for (const s of Object.values(providerState)) s.count = 0;
@@ -340,7 +379,7 @@ async function main(){
       }
       console.log(`[buildPools] ${market} :: ${name} ${route}${routeDetail}`);
 
-      let ret5=null, ret20=null, vol20=null, turnover=null, adv20=null, close=null; let newsCount=0; let sentiment=null; let earn=false; let candles=null;
+      let ret5=null, ret20=null, vol20=null, turnover=null, adv20=null, close=null; let newsCount=0; let sentiment=null; let naverPopularity=0; let earn=false; let candles=null;
       try {
         candles = (sym && budgetOk(REQ_TIMEOUT_MS)) ? await getCandles(sym, { cacheTtlMs: CACHE_TTL_MS, cooloffMs: COOLOFF_MS, maxPerProvider: MAX_PER_PROVIDER }).catch(e => { tripOnError(e); return null; }) : null;
         if (candles && Array.isArray(candles.c) && Array.isArray(candles.v)) {
@@ -351,6 +390,7 @@ async function main(){
         if (nf) {
           newsCount = nf.count || 0;
           sentiment = typeof nf.sentiment === 'number' ? nf.sentiment : null;
+          naverPopularity = typeof nf.naverPopularity === 'number' ? nf.naverPopularity : 0;
         }
         if (FINNHUB && sym && isUS(sym) && budgetOk(REQ_TIMEOUT_MS)) {
           earn   = await finnhubRecentEarnings(sym).catch(e => { tripOnError(e); return false; });
@@ -361,7 +401,7 @@ async function main(){
         tripOnError(e);
       }
 
-      byName[name] = { ret5, ret20, vol20, turnover, adv20, close, newsCount, sentiment, earn, sym, source: candles?.source || null, attempts: candles?.attempts || [], fetchMs: candles?.fetchMs || 0 };
+      byName[name] = { ret5, ret20, vol20, turnover, adv20, close, newsCount, sentiment, naverPopularity, earn, sym, source: candles?.source || null, attempts: candles?.attempts || [], fetchMs: candles?.fetchMs || 0 };
     });
 
     const filteredNames = names.filter(n => {
@@ -379,11 +419,6 @@ async function main(){
     const nRet20  = rank01(filteredNames.map(n => byName[n].ret20));
     const nTurn   = rank01(filteredNames.map(n => byName[n].turnover));
     const nVol    = rank01(filteredNames.map(n => byName[n].vol20));   // higher vol = riskier
-    const nCount  = rank01(filteredNames.map(n => byName[n].newsCount));
-    const newsScoreArr = filteredNames.map((n,i) => {
-      const s = byName[n].sentiment;
-      return typeof s === 'number' ? nCount[i] * s : nCount[i];
-    });
 
     // Scores
     const scoreSafeRaw = {};
@@ -394,11 +429,13 @@ async function main(){
       const isKRName = sym ? isKR(sym) : false;
       const baseKR = isKRName ? 0.05 : 0;
 
-      const ns = newsScoreArr[i];
-      const newsSafe = 0.20 * Math.min(1, ns) * (byName[n].sentiment != null && byName[n].sentiment < 0.5 ? byName[n].sentiment : 1);
-      const newsAggr = 0.20 * Math.min(1, ns);
-      const safe = clamp01(baseKR + 0.40*nRet20[i] + 0.30*(1 - nVol[i]) + newsSafe + 0.10*earnBonus);
-      const aggr = clamp01(baseKR + 0.40*nRet5[i]  + 0.30*nTurn[i]     + 0.20*nVol[i] + newsAggr + earnBonus);
+      const newsCountNorm = Math.min(byName[n].newsCount || 0, 30) / 30;
+      const sentimentNorm = ((byName[n].sentiment ?? 0) + 1) / 2;
+      const pop = byName[n].naverPopularity ?? 0;
+      const newsBoost = newsCountNorm * 0.12 + (sentimentNorm - 0.5) * 0.08 + (isKRName ? pop * 0.20 : 0);
+
+      const safe = clamp01(baseKR + 0.40*nRet20[i] + 0.30*(1 - nVol[i]) + newsBoost + 0.10*earnBonus);
+      const aggr = clamp01(baseKR + 0.40*nRet5[i]  + 0.30*nTurn[i]     + 0.20*nVol[i] + newsBoost + earnBonus);
       scoreSafeRaw[n] = safe;
       scoreAggrRaw[n] = aggr;
     });
@@ -421,11 +458,14 @@ async function main(){
     };
 
     metricsOut[market] = filteredNames.reduce((acc, n, i) => {
+      const newsCountNorm = Math.min(byName[n].newsCount || 0, 30) / 30;
+      const sentimentNorm = ((byName[n].sentiment ?? 0) + 1) / 2;
+      const pop = byName[n].naverPopularity ?? 0;
       acc[n] = {
         ret5: byName[n].ret5, ret20: byName[n].ret20, vol20: byName[n].vol20, turnover: byName[n].turnover,
-        adv20: byName[n].adv20, close: byName[n].close, newsCount: byName[n].newsCount, sentiment: byName[n].sentiment, recentEarnings: byName[n].earn,
+        adv20: byName[n].adv20, close: byName[n].close, newsCount: byName[n].newsCount, sentiment: byName[n].sentiment, naverPopularity: byName[n].naverPopularity, recentEarnings: byName[n].earn,
         source: byName[n].source, attempts: byName[n].attempts, fetchMs: byName[n].fetchMs,
-        norm: { ret5: nRet5[i], ret20: nRet20[i], vol20: nVol[i], turnover: nTurn[i], news: newsScoreArr[i] },
+        norm: { ret5: nRet5[i], ret20: nRet20[i], vol20: nVol[i], turnover: nTurn[i], newsCount: newsCountNorm, sentiment: sentimentNorm, popularity: pop },
         score: { safe: scoreSafe[n], aggressive: scoreAggr[n] }
       };
       return acc;
@@ -467,6 +507,11 @@ async function main(){
   }
   if (avgCoverage < COVERAGE_MIN) {
     console.warn(`[buildPools] low metric coverage (avg=${(avgCoverage*100).toFixed(1)}%), using names-only ranking`);
+    const ranked = namesOnlyRank(universe, NEWS_FEATURES);
+    await writeAtomic(POOLS_FILE, JSON.stringify(ranked, null, 2));
+    await writeAtomic(METRICS_FILE, JSON.stringify(metricsOut, null, 2));
+    console.log('[buildPools] wrote pools.json and pools-metrics.json :: names-only');
+    return;
   }
 
   // Decay feedback periodically


### PR DESCRIPTION
## Summary
- add withRetry limiter utility to standardize fetch retries
- fetch Google/Finnhub/NewsAPI stories and Naver search trends per ticker
- enrich pool builder with news features, popularity scoring, fallback ranking, and larger rotation buckets

## Testing
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68a5152b75dc832abfc65b0347925bb7