### PR TITLE
feat: add KOTRA news backup

### DIFF
--- a/.github/workflows/stock-recs.yml
+++ b/.github/workflows/stock-recs.yml
@@ -29,6 +29,9 @@ jobs:
       # GitHub often has flaky access to Naver; feel free to unset.
       SKIP_NAVER: "0"
       IS_CRON: ${{ github.event_name == 'schedule' }}
+      # Use the portal key for KOTRA + (optionally KRX if you share it)
+      DATA_API_KEY: ${{ secrets.KRX_API_KEY }}
+      USE_KOTRA_BACKUP: "1"
 
       # Optional: hybrid remote cache (leave empty if not used)
       # REMOTE_URL: ${{ secrets.REMOTE_URL }}   # e.g. public GET or signed GET to last-good recommendations.json

--- a/fetchNews.js
+++ b/fetchNews.js
@@ -5,6 +5,7 @@ import { XMLParser } from 'fast-xml-parser';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { nowKSTISO } from './utils/time.js';
+import { fetchKotraOverseasRecent } from './src/news/kotraOverseas.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -101,7 +102,29 @@ async function gather() {
 }
 
 async function main() {
-  const items = await gather();
+  let items = await gather();
+  const NEED_BACKUP = process.env.USE_KOTRA_BACKUP === "1" && (!items?.length || items.length < 12);
+  if (NEED_BACKUP) {
+    try {
+      const kotraRaw = await fetchKotraOverseasRecent(2, 50);
+      const kotra = kotraRaw.map(it => ({ title: it.title, link: it.url })).filter(it => it.link);
+      const combined = [...(items || []), ...kotra];
+      const seen = new Set();
+      const deduped = [];
+      for (const it of combined) {
+        const key = it.link || it.title;
+        const key2 = it.title;
+        if (seen.has(key) || seen.has(key2)) continue;
+        seen.add(key);
+        seen.add(key2);
+        deduped.push(it);
+      }
+      items = deduped.slice(0, 120);
+      console.log(`[kotra-backup] merged ${kotra.length} items (recent overseas market news)`);
+    } catch (e) {
+      console.error('[kotra-backup] failed:', e.message);
+    }
+  }
   if (!items.length) throw new Error('No news items after filtering');
   const out = { lastUpdated: nowKSTISO(), items };
   await fs.writeFile(OUT_FILE, JSON.stringify(out, null, 2));

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "dependencies": {
         "cheerio": "^1.0.0",
-        "fast-xml-parser": "^5.2.5"
+        "fast-xml-parser": "^5.2.5",
+        "node-fetch": "^3.3.2"
       },
       "engines": {
         "node": ">=18"
@@ -89,6 +90,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/dom-serializer": {
@@ -189,6 +199,41 @@
         "fxparser": "src/cli/cli.js"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/htmlparser2": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
@@ -230,6 +275,44 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/nth-check": {
@@ -318,6 +401,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/whatwg-encoding": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "fast-xml-parser": "^5.2.5",
-    "cheerio": "^1.0.0"
+    "cheerio": "^1.0.0",
+    "node-fetch": "^3.3.2"
   }
 }

--- a/src/data/krxDirectory.js
+++ b/src/data/krxDirectory.js
@@ -1,0 +1,42 @@
+import fetch from "node-fetch";
+
+const KRX_BASE = "https://apis.data.go.kr/1160100/service/GetKrxListedInfoService/getItemInfo";
+
+function key() {
+  const k = process.env.DATA_API_KEY;
+  if (!k) throw new Error("DATA_API_KEY missing");
+  return encodeURIComponent(k);
+}
+
+async function fetchPage(pageNo = 1, numOfRows = 1000) {
+  const qs = new URLSearchParams({
+    serviceKey: key(),
+    resultType: "json",
+    pageNo: String(pageNo),
+    numOfRows: String(numOfRows),
+  });
+  const res = await fetch(`${KRX_BASE}?${qs.toString()}`);
+  if (!res.ok) throw new Error(`KRX HTTP ${res.status}`);
+  const j = await res.json();
+  const body = j?.response?.body || {};
+  const items = body?.items?.item || [];
+  return Array.isArray(items) ? items : (items ? [items] : []);
+}
+
+let CACHE = null;
+export async function getCompanyNameByYahooSymbol(symbol) {
+  // Expect symbols like 005930.KS / 035720.KQ
+  const code6 = (symbol || "").split(".")[0];
+  if (!code6) return null;
+  if (!CACHE) {
+    // In practice, 1–2 pages covers >1k rows; loop as needed.
+    const page1 = await fetchPage(1, 1000);
+    CACHE = page1.map(it => ({
+      code: String(it?.ISU_SRT_CD || it?.itmsCd || "").padStart(6, "0"),
+      name: it?.ITM_NM || it?.itmsNm || "",
+    })).filter(x => x.code && x.name);
+  }
+  const hit = CACHE.find(x => x.code === code6);
+  return hit?.name || null; // Korean name (best for KOTRA search)
+}
+

