### PR TITLE
feat: enhance pool builder with naver signals and offline guard

### DIFF
--- a/src/news/apis.js
+++ b/src/news/apis.js
@@ -58,4 +58,30 @@ export async function fetchNaverTrends(keyword) {
   }
 }
 
+export async function fetchNaverBlogCount(keyword) {
+  if (!NAVER_CLIENT_ID || !NAVER_CLIENT_SECRET) return null;
+  try {
+    const url = `https://openapi.naver.com/v1/search/blog?query=${encodeURIComponent(keyword)}&display=1`;
+    const res = await withRetry(() =>
+      fetchWithTimeout(
+        url,
+        {
+          headers: {
+            'X-Naver-Client-Id': NAVER_CLIENT_ID,
+            'X-Naver-Client-Secret': NAVER_CLIENT_SECRET,
+            'User-Agent': UA
+          }
+        },
+        Number(process.env.REQ_TIMEOUT_MS || 5000)
+      )
+    );
+    if (!res.ok) throw new Error(`Naver Blog API HTTP ${res.status}`);
+    const data = await res.json();
+    return typeof data.total === 'number' ? data.total : null;
+  } catch (err) {
+    console.warn('fetchNaverBlogCount failed', err.message);
+    return null;
+  }
+}
+
 export { NEWSAPI_KEY, NAVER_CLIENT_ID, NAVER_CLIENT_SECRET };

--- a/src/news/fetchByTicker.js
+++ b/src/news/fetchByTicker.js
@@ -1,6 +1,6 @@
 import { aggregate } from './sentiment.js';
 import { TICKER_MAP } from '../maps.js';
-import { fetchNews, fetchNaverTrends, NEWSAPI_KEY } from './apis.js';
+import { fetchNews, fetchNaverTrends, fetchNaverBlogCount, NEWSAPI_KEY } from './apis.js';
 import { withRetry, fetchWithTimeout } from '../util/limiter.js';
 
 const UA = 'ddsciencehs-trender/1.0 (+github actions)';
@@ -15,8 +15,14 @@ async function naverPopularityScore(name) {
   return Math.max(0, Math.min(1, avg));
 }
 
