### PR TITLE
Normalize keys and harden news fetching

### DIFF
--- a/fetchNews.js
+++ b/fetchNews.js
@@ -109,9 +109,9 @@ async function fetchNaverNews() {
   };
   const usRaw = await Promise.all(NAVER_US_QUERIES.map(q => naverSearch(q, headers)));
   const krRaw = await Promise.all(NAVER_KR_QUERIES.map(q => naverSearch(q, headers)));
-  const us = dedupe(usRaw.flat()).slice(0, 5);
-  const kr = dedupe(krRaw.flat()).slice(0, 5);
-  return [...us, ...kr];
+  const us = dedupe(usRaw.flat()).slice(0, 6);
+  const kr = dedupe(krRaw.flat()).slice(0, 6);
+  return [...us, ...kr].slice(0, 12);
 }
 
 async function gatherFeeds() {
@@ -134,14 +134,14 @@ async function gatherFeeds() {
     (isKR(it) ? kr : us).push(it);
   }
 
-  return [...us.slice(0, 5), ...kr.slice(0, 5)];
+  return [...us.slice(0, 6), ...kr.slice(0, 6)].slice(0, 12);
 }
 
 async function gather() {
   if (process.env.SKIP_NAVER !== '1') {
     try {
       const naverItems = await fetchNaverNews();
-      if (naverItems.length >= 10) return naverItems;
+      if (naverItems.length >= 8) return naverItems;
       console.warn('Naver returned insufficient items; falling back to feeds');
     } catch (e) {
       console.warn('Naver fetch failed', e.message);
@@ -154,7 +154,7 @@ async function gather() {
 
 async function main() {
   let items = await gather();
-  const NEED_BACKUP = process.env.USE_KOTRA_BACKUP === "1" && (!items?.length || items.length < 10);
+  const NEED_BACKUP = process.env.USE_KOTRA_BACKUP === "1" && (!items?.length || items.length < 8);
   if (NEED_BACKUP) {
     try {
       const kotraRaw = await fetchKotraOverseasRecent(2, 50);
@@ -170,8 +170,8 @@ async function main() {
   for (const it of items) {
     (isKR(it) ? kr : us).push(it);
   }
-  items = [...us.slice(0, 5), ...kr.slice(0, 5)];
-  if (!items.length) throw new Error('No news items after filtering');
+  items = [...us.slice(0, 6), ...kr.slice(0, 6)].slice(0, 12);
+  if (items.length < 8) throw new Error('No news items after filtering');
   const out = { lastUpdated: nowKSTISO(), items };
   await fs.writeFile(OUT_FILE, JSON.stringify(out, null, 2));
   console.log(`Wrote ${items.length} items to ${OUT_FILE}`);

--- a/src/news/fetchByTicker.js
+++ b/src/news/fetchByTicker.js
@@ -8,7 +8,7 @@ import { getTickerArticlesBackup } from './fetchByTicker.kotraBackup.js';
 
 const CACHE_DIR = 'cache';
 const NEWS_TTL_MS = Number(process.env.NEWS_TTL_MS || 60 * 60 * 1000); // 1h
-const NEWS_CONCURRENCY = Number(process.env.NEWS_CONCURRENCY || 3);
+const NEWS_CONCURRENCY = Number(process.env.NEWS_CONCURRENCY || 2);
 const ALLOW_STALE_NEWS = process.env.ALLOW_STALE_NEWS !== '0';
 
 const UA = 'ddsciencehs-trender/1.0 (+github actions)';
@@ -23,15 +23,21 @@ function cacheKey(url) {
 }
 async function cachedJson(url, fetcher, ttlMs = NEWS_TTL_MS, allowStale = ALLOW_STALE_NEWS) {
   const key = cacheKey(url);
+  let stale;
   try {
     const st = fs.statSync(key);
     const age = Date.now() - st.mtimeMs;
-    if (age < ttlMs) return JSON.parse(fs.readFileSync(key, 'utf8'));
-    if (allowStale) return JSON.parse(fs.readFileSync(key, 'utf8'));
+    stale = JSON.parse(fs.readFileSync(key, 'utf8'));
+    if (age < ttlMs) return stale;
   } catch {}
-  const data = await fetcher(url);
-  try { fs.mkdirSync(CACHE_DIR, { recursive: true }); fs.writeFileSync(key, JSON.stringify(data)); } catch {}
-  return data;
+  try {
+    const data = await fetcher(url);
+    try { fs.mkdirSync(CACHE_DIR, { recursive: true }); fs.writeFileSync(key, JSON.stringify(data)); } catch {}
+    return data;
+  } catch (e) {
+    if (allowStale && stale != null) return stale;
+    throw e;
+  }
 }
 async function safeGetJson(url, headers = {}) {
   const res = await fetch(url, { headers });
@@ -85,9 +91,9 @@ async function naverBlogMentions(name) {
 
 export async function fetchByTicker(symbol, name) {
   const out = { count:0, sentiment:null, top:null, naverPopularity:null, blogMentions:null };
+  let titles = [];
+  let lang = 'en';
   try {
-    let titles = [];
-    let lang = 'en';
     if (/\.K[QS]$/.test(symbol)) {
       const query = encodeURIComponent(name || symbol);
       const url = `https://news.google.com/rss/search?q=${query}&hl=ko&gl=KR&ceid=KR:ko`;
@@ -101,17 +107,28 @@ export async function fetchByTicker(symbol, name) {
       const txt = await res.text();
       titles = Array.from(txt.matchAll(/<title><!\[CDATA\[(.*?)\]\]><\/title>/g)).slice(1).map(m=>m[1]);
       lang = 'kr';
-    } else if (process.env.FINNHUB_API_KEY) {
-      const from = new Date(Date.now()-72*3600*1000).toISOString().slice(0,10);
-      const to = new Date().toISOString().slice(0,10);
-      const url = `https://finnhub.io/api/v1/company-news?symbol=${encodeURIComponent(symbol)}&from=${from}&to=${to}&token=${process.env.FINNHUB_API_KEY}`;
-      const data = await cachedJson(url, (u)=>safeGetJson(u), 30*60*1000, true);
-      titles = Array.isArray(data) ? data.map(d=>d.headline) : [];
-    } else if (NEWSAPI_KEY) {
-      const q = encodeURIComponent(name || symbol);
-      const url = `https://newsapi.org/v2/everything?q=${q}&language=en&pageSize=20&sortBy=publishedAt&apiKey=${NEWSAPI_KEY}`;
-      const data = await cachedJson(url, (u)=>safeGetJson(u), 30*60*1000, true);
-      titles = Array.isArray(data?.articles) ? data.articles.map(a => a.title) : [];
+    } else {
+      if (process.env.FINNHUB_API_KEY) {
+        try {
+          const from = new Date(Date.now()-72*3600*1000).toISOString().slice(0,10);
+          const to = new Date().toISOString().slice(0,10);
+          const url = `https://finnhub.io/api/v1/company-news?symbol=${encodeURIComponent(symbol)}&from=${from}&to=${to}&token=${process.env.FINNHUB_API_KEY}`;
+          const data = await cachedJson(url, (u)=>safeGetJson(u), 30*60*1000, true);
+          titles = Array.isArray(data) ? data.map(d=>d.headline) : [];
+        } catch (e) {
+          console.warn(`[news] Finnhub failed for ${symbol}: ${e.message}`);
+        }
+      }
+      if (!titles.length && NEWSAPI_KEY) {
+        try {
+          const q = encodeURIComponent(name || symbol);
+          const url = `https://newsapi.org/v2/everything?q=${q}&language=en&pageSize=20&sortBy=publishedAt&apiKey=${NEWSAPI_KEY}`;
+          const data = await cachedJson(url, (u)=>safeGetJson(u), 30*60*1000, true);
+          titles = Array.isArray(data?.articles) ? data.articles.map(a => a.title) : [];
+        } catch (e) {
+          console.warn(`[news] NewsAPI failed for ${symbol}: ${e.message}`);
+        }
+      }
     }
 
     if (!titles.length && process.env.USE_KOTRA_BACKUP === '1') {
@@ -135,17 +152,17 @@ export async function fetchByTicker(symbol, name) {
     }
   } catch (e) {
     console.warn(`[news] primary failed for ${symbol}: ${e.message}`);
-    if (process.env.USE_KOTRA_BACKUP === '1') {
-      try {
-        const backup = await getTickerArticlesBackup(symbol);
-        const titles = backup.map(x => x.title);
-        if (titles.length) {
-          const agg = aggregate(titles, /\.K[QS]$/.test(symbol)?'kr':'en');
-          return { count: titles.length, sentiment: agg.sentiment, top: agg.top };
-        }
-      } catch (e2) {
-        console.error(`[kotra-backup] ${symbol} backup failed:`, e2.message);
+  }
+  if (process.env.USE_KOTRA_BACKUP === '1') {
+    try {
+      const backup = await getTickerArticlesBackup(symbol);
+      const titles = backup.map(x => x.title);
+      if (titles.length) {
+        const agg = aggregate(titles, /\.K[QS]$/.test(symbol)?'kr':'en');
+        return { count: titles.length, sentiment: agg.sentiment, top: agg.top };
       }
+    } catch (e2) {
+      console.error(`[kotra-backup] ${symbol} backup failed:`, e2.message);
     }
   }
   return out;

--- a/tools/buildPoolsTrendy.js
+++ b/tools/buildPoolsTrendy.js
@@ -95,18 +95,19 @@ const NAME_TO_SYMBOL = loadNameToSymbol();
 function normalizeKey(s) {
   if (s == null) return '';
   let t = String(s).normalize('NFKC');
-  // Remove format controls (Cf), bidi marks, soft-hyphen, word joiner, etc.
-  try { t = t.replace(/\p{Cf}/gu, ''); } catch { /* older engines */ }
-  t = t
-    .replace(/[\u00AD\u034F\u061C\u200E\u200F\u202A-\u202E\u2060\u2066-\u2069]/g, '')
-    .replace(/\u2212/g, '-') // minus sign → hyphen
-    // Remove all space separators (Zs) and regular whitespace
-    .replace(/\u00A0|\u1680|[\u2000-\u200A]|\u202F|\u205F|\u3000/g, '')
-    .replace(/\s+/g, '')
-    .trim();
-  // Uppercase to normalize mixed-case tickers safely (Korean/nums unaffected)
-  t = t.toUpperCase();
-  return t;
+  // Remove all format controls (Cf) if supported
+  try { t = t.replace(/\p{Cf}/gu, ''); } catch {}
+  // Remove common invisibles (soft hyphen, word joiner, bidi, etc.)
+  t = t.replace(/[\u00AD\u034F\u061C\u200E\u200F\u202A-\u202E\u2060\u2066-\u2069]/g, '');
+  // Remove ASCII/Latin control chars (Cc)
+  t = t.replace(/[\u0000-\u001F\u007F-\u009F]/g, '');
+  // Unify Unicode minus to hyphen
+  t = t.replace(/\u2212/g, '-');
+  // Remove all space separators (Zs) and then any remaining whitespace
+  t = t.replace(/\u00A0|\u1680|[\u2000-\u200A]|\u202F|\u205F|\u3000/g, '');
+  t = t.replace(/\s+/g, '').trim();
+  // Uppercase for stable ticker comparisons (safe for KR codes)
+  return t.toUpperCase();
 }
 
 function keyVariants(k) {
@@ -175,7 +176,8 @@ function mapOne(rawKey) {
 function fallbackSymbolFromRaw(raw) {
   const s = normalizeKey(raw);
   if (/^\d{6}\.K[QS]$/.test(s)) return s;
-  if (/^[A-Z]{1,5}(\.[A-Z]{1,3})?$/.test(s)) return s;
+  if (ALLOWLIST.has(s)) return s;
+  if (/^[A-Z]{1,5}\.[A-Z]{1,3}$/.test(s)) return s;
   if (/^[A-Z]{1,5}[-/][A-Z]{1,3}$/.test(s)) {
     const [a,b] = s.split(/[-/]/);
     return `${a}.${b}`;
@@ -380,6 +382,22 @@ Object.assign(NAME_TO_SYMBOL, {
   'LG에너지솔루션': '373220.KS'
 });
 
+// Reindex NAME_TO_SYMBOL and also merge TICKER_MAP by normalized keys
+(function normalizeDictionaries() {
+  const entries = Object.entries(NAME_TO_SYMBOL);
+  for (const [k, v] of entries) {
+    const nk = normalizeKey(k);
+    if (nk !== k) {
+      delete NAME_TO_SYMBOL[k];
+      if (!(nk in NAME_TO_SYMBOL)) NAME_TO_SYMBOL[nk] = v;
+    }
+  }
+  for (const [k, v] of Object.entries(TICKER_MAP)) {
+    const nk = normalizeKey(k);
+    if (!(nk in NAME_TO_SYMBOL)) NAME_TO_SYMBOL[nk] = v;
+  }
+})();
+
 // Build reverse lookup to convert tickers back to display names
 const SYMBOL_TO_NAME = {};
 for (const [name, symbol] of Object.entries({ ...NAME_TO_SYMBOL, ...TICKER_MAP })) {
@@ -429,6 +447,29 @@ function isUS(symbolOrName) {
 function toTwelveSymbol(sym) {
   const m = String(sym).match(/^(\d{6})\.(K[QS])$/);
   return m ? `${m[1]}:${m[2]}` : sym;
+}
+
+// Try fetching candles with alternate symbol variants
+async function getCandlesWithVariants(sym, opts) {
+  const tried = new Set();
+  const candidates = [sym];
+  if (isKR(sym)) candidates.push(toTwelveSymbol(sym));
+  else {
+    const dash = sym.includes('.') ? sym.replace(/\./g, '-') : null;
+    const slsh = sym.includes('.') ? sym.replace(/\./g, '/') : null;
+    const dot1 = sym.includes('-') ? sym.replace(/-/g, '.') : null;
+    const dot2 = sym.includes('/') ? sym.replace(/\//g, '.') : null;
+    for (const c of [dash, slsh, dot1, dot2]) if (c && c !== sym) candidates.push(c);
+  }
+  for (const c of candidates) {
+    if (tried.has(c)) continue;
+    tried.add(c);
+    try {
+      const res = await getCandles(c, opts);
+      if (res && Array.isArray(res.c) && res.c.length >= 21) return res;
+    } catch (_) {}
+  }
+  return null;
 }
 
 
@@ -722,12 +763,9 @@ async function main(){
   }
 
   if (!OFFLINE) {
-    // get fresh features first, but skip if we’re tight on time
-    if (timeLeft() > GLOBAL_BUDGET_MS * 0.35) {
-      NEWS_FEATURES = await enrichWithNewsFeatures(symbols);
-    } else {
-      NEWS_FEATURES = {};
-    }
+    NEWS_FEATURES = timeLeft() > GLOBAL_BUDGET_MS * 0.35
+      ? await enrichWithNewsFeatures(symbols)
+      : {};
   }
 
   // now build keywords using up-to-date features
@@ -798,7 +836,10 @@ async function main(){
       try {
         const countsBefore = Object.fromEntries(Object.entries(providerState).map(([p,s])=>[p, s.count||0]));
         candles = (sym && budgetOk(REQ_TIMEOUT_MS) && !circuitOpen())
-          ? await getCandles(sym, { cacheTtlMs: CACHE_TTL_MS, cooloffMs: COOLOFF_MS, maxPerProvider: MAX_PER_PROVIDER }).catch(e => { tripOnError(e); return null; })
+          ? await getCandlesWithVariants(
+              sym,
+              { cacheTtlMs: CACHE_TTL_MS, cooloffMs: COOLOFF_MS, maxPerProvider: MAX_PER_PROVIDER }
+            ).catch(e => { tripOnError(e); return null; })
           : null;
         if (candles?.source) {
           bump(candles.source, true);


### PR DESCRIPTION
## Summary
- Normalize ticker keys by stripping control characters, reindexing dictionaries, and tightening fallback lookups
- Retry candle fetches with alternate symbol formats, improving KR coverage
- Harden news retrieval with safe JSON parsing, caching, concurrency limits, and bounded headline counts

## Testing
- `node --check tools/buildPoolsTrendy.js`
- `node --check src/news/fetchByTicker.js`
- `node --check fetchNews.js`
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68ad904fc424832a9e030e9709705301