### PR TITLE
chore: add fx verification in workflow

### DIFF
--- a/.github/workflows/stock-recs.yml
+++ b/.github/workflows/stock-recs.yml
@@ -200,10 +200,15 @@ jobs:
         run: |
           set -Eeuo pipefail
           node fetchFxRates.js
-          test -s data/fx_rates.json
-          echo "fx_rates lastUpdated:"
-          node -e "console.log(require('./data/fx_rates.json').lastUpdated || 'missing')"
-          echo "--- git status/diff (fx_rates) ---"
+
+      - name: Verify fx_rates has lastUpdated
+        run: |
+          test -f data/fx_rates.json
+          node -e "const j=require('./data/fx_rates.json'); if(!j.lastUpdated){console.error('ERROR: lastUpdated missing (fx_rates)'); process.exit(1)} console.log('fx_rates lastUpdated:', j.lastUpdated)"
+          head -n 20 data/fx_rates.json
+
+      - name: Show git status for fx_rates
+        run: |
           git status --porcelain -- data/fx_rates.json || true
           git --no-pager diff -- data/fx_rates.json | sed -n '1,80p' || true
 
@@ -231,7 +236,6 @@ jobs:
             data/fx_rates.json
             stocks.html
             src/template.html
-          add_options: '-A'
 
       - name: "Show last commit (debug)"
         if: always()


### PR DESCRIPTION
## Summary
- add separate FX rate verification and diff steps
- remove auto-commit -A option

## Testing
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68ac7a967794832a8edf144b3a3e40aa