+async function naverBlogMentions(name) {
+  if (process.env.SKIP_NAVER === '1') return null;
+  const total = await fetchNaverBlogCount(name);
+  return total == null ? null : Number(total);
+}
+
 export async function fetchByTicker(symbol, name){
-  const out = { count:0, sentiment:null, top:null, naverPopularity:null };
+  const out = { count:0, sentiment:null, top:null, naverPopularity:null, blogMentions:null };
   try {
     if (/\.K[QS]$/.test(symbol)) {
       const query = encodeURIComponent(name || symbol);
@@ -32,7 +38,8 @@ export async function fetchByTicker(symbol, name){
       const titles = Array.from(txt.matchAll(/<title><!\[CDATA\[(.*?)\]\]><\/title>/g)).slice(1).map(m=>m[1]);
       const agg = aggregate(titles, 'kr');
       const pop = await naverPopularityScore(name || symbol);
-      return { count: titles.length, sentiment: agg.sentiment, top: agg.top, naverPopularity: pop };
+      const blog = await naverBlogMentions(name || symbol);
+      return { count: titles.length, sentiment: agg.sentiment, top: agg.top, naverPopularity: pop, blogMentions: blog };
     } else if (process.env.FINNHUB_API_KEY) {
       const from = new Date(Date.now()-72*3600*1000).toISOString().slice(0,10);
       const to = new Date().toISOString().slice(0,10);

--- a/src/universe/index.js
+++ b/src/universe/index.js
@@ -30,6 +30,12 @@ async function fmpActives(exchange){
 
 const SP_MEGA = ['AAPL','MSFT','NVDA','AMZN','META','GOOGL','TSLA','BRK-B','JNJ','PG','V','KO','JPM','UNH','LLY'];
 const ETF_LIST = ['SPY','QQQ','XLK','XLF','ARKK'];
+const EXTRA_TICKERS = {
+  KOSPI: (process.env.EXTRA_TICKERS_KOSPI || '').split(',').map(t=>t.trim()).filter(Boolean),
+  KOSDAQ: (process.env.EXTRA_TICKERS_KOSDAQ || '').split(',').map(t=>t.trim()).filter(Boolean),
+  'S&P 500': (process.env.EXTRA_TICKERS_SP500 || '').split(',').map(t=>t.trim()).filter(Boolean),
+  'NASDAQ 100': (process.env.EXTRA_TICKERS_NASDAQ100 || '').split(',').map(t=>t.trim()).filter(Boolean)
+};
 
 export async function buildUniverse(basePools={}, {limitPerMarket=60}={}){
   const out = {};
@@ -67,6 +73,7 @@ export async function buildUniverse(basePools={}, {limitPerMarket=60}={}){
         if (INCLUDE_ETFS) tickers.push(...ETF_LIST);
       }
     } catch {}
+    tickers.push(...(EXTRA_TICKERS[m] || []));
     for (const t of tickers){
       const sym = t;
       if (seen.has(sym)) continue;

--- a/tools/buildPoolsTrendy.js
+++ b/tools/buildPoolsTrendy.js
@@ -381,7 +381,9 @@ async function main(){
   const metricsOut = {};
   const marketCoverage = {};
 
-  const universe = await buildUniverse(pools, { limitPerMarket: Number(process.env.UNIVERSE_LIMIT || 100) });
+  const universe = OFFLINE
+    ? Object.fromEntries(MARKETS.map(m => [m, Array.from(new Set([...(pools[m]?.safe || []), ...(pools[m]?.aggressive || [])]))]))
+    : await buildUniverse(pools, { limitPerMarket: Number(process.env.UNIVERSE_LIMIT || 100) });
 
   const symbolSet = new Set();
   for (const names of Object.values(universe)) {
@@ -390,7 +392,11 @@ async function main(){
       if (sym) symbolSet.add(sym);
     }
   }
-  NEWS_FEATURES = await enrichWithNewsFeatures(Array.from(symbolSet));
+  if (!OFFLINE) {
+    NEWS_FEATURES = await enrichWithNewsFeatures(Array.from(symbolSet));
+  } else {
+    console.warn('[buildPools] offline mode, using cached news features');
+  }
   const prevPools = await readPrevPools();
 
   for (const market of MARKETS){
@@ -429,7 +435,7 @@ async function main(){
       }
       console.log(`[buildPools] ${market} :: ${name} ${route}${routeDetail}`);
 
-      let ret5=null, ret20=null, vol20=null, turnover=null, adv20=null, close=null; let newsCount=0; let sentiment=null; let naverPopularity=0; let earn=false; let candles=null;
+      let ret5=null, ret20=null, vol20=null, turnover=null, adv20=null, close=null; let newsCount=0; let sentiment=null; let naverPopularity=0; let blogMentions=0; let earn=false; let candles=null;
       try {
         candles = (sym && budgetOk(REQ_TIMEOUT_MS)) ? await getCandles(sym, { cacheTtlMs: CACHE_TTL_MS, cooloffMs: COOLOFF_MS, maxPerProvider: MAX_PER_PROVIDER }).catch(e => { tripOnError(e); return null; }) : null;
         if (candles && Array.isArray(candles.c) && Array.isArray(candles.v)) {
@@ -441,6 +447,7 @@ async function main(){
           newsCount = nf.count || 0;
           sentiment = typeof nf.sentiment === 'number' ? nf.sentiment : null;
           naverPopularity = typeof nf.naverPopularity === 'number' ? nf.naverPopularity : 0;
+          blogMentions = typeof nf.blogMentions === 'number' ? nf.blogMentions : 0;
         }
         if (FINNHUB && sym && isUS(sym) && budgetOk(REQ_TIMEOUT_MS)) {
           earn   = await finnhubRecentEarnings(sym).catch(e => { tripOnError(e); return false; });
@@ -451,7 +458,7 @@ async function main(){
         tripOnError(e);
       }
 
-      byName[name] = { ret5, ret20, vol20, turnover, adv20, close, newsCount, sentiment, naverPopularity, earn, sym: sym || null, source: candles?.source || null, attempts: candles?.attempts || [], fetchMs: candles?.fetchMs || 0 };
+      byName[name] = { ret5, ret20, vol20, turnover, adv20, close, newsCount, sentiment, naverPopularity, blogMentions, earn, sym: sym || null, source: candles?.source || null, attempts: candles?.attempts || [], fetchMs: candles?.fetchMs || 0 };
     });
     const filteredNames = names.filter(n => {
       const m = byName[n];
@@ -467,6 +474,7 @@ async function main(){
     const nRet20  = rank01(filteredNames.map(n => byName[n].ret20));
     const nTurn   = rank01(filteredNames.map(n => byName[n].turnover));
     const nVol    = rank01(filteredNames.map(n => byName[n].vol20));   // higher vol = riskier
+    const nBlog   = rank01(filteredNames.map(n => byName[n].blogMentions));
 
     // Scores
     const scoreSafeRaw = {};
@@ -480,7 +488,8 @@ async function main(){
       const newsCountNorm = Math.min(byName[n].newsCount || 0, 30) / 30;
       const sentimentNorm = ((byName[n].sentiment ?? 0) + 1) / 2;
       const pop = byName[n].naverPopularity ?? 0;
-      const newsBoost = newsCountNorm * 0.12 + (sentimentNorm - 0.5) * 0.08 + (isKRName ? pop * 0.20 : 0);
+      const blogNorm = nBlog[i];
+      const newsBoost = newsCountNorm * 0.12 + (sentimentNorm - 0.5) * 0.08 + (isKRName ? pop * 0.20 : 0) + blogNorm * 0.05;
 
       const safe = clamp01(baseKR + 0.40*nRet20[i] + 0.30*(1 - nVol[i]) + newsBoost + 0.10*earnBonus);
       const aggr = clamp01(baseKR + 0.40*nRet5[i]  + 0.30*nTurn[i]     + 0.20*nVol[i] + newsBoost + earnBonus);
@@ -494,8 +503,12 @@ async function main(){
 
     // Pick top K distinct names for each bucket
     const total = filteredNames.length;
-    const kSafe = Math.min(8, Math.ceil(total * 0.7));
-    const kAggr = Math.min(4, Math.max(0, total - kSafe));
+    let kSafe = Math.min(6, Math.ceil(total * 0.5));
+    let kAggr = Math.min(6, total - kSafe);
+    if (total >= 2 && kAggr === 0) {
+      kAggr = 1;
+      if (kSafe > 0) kSafe = Math.min(kSafe, total - kAggr);
+    }
 
     function topK(scores, k){
       return Object.entries(scores).sort((a,b)=>b[1]-a[1]).slice(0,k).map(([n])=>n);
@@ -536,11 +549,12 @@ async function main(){
       const newsCountNorm = Math.min(byName[n].newsCount || 0, 30) / 30;
       const sentimentNorm = ((byName[n].sentiment ?? 0) + 1) / 2;
       const pop = byName[n].naverPopularity ?? 0;
+      const blogNorm = nBlog[i];
       acc[n] = {
         ret5: byName[n].ret5, ret20: byName[n].ret20, vol20: byName[n].vol20, turnover: byName[n].turnover,
-        adv20: byName[n].adv20, close: byName[n].close, newsCount: byName[n].newsCount, sentiment: byName[n].sentiment, naverPopularity: byName[n].naverPopularity, recentEarnings: byName[n].earn,
+        adv20: byName[n].adv20, close: byName[n].close, newsCount: byName[n].newsCount, sentiment: byName[n].sentiment, naverPopularity: byName[n].naverPopularity, blogMentions: byName[n].blogMentions, recentEarnings: byName[n].earn,
         source: byName[n].source, attempts: byName[n].attempts, fetchMs: byName[n].fetchMs,
-        norm: { ret5: nRet5[i], ret20: nRet20[i], vol20: nVol[i], turnover: nTurn[i], newsCount: newsCountNorm, sentiment: sentimentNorm, popularity: pop },
+        norm: { ret5: nRet5[i], ret20: nRet20[i], vol20: nVol[i], turnover: nTurn[i], newsCount: newsCountNorm, sentiment: sentimentNorm, popularity: pop, blogMentions: blogNorm },
         score: { safe: scoreSafe[n], aggressive: scoreAggr[n] }
       };
       return acc;


### PR DESCRIPTION
## Summary
- harden buildPoolsTrendy offline path and enforce at least one aggressive pick
- incorporate Naver Data Lab & blog search metrics to boost scoring
- allow ticker universe expansion via EXTRA_TICKERS_* env vars

## Testing
- `node tests/apple_association.test.js`
- `node tools/buildPoolsTrendy.js --offline`


------
https://chatgpt.com/codex/tasks/task_b_68a5dbd176a0832a83400c84ef8b0ad5