### PR TITLE
feat: integrate SerpApi news source and workflow preflight

### DIFF
--- a/.github/workflows/stock-recs.yml
+++ b/.github/workflows/stock-recs.yml
@@ -27,7 +27,7 @@ jobs:
       # Keep the run under typical 60s shells; script respects this.
       HARD_DEADLINE_MS: "55000"
       # GitHub often has flaky access to Naver; feel free to unset.
-      SKIP_NAVER: "0"
+      SKIP_NAVER: "1"          # optional: avoid flaky Naver on GH runners
       IS_CRON: ${{ github.event_name == 'schedule' }}
       # FX backup via Korea Eximbank (oapi.koreaexim.go.kr)
       USE_EXIM_FX_BACKUP: "1"
@@ -49,10 +49,14 @@ jobs:
       NEWSAPI_KEY: ${{ secrets.NEWSAPI_KEY }}
       NAVER_CLIENT_ID: ${{ secrets.NAVER_CLIENT_ID }}
       NAVER_CLIENT_SECRET: ${{ secrets.NAVER_CLIENT_SECRET }}
+      SERP_API_KEY: ${{ secrets.SERP_API_KEY }}
+      # Optional tuning for this module
+      NEWS_CONCURRENCY: 2        # your code already defaults to 2; keep it small for SerpApi quotas
+      NEWS_TTL_MS: 1800000       # 30m cache TTL (aligns with your comment)
       NAVER_TRENDS_CACHE_TTL_MS: 21600000   # 6h (matches the code)
       GLOBAL_BUDGET_MS: 90000
       MAX_CONCURRENCY: 2
-      REQ_TIMEOUT_MS: 5000
+      REQ_TIMEOUT_MS: 8000       # helps fail fast instead of hanging
       RETRIES: 2
       BACKOFF_BASE_MS: 600
       CIRCUIT_MAX_ERRORS: 6
@@ -79,7 +83,7 @@ jobs:
             echo "❌ Possible hardcoded secret detected"; exit 1
           fi
           # Fail if someone echoes secret env vars
-          if git grep -nI -E 'echo\s+(\$\{?(FINNHUB_API_KEY|TWELVEDATA_API_KEY|ALPHA_VANTAGE_KEY|FMP_KEY)\}?|%(\1)%)' -- \
+          if git grep -nI -E 'echo\s+(\$\{?(FINNHUB_API_KEY|TWELVEDATA_API_KEY|ALPHA_VANTAGE_KEY|FMP_KEY|SERP_API_KEY)\}?|%(\1)%)' -- \
               ':!README.md' ':!.github/workflows/**' ':!**/*.yml' ':!**/*.yaml' ':!**/*.md'; then
             echo "❌ Attempt to echo a secret environment variable"; exit 1
           fi
@@ -187,6 +191,27 @@ jobs:
           fi
 
       # ⬇️ Added from daily-build.yml
+      - name: Preflight: outbound connectivity (SerpApi/GDELT)
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          echo "DNS:"
+          getent hosts serpapi.com || true
+          getent hosts api.gdeltproject.org || true
+
+          echo "HTTP head checks:"
+          curl -4sS -I https://serpapi.com | head -n 1
+          curl -4sS -I https://api.gdeltproject.org | head -n 1
+
+          echo "SerpApi auth check (status only; key masked by Actions):"
+          curl -4sS --get 'https://serpapi.com/search.json' \
+            --data-urlencode 'engine=google_news' \
+            --data-urlencode 'q=TSLA' \
+            --data-urlencode 'gl=us' \
+            --data-urlencode 'hl=en' \
+            --data-urlencode "api_key=${SERP_API_KEY}" \
+            -o /dev/null -w 'HTTP %{http_code}\n'
+
       - name: Update market news
         shell: bash
         run: |

--- a/src/news/fetchByTicker.js
+++ b/src/news/fetchByTicker.js
@@ -7,18 +7,8 @@ const CACHE_DIR = 'cache';
 const NEWS_TTL_MS = Number(process.env.NEWS_TTL_MS || 30 * 60 * 1000); // 30m
 const NEWS_CONCURRENCY = Number(process.env.NEWS_CONCURRENCY || 2);
 const ALLOW_STALE_NEWS = process.env.ALLOW_STALE_NEWS !== '0';
+const REQ_TIMEOUT_MS = Number(process.env.REQ_TIMEOUT_MS || 8000);
 const defaultUA = { 'User-Agent': 'stock-recs/1.0 (+github-actions)' };
