### PR TITLE
fix: harden stock workflow and enforce KOTRA JSON

### DIFF
--- a/.github/workflows/stock-recs.yml
+++ b/.github/workflows/stock-recs.yml
@@ -19,7 +19,7 @@ jobs:
 
     concurrency:
       group: daily-stock-report
-      cancel-in-progress: false
+      cancel-in-progress: true
 
     env:
       TZ: Asia/Seoul
@@ -219,18 +219,16 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@778341af668090896ca464160c2def5d1d1a3eb0  # v5
         with:
           commit_message: "chore: data update (news/fx) [skip ci]"
-          file_pattern: |
-            recommendations.json
-            pools.json
-            pools-cache.json
-            pools-metrics.json
-            metrics-cache.json
-            ticker-cache.json
-            feedback.json
-            data/market_news.json
-            data/fx_rates.json
-            stocks.html
-            src/template.html
+          file_pattern: .   # stage all tracked changes
+          branch: ${{ github.ref_name }}
+
+      - name: Verify HEAD has fresh data
+        if: always()
+        run: |
+          echo "market_news HEAD lastUpdated:"
+          git show HEAD:data/market_news.json | jq -r .lastUpdated
+          echo "fx_rates HEAD lastUpdated:"
+          git show HEAD:data/fx_rates.json | jq -r .lastUpdated
 
       - name: "Show last commit (debug)"
         if: always()

--- a/src/news/kotraOverseas.js
+++ b/src/news/kotraOverseas.js
@@ -49,9 +49,10 @@ export async function fetchKotraOverseasPage({ pageNo = 1, numOfRows = 50 } = {}
     serviceKey: apiKeyRaw(),
     numOfRows: String(numOfRows),
     pageNo: String(pageNo),
+    _type: "json",
   });
   const url = `${BASE}?${qs.toString()}`;
-  const res = await fetch(url);
+  const res = await fetch(url, { headers: { Accept: "application/json" } });
   if (!res.ok) throw new Error(`KOTRA HTTP ${res.status}`);
   const json = await res.json();
 


### PR DESCRIPTION
## Summary
- cancel overlapping stock recommendation runs
- commit all tracked data files and verify latest news/FX in HEAD
- request JSON from KOTRA backup endpoint

## Testing
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68ac8a1c89ac832a9b299a82c41d08ce