### PR TITLE
fix data API key handling and KRX/KOTRA fetchers

### DIFF
--- a/.github/workflows/stock-recs.yml
+++ b/.github/workflows/stock-recs.yml
@@ -31,9 +31,9 @@ jobs:
       IS_CRON: ${{ github.event_name == 'schedule' }}
       # FX backup via Korea Eximbank (oapi.koreaexim.go.kr)
       USE_EXIM_FX_BACKUP: "1"
-      EXIM_AUTH_KEY: ${{ secrets.KRX_API_KEY }}  # <- you stored FNOdFh... under KRX_API_KEY
+      EXIM_AUTH_KEY: ${{ secrets.EXIM_AUTH_KEY }}   # Exim
       # Use the portal key for KOTRA + (optionally KRX if you share it)
-      DATA_API_KEY: ${{ secrets.KRX_API_KEY }}
+      DATA_API_KEY: ${{ secrets.DATA_API_KEY }}     # data.go.kr (KRX & KOTRA)
       USE_KOTRA_BACKUP: "1"
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/src/data/krxDirectory.js
+++ b/src/data/krxDirectory.js
@@ -1,42 +1,73 @@
 import fetch from "node-fetch";
+import fs from "fs/promises";
 
 const KRX_BASE = "https://apis.data.go.kr/1160100/service/GetKrxListedInfoService/getItemInfo";
 
-function key() {
+function portalKeyRaw() {
   const k = process.env.DATA_API_KEY;
   if (!k) throw new Error("DATA_API_KEY missing");
-  return encodeURIComponent(k);
+  return k; // RAW decoded key (no manual encode)
 }
 
-async function fetchPage(pageNo = 1, numOfRows = 1000) {
+async function fetchKrxPage(pageNo = 1, numOfRows = 1000) {
   const qs = new URLSearchParams({
-    serviceKey: key(),
+    serviceKey: portalKeyRaw(),
     resultType: "json",
     pageNo: String(pageNo),
     numOfRows: String(numOfRows),
   });
-  const res = await fetch(`${KRX_BASE}?${qs.toString()}`);
-  if (!res.ok) throw new Error(`KRX HTTP ${res.status}`);
-  const j = await res.json();
+  const url = `${KRX_BASE}?${qs.toString()}`;
+  const res = await fetch(url, { headers: { Accept: "application/json" } });
+  const text = await res.text();
+  let j;
+  try { j = JSON.parse(text); }
+  catch {
+    throw new Error(`KRX non-JSON response (first 60 chars): ${text.slice(0,60)}`);
+  }
   const body = j?.response?.body || {};
   const items = body?.items?.item || [];
   return Array.isArray(items) ? items : (items ? [items] : []);
 }
 
-let CACHE = null;
-export async function getCompanyNameByYahooSymbol(symbol) {
-  // Expect symbols like 005930.KS / 035720.KQ
-  const code6 = (symbol || "").split(".")[0];
-  if (!code6) return null;
-  if (!CACHE) {
-    // In practice, 1–2 pages covers >1k rows; loop as needed.
-    const page1 = await fetchPage(1, 1000);
-    CACHE = page1.map(it => ({
-      code: String(it?.ISU_SRT_CD || it?.itmsCd || "").padStart(6, "0"),
-      name: it?.ITM_NM || it?.itmsNm || "",
-    })).filter(x => x.code && x.name);
-  }
-  const hit = CACHE.find(x => x.code === code6);
-  return hit?.name || null; // Korean name (best for KOTRA search)
+let _dirCachePromise;
+export async function getKrxDirectory() {
+  if (_dirCachePromise) return _dirCachePromise;
+  _dirCachePromise = (async () => {
+    const maxTries = 3;
+    for (let i = 1; i <= maxTries; i++) {
+      try {
+        const page1 = await fetchKrxPage(1, 1000);
+        return page1.map(it => ({
+          code: String(it?.ISU_SRT_CD || it?.itmsCd || "").padStart(6, "0"),
+          name: it?.ITM_NM || it?.itmsNm || "",
+        })).filter(x => x.code && x.name);
+      } catch (e) {
+        console.error(`[KRX] attempt ${i} failed:`, e.message);
+        if (i === maxTries) throw e;
+        await new Promise(r => setTimeout(r, i * 1000));
+      }
+    }
+  })();
+  return _dirCachePromise;
 }
 
+async function tryLocalName(symbol) {
+  const files = ["ticker-cache.json", "pools.json", "recommendations.json"];
+  for (const f of files) {
+    try {
+      const s = await fs.readFile(f, "utf8");
+      const j = JSON.parse(s);
+      const n = j?.[symbol]?.name || j?.tickers?.[symbol]?.name;
+      if (n) return n;
+    } catch {}
+  }
+  return null;
+}
+
+export async function getCompanyNameByYahooSymbol(symbol) {
+  const local = await tryLocalName(symbol);
+  if (local) return local;
+  const dir = await getKrxDirectory();
+  const code6 = (symbol || "").split(".")[0];
+  return dir.find(x => x.code === code6)?.name || null;
+}

--- a/src/news/kotraOverseas.js
+++ b/src/news/kotraOverseas.js
@@ -9,10 +9,10 @@ import fetch from "node-fetch";
 
 const BASE = "https://apis.data.go.kr/B410001/kotra_overseasMarketNews/ovseaMrktNews/ovseaMrktNews";
 
-function apiKey() {
+function apiKeyRaw() {
   const k = process.env.DATA_API_KEY;
   if (!k) throw new Error("DATA_API_KEY missing");
-  return encodeURIComponent(k); // safe for decoded/encoded
+  return k; // RAW
 }
 
 function toISO(d) {
@@ -46,7 +46,7 @@ function dedupeByUrl(arr) {
 // Fetch a single page (default larger page to reduce calls)
 export async function fetchKotraOverseasPage({ pageNo = 1, numOfRows = 50 } = {}) {
   const qs = new URLSearchParams({
-    serviceKey: apiKey(),
+    serviceKey: apiKeyRaw(),
     numOfRows: String(numOfRows),
     pageNo: String(pageNo),
   });


### PR DESCRIPTION
## Summary
- use dedicated EXIM_AUTH_KEY and DATA_API_KEY secrets in stock-recs workflow
- drop manual encoding for DATA_API_KEY in KOTRA client
- refactor KRX directory fetcher: no double encoding, better error handling, retries, and local cache

## Testing
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68ac6fd9fa1c832aaed2c4bedb9eff88