-
-// Prefer explicitly encoded key if provided; otherwise encode decoded/plain
-function chooseEncodedServiceKey() {
-  const enc = process.env.DATA_API_KEY || '';
-  const dec = process.env.DATA_API_KEY_DECODED || '';
-  const looksEncoded = /%[0-9a-fA-F]{2}/.test(enc);
-  if (enc && looksEncoded) return enc;
-  if (!enc && dec) return encodeURIComponent(dec);
-  if (enc) return encodeURIComponent(enc);
-  return '';
-}
 
 function looksLikeXmlOrHtml(s){ const t=String(s||'').trim(); return !!t && t.startsWith('<'); }
 function cacheKey(url){ return path.join(CACHE_DIR, `news-${Buffer.from(url).toString('base64url')}.json`); }
@@ -35,7 +25,18 @@ async function cachedJson(url, fetcher, ttlMs=NEWS_TTL_MS, allowStale=ALLOW_STAL
   return data;
 }
 async function safeGetJson(url, headers={}){
-  const res = await fetch(url, { headers });
+  const ac = new AbortController();
+  const to = setTimeout(() => ac.abort(new Error('timeout')), REQ_TIMEOUT_MS);
+  let res;
+  try {
+    res = await fetch(url, { headers, signal: ac.signal });
+  } catch (e) {
+    const host = (()=>{ try { return new URL(url).host; } catch { return 'unknown-host'; }})();
+    const code = e?.cause?.code || e.name || 'ERR_FETCH';
+    throw new Error(`fetch failed (${host}): ${e.message} [${code}]`);
+  } finally {
+    clearTimeout(to);
+  }
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
   const ct = res.headers?.get?.('content-type') || '';
   if (/json/i.test(ct)) return await res.json();
@@ -110,6 +111,23 @@ async function newsFromNewsAPI(sym, q, NEWSAPI){
   return { count: Math.min(arr.length, 30), sentiment: 0, blogMentions: 0 };
 }
 
+/**
+ * SerpApi (Google News)
+ * Docs: https://serpapi.com/google-news-api
+ * We localize KR vs US via gl/hl and add a recency hint (when:7d).
+ */
+async function newsFromSerpApi(sym, q, SERPAPI){
+  if (!SERPAPI) return null;
+  const isKr = isKR(sym);
+  const gl = isKr ? 'kr' : 'us';
+  const hl = isKr ? 'ko' : 'en';
+  const finalQ = /\bwhen:\d+[hdwmy]?\b/i.test(q) ? q : `${q} when:7d`;
+  const url = `https://serpapi.com/search.json?engine=google_news&q=${encodeURIComponent(finalQ)}&gl=${gl}&hl=${hl}&no_cache=false&api_key=${SERPAPI}`;
+  const j = await cachedJson(url, (u)=>safeGetJson(u, defaultUA), 20*60*1000, true);
+  const arr = Array.isArray(j?.news_results) ? j.news_results : [];
+  return { count: Math.min(arr.length, 30), sentiment: 0, blogMentions: 0 };
+}
+
 async function newsFromNaver(sym, q, NAVER_ID, NAVER_SECRET){
   if (!NAVER_ID || !NAVER_SECRET) return null;
   // news search (date-sorted); we only need a small page to decide "non-zero"
@@ -150,7 +168,8 @@ function buildKotraUrl({ serviceKey, natn, title, rows = 10, page = 1, includeTe
 }
 
 async function newsFromKotra(sym, rawQuery) {
-  const serviceKey = chooseEncodedServiceKey();
+  // Prefer decoded service key so URLSearchParams encodes it exactly once.
+  const serviceKey = chooseServiceKeyForDataGoKr();
   if (!serviceKey) return null;
 
   const natn = natnForSym(sym);
@@ -164,7 +183,16 @@ async function newsFromKotra(sym, rawQuery) {
   });
 
   const headers = { Accept: 'application/json' };
-  const j = await cachedJson(url, (u) => safeGetJson(u, headers), 20 * 60 * 1000, true);
+  // KOTRA will often return XML on auth/param error; soft-fail to keep other providers running.
+  const j = await cachedJson(url, async (u) => {
+    try { return await safeGetJson(u, headers); }
+    catch (e) {
+      if (String(e.message).includes('non-JSON payload')) {
+        return { response: { header: { resultCode: 'XX' }, body: {} } };
+      }
+      throw e;
+    }
+  }, 20 * 60 * 1000, true);
 
   const header = j?.response?.header;
   if (!header || header.resultCode !== '00') return { count: 0, sentiment: 0, blogMentions: 0 };
@@ -176,6 +204,13 @@ async function newsFromKotra(sym, rawQuery) {
   return { count, sentiment: 0, blogMentions: hasKw ? Math.min(count, 10) : 0 };
 }
 
+async function newsFromGdelt(sym, q){
+  const url = `https://api.gdeltproject.org/api/v2/doc/doc?query=${encodeURIComponent(q)}&mode=artlist&format=jsonfeed&maxrecords=10&sort=DateDesc`;
+  const j = await cachedJson(url, (u)=>safeGetJson(u, defaultUA), 15*60*1000, true);
+  const arr = Array.isArray(j?.items) ? j.items : [];
+  return { count: Math.min(arr.length, 30), sentiment: 0, blogMentions: 0 };
+}
+
 /**
  * Main: buildNewsFeatures(symbols, { symbolToName })
  * Returns shape: { [symbol]: { count, sentiment, blogMentions } }
@@ -183,6 +218,7 @@ async function newsFromKotra(sym, rawQuery) {
 export async function buildNewsFeatures(symbols, opts={}){
   const FINNHUB = process.env.FINNHUB_API_KEY || '';
   const NEWSAPI = process.env.NEWSAPI_KEY || '';
+  const SERPAPI = process.env.SERP_API_KEY || '';
   const NAVER_ID = process.env.NAVER_CLIENT_ID || '';
   const NAVER_SECRET = process.env.NAVER_CLIENT_SECRET || '';
 
@@ -192,16 +228,20 @@ export async function buildNewsFeatures(symbols, opts={}){
   await mapLimit(symbols, NEWS_CONCURRENCY, async (sym)=>{
     const q = queries[sym];
     let feat = { count: 0, sentiment: 0, blogMentions: 0 };
-    const isKr = /\.K[QS]$/.test(sym);
-    const providers = isKr
-      ? ['naver', 'kotra', 'finnhub', 'newsapi']
-      : ['finnhub', 'newsapi', 'kotra', 'naver'];
-    try {
-      for (const p of providers) {
+    // Prefer SerpApi early; keep NewsAPI as a late fallback. GDELT is a last-resort fallback.
+    const providers = isKR(sym)
+      ? ['naver', 'serpapi', 'finnhub', 'kotra', 'newsapi', 'gdelt']
+      : ['finnhub', 'serpapi', 'newsapi', 'kotra', 'naver', 'gdelt'];
+
+    let lastErr = null;
+    for (const p of providers) {
+      try {
         let v = null;
         if (p === 'finnhub') v = await newsFromFinnhub(sym, FINNHUB);
-        else if (p === 'newsapi') v = await with429Retry(() => newsFromNewsAPI(sym, q, NEWSAPI), 1);
+        else if (p === 'serpapi') v = await with429Retry(() => newsFromSerpApi(sym, q, SERPAPI), 2, 600);
+        else if (p === 'newsapi') v = await with429Retry(() => newsFromNewsAPI(sym, q, NEWSAPI), 1, 600);
         else if (p === 'kotra') v = await newsFromKotra(sym, q);
+        else if (p === 'gdelt') v = await newsFromGdelt(sym, q);
         else v = await newsFromNaver(sym, q, NAVER_ID, NAVER_SECRET);
         if (v && v.count > 0) {
           try {
@@ -211,14 +251,24 @@ export async function buildNewsFeatures(symbols, opts={}){
           out[sym] = v;
           return;
         }
+      } catch (e) {
+        lastErr = e;
+        console.warn(`[news] ${sym} provider ${p} failed: ${e.message}`);
       }
-    } catch (e) {
-      console.warn(`[news] providers failed for ${sym}: ${e.message}`);
     }
+    if (lastErr) console.warn(`[news] providers exhausted for ${sym}. Last: ${lastErr.message}`);
     out[sym] = feat;
   });
 
   return out;
+}
+
+// --- helpers for KOTRA key handling (replace old chooseEncodedServiceKey) ---
+function chooseServiceKeyForDataGoKr() {
+  const dec = (process.env.DATA_API_KEY_DECODED || '').trim();
+  const enc = (process.env.DATA_API_KEY || '').trim();
+  if (dec) return dec;
+  try { return decodeURIComponent(enc); } catch { return enc; }
 }
 
 function normalizeNewsApiArticle(it) {


### PR DESCRIPTION
## Summary
- add SerpApi env vars and connectivity preflight to stock-recs workflow
- expand news fetching with SerpApi and GDELT providers and improved timeouts

## Testing
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68ae685d6a4c832a8ac23ffaea3319b7