--- a/src/news/fetchByTicker.js
+++ b/src/news/fetchByTicker.js
@@ -2,6 +2,7 @@ import { aggregate } from './sentiment.js';
 import { TICKER_MAP } from '../maps.js';
 import { fetchNews, fetchNaverTrends, fetchNaverBlogCount, NEWSAPI_KEY } from './apis.js';
 import { withRetry, fetchWithTimeout } from '../util/limiter.js';
+import { getTickerArticlesBackup } from './fetchByTicker.kotraBackup.js';
 
 const UA = 'ddsciencehs-trender/1.0 (+github actions)';
 
@@ -24,6 +25,8 @@ async function naverBlogMentions(name) {
 export async function fetchByTicker(symbol, name){
   const out = { count:0, sentiment:null, top:null, naverPopularity:null, blogMentions:null };
   try {
+    let titles = [];
+    let lang = 'en';
     if (/\.K[QS]$/.test(symbol)) {
       const query = encodeURIComponent(name || symbol);
       const url = `https://news.google.com/rss/search?q=${query}&hl=ko&gl=KR&ceid=KR:ko`;
@@ -35,11 +38,8 @@ export async function fetchByTicker(symbol, name){
         )
       );
       const txt = await res.text();
-      const titles = Array.from(txt.matchAll(/<title><!\[CDATA\[(.*?)\]\]><\/title>/g)).slice(1).map(m=>m[1]);
-      const agg = aggregate(titles, 'kr');
-      const pop = await naverPopularityScore(name || symbol);
-      const blog = await naverBlogMentions(name || symbol);
-      return { count: titles.length, sentiment: agg.sentiment, top: agg.top, naverPopularity: pop, blogMentions: blog };
+      titles = Array.from(txt.matchAll(/<title><!\[CDATA\[(.*?)\]\]><\/title>/g)).slice(1).map(m=>m[1]);
+      lang = 'kr';
     } else if (process.env.FINNHUB_API_KEY) {
       const from = new Date(Date.now()-72*3600*1000).toISOString().slice(0,10);
       const to = new Date().toISOString().slice(0,10);
@@ -52,16 +52,46 @@ export async function fetchByTicker(symbol, name){
         )
       );
       const data = await res.json();
-      const titles = Array.isArray(data) ? data.map(d=>d.headline) : [];
-      const agg = aggregate(titles, 'en');
-      return { count: titles.length, sentiment: agg.sentiment, top: agg.top };
+      titles = Array.isArray(data) ? data.map(d=>d.headline) : [];
     } else if (NEWSAPI_KEY) {
       const data = await fetchNews(name || symbol);
-      const titles = Array.isArray(data?.articles) ? data.articles.map(a => a.title) : [];
-      const agg = aggregate(titles, 'en');
+      titles = Array.isArray(data?.articles) ? data.articles.map(a => a.title) : [];
+    }
+
+    if (!titles.length && process.env.USE_KOTRA_BACKUP === '1') {
+      try {
+        const backup = await getTickerArticlesBackup(symbol);
+        titles = backup.map(x => x.title);
+        if (titles.length) console.log(`[kotra-backup] ${symbol}: ${titles.length} items from KOTRA`);
+      } catch (e) {
+        console.error(`[kotra-backup] ${symbol} backup failed:`, e.message);
+      }
+    }
+
+    if (titles.length) {
+      const agg = aggregate(titles, lang);
+      if (/\.K[QS]$/.test(symbol)) {
+        const pop = await naverPopularityScore(name || symbol);
+        const blog = await naverBlogMentions(name || symbol);
+        return { count: titles.length, sentiment: agg.sentiment, top: agg.top, naverPopularity: pop, blogMentions: blog };
+      }
       return { count: titles.length, sentiment: agg.sentiment, top: agg.top };
     }
-  } catch {}
+  } catch (e) {
+    console.error(`[news] primary failed for ${symbol}:`, e.message);
+    if (process.env.USE_KOTRA_BACKUP === '1') {
+      try {
+        const backup = await getTickerArticlesBackup(symbol);
+        const titles = backup.map(x => x.title);
+        if (titles.length) {
+          const agg = aggregate(titles, /\.K[QS]$/.test(symbol)?'kr':'en');
+          return { count: titles.length, sentiment: agg.sentiment, top: agg.top };
+        }
+      } catch (e2) {
+        console.error(`[kotra-backup] ${symbol} backup failed:`, e2.message);
+      }
+    }
+  }
   return out;
 }
 

