### PR TITLE
Fix workflow YAML syntax error

### DIFF
--- a/.github/workflows/stock-recs.yml
+++ b/.github/workflows/stock-recs.yml
@@ -191,7 +191,7 @@ jobs:
           fi
 
       # ⬇️ Added from daily-build.yml
-      - name: Preflight: outbound connectivity (SerpApi/GDELT)
+      - name: "Preflight: outbound connectivity (SerpApi/GDELT)"
         shell: bash
         run: |
           set -Eeuo pipefail


### PR DESCRIPTION
## Summary
- quote workflow step name to handle colon characters

## Testing
- `node tests/apple_association.test.js`
- `python - <<'PY'
import yaml, sys
with open('.github/workflows/stock-recs.yml') as f:
    yaml.safe_load(f)
print('Parsed ok')
PY`

------
https://chatgpt.com/codex/tasks/task_b_68ae6d4d2bd0832ab1654cfd61f99482