### PR TITLE
Add AdSense integration and ads.txt

### DIFF
--- a/ads.txt
+++ b/ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-3360521146359419, DIRECT, f08c47fec0942fa0

--- a/appdownload.html
+++ b/appdownload.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-3360521146359419" crossorigin="anonymous"></script>
+    <meta name="google-adsense-account" content="ca-pub-3360521146359419">
+
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Manage Students App</title>

--- a/appdownloadGS.html
+++ b/appdownloadGS.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-3360521146359419" crossorigin="anonymous"></script>
+    <meta name="google-adsense-account" content="ca-pub-3360521146359419">
+
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Gridlock Shooter</title>

--- a/appdownloadLFE.html
+++ b/appdownloadLFE.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-3360521146359419" crossorigin="anonymous"></script>
+    <meta name="google-adsense-account" content="ca-pub-3360521146359419">
+
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Log for Everything</title>

--- a/cardbenefitapp.html
+++ b/cardbenefitapp.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-3360521146359419" crossorigin="anonymous"></script>
+    <meta name="google-adsense-account" content="ca-pub-3360521146359419">
+
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Privacy Policy - Card Benefits</title>

--- a/index.html
+++ b/index.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-3360521146359419" crossorigin="anonymous"></script>
+    <meta name="google-adsense-account" content="ca-pub-3360521146359419">
+
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Singaseong Apps - Mobile App Development</title>

--- a/logforeverything.html
+++ b/logforeverything.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-3360521146359419" crossorigin="anonymous"></script>
+    <meta name="google-adsense-account" content="ca-pub-3360521146359419">
+
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Privacy Policy - Log For Everything</title>

--- a/privacy_policy.html
+++ b/privacy_policy.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="ko">
 <head>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-3360521146359419" crossorigin="anonymous"></script>
+    <meta name="google-adsense-account" content="ca-pub-3360521146359419">
+
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>개인정보처리방침</title>

--- a/privacy_policy_gs.html
+++ b/privacy_policy_gs.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-3360521146359419" crossorigin="anonymous"></script>
+    <meta name="google-adsense-account" content="ca-pub-3360521146359419">
+
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Privacy Policy - Gridlock Shooter</title>

--- a/privacy_policy_ms.html
+++ b/privacy_policy_ms.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-3360521146359419" crossorigin="anonymous"></script>
+    <meta name="google-adsense-account" content="ca-pub-3360521146359419">
+
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Privacy Policy - Manage Students</title>

--- a/privacy_policy_ms_kr.html
+++ b/privacy_policy_ms_kr.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="ko">
 <head>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-3360521146359419" crossorigin="anonymous"></script>
+    <meta name="google-adsense-account" content="ca-pub-3360521146359419">
+
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>개인정보처리방침 - 학생 관리</title>

--- a/seongsigan/dongsin1-2.html
+++ b/seongsigan/dongsin1-2.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="ko">
 <head>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-3360521146359419" crossorigin="anonymous"></script>
+    <meta name="google-adsense-account" content="ca-pub-3360521146359419">
+
   <meta charset="UTF-8" />
   <title>1-2반 2학기 시간표</title>
   <link rel="icon" type="image/png" sizes="32x32" href="../src/favicon-32x32.png">

--- a/seongsigan/readme.html
+++ b/seongsigan/readme.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="ko">
 <head>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-3360521146359419" crossorigin="anonymous"></script>
+    <meta name="google-adsense-account" content="ca-pub-3360521146359419">
+
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>SeongSigan - 개요</title>

--- a/seongsigan/seongsigan.html
+++ b/seongsigan/seongsigan.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="ko">
 <head>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-3360521146359419" crossorigin="anonymous"></script>
+    <meta name="google-adsense-account" content="ca-pub-3360521146359419">
+
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>SeongSigan</title>

--- a/src/template.html
+++ b/src/template.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="ko">
 <head>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-3360521146359419" crossorigin="anonymous"></script>
+    <meta name="google-adsense-account" content="ca-pub-3360521146359419">
+
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title data-i18n="title">데일리 주식 리포트 자동화</title>

--- a/stocks.html
+++ b/stocks.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="ko">
 <head>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-3360521146359419" crossorigin="anonymous"></script>
+    <meta name="google-adsense-account" content="ca-pub-3360521146359419">
+
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title data-i18n="title">데일리 주식 리포트 자동화</title>

--- a/stocks_ex.html
+++ b/stocks_ex.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="ko">
 <head>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-3360521146359419" crossorigin="anonymous"></script>
+    <meta name="google-adsense-account" content="ca-pub-3360521146359419">
+
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>한국 시장 종목 선정 로직</title>

--- a/voice-hotkey/index.html
+++ b/voice-hotkey/index.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-3360521146359419" crossorigin="anonymous"></script>
+    <meta name="google-adsense-account" content="ca-pub-3360521146359419">
+
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>voice to keys</title>


### PR DESCRIPTION
## Summary
- inject Google AdSense script and account meta tag into site HTML pages
- add ads.txt for AdSense verification

## Testing
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68a7103292b0832aa0796ea41d28d3bc