### PR TITLE
Link recommended stock names to news search URLs

### DIFF
--- a/src/template.html
+++ b/src/template.html
@@ -423,8 +423,9 @@
         for (const bucket of ['safe', 'aggressive']) {
           const itemsArr = (info?.[bucket] || []).map(item => {
             const name = FULL_NAME_MAP[item.name] || item.name;
+            const link = item.searchUrl ? `<a href="${item.searchUrl}" target="_blank" rel="noopener">${name}</a>` : name;
             const sector = item.sector ? `<span class="sector">${item.sector}</span>` : '';
-            return `<li>${name}${sector}</li>`;
+            return `<li>${link}${sector}</li>`;
           });
           const list = itemsArr.length ? itemsArr.join('') : `<li class="empty">${translations[currentLang].noPicks}</li>`;
           const label = bucket === 'safe' ? translations[currentLang].safe : translations[currentLang].aggressive;

--- a/stocks.html
+++ b/stocks.html
@@ -423,8 +423,9 @@
         for (const bucket of ['safe', 'aggressive']) {
           const itemsArr = (info?.[bucket] || []).map(item => {
             const name = FULL_NAME_MAP[item.name] || item.name;
+            const link = item.searchUrl ? `<a href="${item.searchUrl}" target="_blank" rel="noopener">${name}</a>` : name;
             const sector = item.sector ? `<span class="sector">${item.sector}</span>` : '';
-            return `<li>${name}${sector}</li>`;
+            return `<li>${link}${sector}</li>`;
           });
           const list = itemsArr.length ? itemsArr.join('') : `<li class="empty">${translations[currentLang].noPicks}</li>`;
           const label = bucket === 'safe' ? translations[currentLang].safe : translations[currentLang].aggressive;


### PR DESCRIPTION
## Summary
- Wrap recommended stock names with anchor tags that use their `searchUrl` so each stock links to its related news
- Update stock page template to render company names as clickable links

## Testing
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68ac8109a1dc832aba037b600c9270e1