### PR TITLE
feat: add KOTRA news backup

### DIFF
--- a/fetchNews.js
+++ b/fetchNews.js
@@ -5,7 +5,7 @@ import { XMLParser } from 'fast-xml-parser';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { nowKSTISO } from './utils/time.js';
-import { fetchKotraOverseasRecent } from './src/news/kotraOverseas.js';
+import { fetchKotraRecent } from './src/news/kotraOverseas.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -154,15 +154,15 @@ async function gather() {
 
 async function main() {
   let items = await gather();
-  const NEED_BACKUP = process.env.USE_KOTRA_BACKUP === "1" && (!items?.length || items.length < 8);
-  if (NEED_BACKUP) {
+  const NEED = process.env.USE_KOTRA_BACKUP === "1" && (!items?.length || items.length < 12);
+  if (NEED) {
     try {
-      const kotraRaw = await fetchKotraOverseasRecent(2, 50);
+      const kotraRaw = await fetchKotraRecent({ pages: 2, pageSize: 50 });
       const kotra = kotraRaw.map(it => ({ title: it.title, link: it.url })).filter(it => it.link);
-      items = dedupe([...(items || []), ...kotra]);
-      console.log(`[kotra-backup] merged ${kotra.length} items (recent overseas market news)`);
+      items = dedupe([...(items || []), ...kotra]).slice(0, 120);
+      console.log(`[kotra-backup] merged ${kotra.length} items`);
     } catch (e) {
-      console.error('[kotra-backup] failed:', e.message);
+      console.error('[kotra-backup] homepage backup failed:', e.message);
     }
   }
   const us = [];

--- a/src/news/fetchByTicker.js
+++ b/src/news/fetchByTicker.js
@@ -1,5 +1,7 @@
 import fs from 'fs';
 import path from 'path';
+import { fetchKotraRecent } from "./kotraOverseas.js";
+import { getCompanyNameByYahooSymbol } from "../data/krxDirectory.js";
 
 const CACHE_DIR = 'cache';
 const NEWS_TTL_MS = Number(process.env.NEWS_TTL_MS || 30 * 60 * 1000); // 30m
@@ -218,3 +220,84 @@ export async function buildNewsFeatures(symbols, opts={}){
 
   return out;
 }
+
+function normalizeNewsApiArticle(it) {
+  const title = it?.title || "";
+  const url = it?.url || "";
+  if (!title || !url) return null;
+  const date = it?.publishedAt ? new Date(it.publishedAt).toISOString() : new Date().toISOString();
+  const source = it?.source?.name || "NewsAPI";
+  return { title, url, source, publishedAt: date };
+}
+
+function normalizeNaverArticle(it) {
+  const title = (it?.title || "").replace(/<[^>]*>/g, "").trim();
+  const url = (it?.originallink || it?.link || "").trim();
+  if (!title || !url) return null;
+  const date = it?.pubDate ? new Date(it.pubDate).toISOString() : new Date().toISOString();
+  return { title, url, source: "Naver", publishedAt: date };
+}
+
+function dedupeArticles(items) {
+  const seen = new Set();
+  return items.filter(it => {
+    const u = (it?.url || "").trim();
+    if (!u || seen.has(u)) return false;
+    seen.add(u);
+    return true;
+  });
+}
+
+async function getTickerArticlesPrimary(ticker) {
+  const out = [];
+  const NEWSAPI = process.env.NEWSAPI_KEY || "";
+  if (NEWSAPI) {
+    try {
+      const url = `https://newsapi.org/v2/everything?q=${encodeURIComponent(ticker)}&language=en&pageSize=20&sortBy=publishedAt&apiKey=${NEWSAPI}`;
+      const res = await fetch(url, { headers: { 'User-Agent': 'stock-recs/1.0 (+github-actions)' } });
+      const j = await res.json();
+      const arr = Array.isArray(j?.articles) ? j.articles : [];
+      out.push(...arr.map(normalizeNewsApiArticle).filter(Boolean));
+    } catch {}
+  }
+  const NAVER_ID = process.env.NAVER_CLIENT_ID || "";
+  const NAVER_SECRET = process.env.NAVER_CLIENT_SECRET || "";
+  if (NAVER_ID && NAVER_SECRET) {
+    try {
+      const url = `https://openapi.naver.com/v1/search/news.json?query=${encodeURIComponent(ticker)}&display=20&sort=date`;
+      const headers = { 'X-Naver-Client-Id': NAVER_ID, 'X-Naver-Client-Secret': NAVER_SECRET };
+      const res = await fetch(url, { headers });
+      const j = await res.json();
+      const arr = Array.isArray(j?.items) ? j.items : [];
+      out.push(...arr.map(normalizeNaverArticle).filter(Boolean));
+    } catch {}
+  }
+  return dedupeArticles(out);
+}
+
+export async function getTickerArticles(ticker) {
+  const primary = await getTickerArticlesPrimary(ticker).catch(e => {
+    console.error(`[news] primary failed for ${ticker}:`, e.message);
+    return [];
+  });
+  if (primary?.length) return primary;
+
+  if (process.env.USE_KOTRA_BACKUP === "1") {
+    try {
+      const name = await getCompanyNameByYahooSymbol(ticker);
+      if (name) {
+        // Pull ~100–150 recent items then keyword-match by company name
+        const kotra = await fetchKotraRecent({ pages: 3, pageSize: 50, keyword: name });
+        if (kotra.length) {
+          console.log(`[kotra-backup] ${ticker}: ${kotra.length} items`);
+          return kotra.slice(0, 20);
+        }
+      }
+    } catch (e) {
+      console.error(`[kotra-backup] ${ticker} backup failed:`, e.message);
+    }
+  }
+
+  return primary ?? [];
+}
+

--- a/src/news/fetchByTicker.kotraBackup.js
+++ b/src/news/fetchByTicker.kotraBackup.js
@@ -1,4 +1,4 @@
-import { fetchKotraOverseasRecent, filterByKeyword } from "./kotraOverseas.js";
+import { fetchKotraRecent } from "./kotraOverseas.js";
 import { getCompanyNameByYahooSymbol } from "../data/krxDirectory.js";
 
 // When the primary fetch returns nothing for a ticker,
@@ -6,9 +6,7 @@ import { getCompanyNameByYahooSymbol } from "../data/krxDirectory.js";
 export async function getTickerArticlesBackup(ticker) {
   const name = await getCompanyNameByYahooSymbol(ticker);
   if (!name) return [];
-  const recent = await fetchKotraOverseasRecent(3, 50); // ~150 latest
-  // very light heuristic: title OR summary contains company name
-  const filtered = filterByKeyword(recent, name);
-  return filtered.slice(0, 20); // cap for speed
+  const recent = await fetchKotraRecent({ pages: 3, pageSize: 50, keyword: name });
+  return recent.slice(0, 20); // cap for speed
 }
 

--- a/src/news/kotraOverseas.js
+++ b/src/news/kotraOverseas.js
@@ -1,41 +1,33 @@
-// KOTRA Overseas Market News (backup)
-// Endpoint (as provided):
-// https://apis.data.go.kr/B410001/kotra_overseasMarketNews/ovseaMrktNews/ovseaMrktNews
-// Required query: serviceKey, numOfRows, pageNo
-// Response shape (simplified):
-// { response: { header:{resultCode,resultMsg}, body:{ totalCnt, pageNo, itemList:{ item: [...] }, numOfRows } } }
-
 import fetch from "node-fetch";
 
 const BASE = "https://apis.data.go.kr/B410001/kotra_overseasMarketNews/ovseaMrktNews/ovseaMrktNews";
 
-function apiKeyRaw() {
+// Accept decoded OR already-encoded key without double-encoding
+function getPortalKeyRaw() {
   const k = process.env.DATA_API_KEY;
   if (!k) throw new Error("DATA_API_KEY missing");
-  return k; // RAW
+  // If key looks percent-encoded, decode once so URLSearchParams can encode it exactly once
+  return /%[0-9A-Fa-f]{2}/.test(k) ? decodeURIComponent(k) : k;
 }
 
-function toISO(d) {
-  try { return new Date(d).toISOString(); } catch { return new Date().toISOString(); }
-}
+function toISO(d) { try { return new Date(d).toISOString(); } catch { return new Date().toISOString(); } }
 
-// Normalize one raw item to your site/news shape
 function normalizeOne(it) {
   return {
     title: it?.newsTitl || "(no title)",
     url: it?.kotraNewsUrl || "",
     source: "KOTRA 해외시장뉴스",
-    // Provided example had othbcDt like "2024-09-04" (string). Convert to ISO.
     publishedAt: toISO(it?.othbcDt || Date.now()),
     summary: it?.cntntSumar || "",
+    keywords: it?.kwrd || "",
     region: it?.regn || "",
     country: it?.natn || "",
   };
 }
 
-function dedupeByUrl(arr) {
+function dedupeByUrl(items) {
   const seen = new Set();
-  return arr.filter(x => {
+  return items.filter(x => {
     const k = (x.url || "").trim().toLowerCase();
     if (!k || seen.has(k)) return false;
     seen.add(k);
@@ -43,44 +35,50 @@ function dedupeByUrl(arr) {
   });
 }
 
-// Fetch a single page (default larger page to reduce calls)
-export async function fetchKotraOverseasPage({ pageNo = 1, numOfRows = 50 } = {}) {
-  const qs = new URLSearchParams({
-    serviceKey: apiKeyRaw(),
-    numOfRows: String(numOfRows),
+async function fetchPage({ pageNo = 1, numOfRows = 50, withSummary = true, q = {} } = {}) {
+  // q can contain search1..search9; we’ll forward only defined ones.
+  const params = new URLSearchParams({
+    serviceKey: getPortalKeyRaw(),   // RAW; URLSearchParams will encode once
+    type: "json",
     pageNo: String(pageNo),
-    _type: "json",
+    numOfRows: String(numOfRows),
   });
-  const url = `${BASE}?${qs.toString()}`;
-  const res = await fetch(url, { headers: { Accept: "application/json" } });
-  if (!res.ok) throw new Error(`KOTRA HTTP ${res.status}`);
-  const json = await res.json();
+  if (withSummary) params.set("search8", "Y"); // include summary/keywords/body fields
+
+  // Optional filters (search1..search9)
+  for (let i = 1; i <= 9; i++) {
+    const key = `search${i}`;
+    if (q[key]) params.set(key, q[key]);
+  }
+
+  const res = await fetch(`${BASE}?${params.toString()}`, { headers: { Accept: "application/json" } });
+  const text = await res.text();
+  let json;
+  try { json = JSON.parse(text); }
+  catch { throw new Error(`KOTRA non-JSON response (first 80 chars): ${text.slice(0,80)}`); }
 
   const ok = json?.response?.header?.resultCode === "00";
-  if (!ok) return [];
+  if (!ok) {
+    const code = json?.response?.header?.resultCode;
+    const msg  = json?.response?.header?.resultMsg;
+    throw new Error(`KOTRA error ${code}: ${msg}`);
+  }
 
   const raw = json?.response?.body?.itemList?.item ?? [];
   const list = Array.isArray(raw) ? raw : (raw ? [raw] : []);
   return list.map(normalizeOne).filter(x => x.url);
 }
 
-// Pull a few recent pages and merge
-export async function fetchKotraOverseasRecent(pages = 2, pageSize = 50) {
+// Pull recent pages and optionally filter by keyword
+export async function fetchKotraRecent({ pages = 2, pageSize = 50, keyword } = {}) {
   const batches = [];
-  for (let p = 1; p <= pages; p++) {
-    batches.push(fetchKotraOverseasPage({ pageNo: p, numOfRows: pageSize }));
-  }
-  const results = (await Promise.all(batches)).flat();
-  return dedupeByUrl(results).slice(0, pages * pageSize);
-}
-
-// Very light keyword filter (used for per-ticker backup)
-export function filterByKeyword(items, keyword) {
-  if (!keyword) return [];
-  const kw = String(keyword).trim();
-  return items.filter(x =>
-    (x.title && x.title.includes(kw)) ||
-    (x.summary && x.summary.includes(kw))
+  for (let p = 1; p <= pages; p++) batches.push(fetchPage({ pageNo: p, numOfRows: pageSize }));
+  const merged = dedupeByUrl((await Promise.all(batches)).flat());
+  if (!keyword) return merged;
+  return merged.filter(x =>
+    (x.title && x.title.includes(keyword)) ||
+    (x.summary && x.summary.includes(keyword)) ||
+    (x.keywords && x.keywords.includes(keyword))
   );
 }
 


### PR DESCRIPTION
## Summary
- replace KOTRA overseas news client and expose `fetchKotraRecent`
- add `getTickerArticles` with NewsAPI/Naver primary and KOTRA fallback
- use KOTRA backup when homepage news is sparse

## Testing
- `node tests/apple_association.test.js`

------
https://chatgpt.com/codex/tasks/task_b_68ad9dc6b214832abfa79abe7cc8002b