### PR TITLE
feat: prefer decoded KOTRA key and expand workflow env

### DIFF
--- a/.github/workflows/stock-recs.yml
+++ b/.github/workflows/stock-recs.yml
@@ -33,7 +33,8 @@ jobs:
       USE_EXIM_FX_BACKUP: "1"
       EXIM_AUTH_KEY: ${{ secrets.EXIM_AUTH_KEY }}   # Exim
       # Use the portal key for KOTRA + (optionally KRX if you share it)
-      DATA_API_KEY: ${{ secrets.DATA_API_KEY }}     # data.go.kr (KRX & KOTRA)
+      DATA_API_KEY: ${{ secrets.DATA_API_KEY }}             # plain (decoded) KOTRA key (…==)
+      DATA_ENCODE_KEY: ${{ secrets.DATA_ENCODE_KEY }}
       USE_KOTRA_BACKUP: "1"
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/src/news/fetchByTicker.js
+++ b/src/news/fetchByTicker.js
@@ -294,7 +294,21 @@ function chooseApiKey(name){
   if (dec) return dec;
   try { return decodeURIComponent(enc); } catch { return enc; }
 }
-function chooseServiceKeyForDataGoKr(){ return chooseApiKey('DATA_API_KEY'); }
+function chooseServiceKeyForDataGoKr(){
+  // Precedence: plain first, then encoded
+  const candidates = [
+    (process.env.DATA_API_KEY || '').trim(),        // preferred (decoded)
+    (process.env.DATA_API_KEY_DECODED || '').trim(),// legacy plain
+    (process.env.DATA_API_KEY_ENCODED || '').trim(),// legacy encoded
+    (process.env.DATA_ENCODE_KEY || '').trim(),     // your encoded key
+  ].filter(Boolean);
+  if (!candidates.length) return '';
+  const first = candidates[0];
+  if (/%[0-9A-Fa-f]{2}/.test(first)) { // looks encoded
+    try { return decodeURIComponent(first); } catch { /* fallthrough */ }
+  }
+  return first;
+}
 export function chooseKrxApiKey(){ return chooseApiKey('KRX_API_KEY'); }
 
 function normalizeNewsApiArticle(it) {


### PR DESCRIPTION
## Summary
- add explicit `DATA_ENCODE_KEY` and clarify KOTRA `DATA_API_KEY` usage in workflow
- choose first available KOTRA key, decoding if necessary

## Testing
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68aea53337c0832a872f68e21dbf1a01