--- a/src/news/fetchByTicker.kotraBackup.js
+++ b/src/news/fetchByTicker.kotraBackup.js
@@ -1,0 +1,14 @@
+import { fetchKotraOverseasRecent, filterByKeyword } from "./kotraOverseas.js";
+import { getCompanyNameByYahooSymbol } from "../data/krxDirectory.js";
+
+// When the primary fetch returns nothing for a ticker,
+// grab recent KOTRA items and keyword-match by company name.
+export async function getTickerArticlesBackup(ticker) {
+  const name = await getCompanyNameByYahooSymbol(ticker);
+  if (!name) return [];
+  const recent = await fetchKotraOverseasRecent(3, 50); // ~150 latest
+  // very light heuristic: title OR summary contains company name
+  const filtered = filterByKeyword(recent, name);
+  return filtered.slice(0, 20); // cap for speed
+}
+

--- a/src/news/kotraOverseas.js
+++ b/src/news/kotraOverseas.js
@@ -1,0 +1,85 @@
+// KOTRA Overseas Market News (backup)
+// Endpoint (as provided):
+// https://apis.data.go.kr/B410001/kotra_overseasMarketNews/ovseaMrktNews/ovseaMrktNews
+// Required query: serviceKey, numOfRows, pageNo
+// Response shape (simplified):
+// { response: { header:{resultCode,resultMsg}, body:{ totalCnt, pageNo, itemList:{ item: [...] }, numOfRows } } }
+
+import fetch from "node-fetch";
+
+const BASE = "https://apis.data.go.kr/B410001/kotra_overseasMarketNews/ovseaMrktNews/ovseaMrktNews";
+
+function apiKey() {
+  const k = process.env.DATA_API_KEY;
+  if (!k) throw new Error("DATA_API_KEY missing");
+  return encodeURIComponent(k); // safe for decoded/encoded
+}
+
+function toISO(d) {
+  try { return new Date(d).toISOString(); } catch { return new Date().toISOString(); }
+}
+
+// Normalize one raw item to your site/news shape
+function normalizeOne(it) {
+  return {
+    title: it?.newsTitl || "(no title)",
+    url: it?.kotraNewsUrl || "",
+    source: "KOTRA 해외시장뉴스",
+    // Provided example had othbcDt like "2024-09-04" (string). Convert to ISO.
+    publishedAt: toISO(it?.othbcDt || Date.now()),
+    summary: it?.cntntSumar || "",
+    region: it?.regn || "",
+    country: it?.natn || "",
+  };
+}
+
+function dedupeByUrl(arr) {
+  const seen = new Set();
+  return arr.filter(x => {
+    const k = (x.url || "").trim().toLowerCase();
+    if (!k || seen.has(k)) return false;
+    seen.add(k);
+    return true;
+  });
+}
+
+// Fetch a single page (default larger page to reduce calls)
+export async function fetchKotraOverseasPage({ pageNo = 1, numOfRows = 50 } = {}) {
+  const qs = new URLSearchParams({
+    serviceKey: apiKey(),
+    numOfRows: String(numOfRows),
+    pageNo: String(pageNo),
+  });
+  const url = `${BASE}?${qs.toString()}`;
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`KOTRA HTTP ${res.status}`);
+  const json = await res.json();
+
+  const ok = json?.response?.header?.resultCode === "00";
+  if (!ok) return [];
+
+  const raw = json?.response?.body?.itemList?.item ?? [];
+  const list = Array.isArray(raw) ? raw : (raw ? [raw] : []);
+  return list.map(normalizeOne).filter(x => x.url);
+}
+
+// Pull a few recent pages and merge
+export async function fetchKotraOverseasRecent(pages = 2, pageSize = 50) {
+  const batches = [];
+  for (let p = 1; p <= pages; p++) {
+    batches.push(fetchKotraOverseasPage({ pageNo: p, numOfRows: pageSize }));
+  }
+  const results = (await Promise.all(batches)).flat();
+  return dedupeByUrl(results).slice(0, pages * pageSize);
+}
+
+// Very light keyword filter (used for per-ticker backup)
+export function filterByKeyword(items, keyword) {
+  if (!keyword) return [];
+  const kw = String(keyword).trim();
+  return items.filter(x =>
+    (x.title && x.title.includes(kw)) ||
+    (x.summary && x.summary.includes(kw))
+  );
+}
+


### PR DESCRIPTION
## Summary
- expose DATA_API_KEY and USE_KOTRA_BACKUP in stock recommendations workflow
- add KOTRA overseas news client and KRX directory helper
- fall back to KOTRA headlines when RSS data is missing
- use KOTRA articles as backup for per-ticker news

## Testing
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68ac5e808c7c832a9ca2c8f0c2b781b9