### PR TITLE
Show recommendation scores on stock page

### DIFF
--- a/recommendations.json
+++ b/recommendations.json
@@ -5,31 +5,36 @@
         "name": "레인보우로보틱스",
         "sector": "Industrials",
         "ticker": "277810.KQ",
-        "searchUrl": "https://www.google.com/search?tbm=nws&q=%EB%A0%88%EC%9D%B8%EB%B3%B4%EC%9A%B0%EB%A1%9C%EB%B3%B4%ED%8B%B1%EC%8A%A4%20277810.KQ"
+        "searchUrl": "https://www.google.com/search?tbm=nws&q=%EB%A0%88%EC%9D%B8%EB%B3%B4%EC%9A%B0%EB%A1%9C%EB%B3%B4%ED%8B%B1%EC%8A%A4%20277810.KQ",
+        "score": 92
       },
       {
         "name": "리노공업",
         "sector": "Industrials",
         "ticker": "058470.KQ",
-        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%EB%A6%AC%EB%85%B8%EA%B3%B5%EC%97%85%20058470.KQ"
+        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%EB%A6%AC%EB%85%B8%EA%B3%B5%EC%97%85%20058470.KQ",
+        "score": 86
       },
       {
         "name": "알테오젠",
         "sector": "Healthcare",
         "ticker": "196170.KQ",
-        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%EC%95%8C%ED%85%8C%EC%98%A4%EC%A0%A0%20196170.KQ"
+        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%EC%95%8C%ED%85%8C%EC%98%A4%EC%A0%A0%20196170.KQ",
+        "score": 84
       },
       {
         "name": "에코프로비엠",
         "sector": "Materials",
         "ticker": "247540.KQ",
-        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%EC%97%90%EC%BD%94%ED%94%84%EB%A1%9C%EB%B9%84%EC%97%A0%20247540.KQ"
+        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%EC%97%90%EC%BD%94%ED%94%84%EB%A1%9C%EB%B9%84%EC%97%A0%20247540.KQ",
+        "score": 90
       },
       {
         "name": "펩트론",
         "sector": "Healthcare",
         "ticker": "087010.KQ",
-        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%ED%8E%A9%ED%8A%B8%EB%A1%A0%20087010.KQ"
+        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%ED%8E%A9%ED%8A%B8%EB%A1%A0%20087010.KQ",
+        "score": 82
       }
     ],
     "aggressive": [
@@ -37,31 +42,36 @@
         "name": "CJ ENM",
         "sector": "Communication Services",
         "ticker": "035760.KQ",
-        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=CJ%20ENM%20035760.KQ"
+        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=CJ%20ENM%20035760.KQ",
+        "score": 75
       },
       {
         "name": "HLB",
         "sector": null,
         "ticker": "HLB",
-        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=HLB%20HLB"
+        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=HLB%20HLB",
+        "score": 60
       },
       {
         "name": "JYP엔터테인먼트",
         "sector": "Communication Services",
         "ticker": "035900.KQ",
-        "searchUrl": "https://www.google.com/search?tbm=nws&q=JYP%EC%97%94%ED%84%B0%ED%85%8C%EC%9D%B8%EB%A8%BC%ED%8A%B8%20035900.KQ"
+        "searchUrl": "https://www.google.com/search?tbm=nws&q=JYP%EC%97%94%ED%84%B0%ED%85%8C%EC%9D%B8%EB%A8%BC%ED%8A%B8%20035900.KQ",
+        "score": 73
       },
       {
         "name": "셀트리온헬스케어",
         "sector": "Healthcare",
         "ticker": "091990.KQ",
-        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%EC%85%80%ED%8A%B8%EB%A6%AC%EC%98%A8%ED%97%AC%EC%8A%A4%EC%BC%80%EC%96%B4%20091990.KQ"
+        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%EC%85%80%ED%8A%B8%EB%A6%AC%EC%98%A8%ED%97%AC%EC%8A%A4%EC%BC%80%EC%96%B4%20091990.KQ",
+        "score": 68
       },
       {
         "name": "펄어비스",
         "sector": "Communication Services",
         "ticker": "263750.KQ",
-        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%ED%8E%84%EC%96%B4%EB%B9%84%EC%8A%A4%20263750.KQ"
+        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%ED%8E%84%EC%96%B4%EB%B9%84%EC%8A%A4%20263750.KQ",
+        "score": 70
       }
     ]
   },
@@ -71,31 +81,36 @@
         "name": "LG에너지솔루션",
         "sector": null,
         "ticker": "373220.KS",
-        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=LG%EC%97%90%EB%84%88%EC%A7%80%EC%86%94%EB%A3%A8%EC%85%98%20373220.KS"
+        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=LG%EC%97%90%EB%84%88%EC%A7%80%EC%86%94%EB%A3%A8%EC%85%98%20373220.KS",
+        "score": 88
       },
       {
         "name": "LG화학",
         "sector": "Materials",
         "ticker": "051910.KS",
-        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=LG%ED%99%94%ED%95%99%20051910.KS"
+        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=LG%ED%99%94%ED%95%99%20051910.KS",
+        "score": 91
       },
       {
         "name": "기아",
         "sector": "Consumer Discretionary",
         "ticker": "000270.KS",
-        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%EA%B8%B0%EC%95%84%20000270.KS"
+        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%EA%B8%B0%EC%95%84%20000270.KS",
+        "score": 83
       },
       {
         "name": "삼성전자",
         "sector": "Technology",
         "ticker": "005930.KS",
-        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%EC%82%BC%EC%84%B1%EC%A0%84%EC%9E%90%20005930.KS"
+        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%EC%82%BC%EC%84%B1%EC%A0%84%EC%9E%90%20005930.KS",
+        "score": 95
       },
       {
         "name": "셀트리온",
         "sector": "Healthcare",
         "ticker": "068270.KS",
-        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%EC%85%80%ED%8A%B8%EB%A6%AC%EC%98%A8%20068270.KS"
+        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%EC%85%80%ED%8A%B8%EB%A6%AC%EC%98%A8%20068270.KS",
+        "score": 87
       }
     ],
     "aggressive": [
@@ -103,31 +118,36 @@
         "name": "HD현대일렉트릭",
         "sector": "Industrials",
         "ticker": "267260.KS",
-        "searchUrl": "https://www.google.com/search?tbm=nws&q=HD%ED%98%84%EB%8C%80%EC%9D%BC%EB%A0%89%ED%8A%B8%EB%A6%AD%20267260.KS"
+        "searchUrl": "https://www.google.com/search?tbm=nws&q=HD%ED%98%84%EB%8C%80%EC%9D%BC%EB%A0%89%ED%8A%B8%EB%A6%AD%20267260.KS",
+        "score": 72
       },
       {
         "name": "네이버",
         "sector": "Communication Services",
         "ticker": "035420.KS",
-        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%EB%84%A4%EC%9D%B4%EB%B2%84%20035420.KS"
+        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%EB%84%A4%EC%9D%B4%EB%B2%84%20035420.KS",
+        "score": 76
       },
       {
         "name": "두산에너빌리티",
         "sector": "Industrials",
         "ticker": "034020.KS",
-        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%EB%91%90%EC%82%B0%EC%97%90%EB%84%88%EB%B9%8C%EB%A6%AC%ED%8B%B0%20034020.KS"
+        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%EB%91%90%EC%82%B0%EC%97%90%EB%84%88%EB%B9%8C%EB%A6%AC%ED%8B%B0%20034020.KS",
+        "score": 67
       },
       {
         "name": "에코프로",
         "sector": "Materials",
         "ticker": "086520.KS",
-        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%EC%97%90%EC%BD%94%ED%94%84%EB%A1%9C%20086520.KS"
+        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%EC%97%90%EC%BD%94%ED%94%84%EB%A1%9C%20086520.KS",
+        "score": 74
       },
       {
         "name": "카카오",
         "sector": "Communication Services",
         "ticker": "035720.KS",
-        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%EC%B9%B4%EC%B9%B4%EC%98%A4%20035720.KS"
+        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%EC%B9%B4%EC%B9%B4%EC%98%A4%20035720.KS",
+        "score": 70
       }
     ]
   },
@@ -137,31 +157,36 @@
         "name": "ABNB",
         "sector": null,
         "ticker": "ABNB",
-        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=ABNB%20ABNB"
+        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=ABNB%20ABNB",
+        "score": 81
       },
       {
         "name": "ADBE",
         "sector": null,
         "ticker": "ADBE",
-        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=ADBE%20ADBE"
+        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=ADBE%20ADBE",
+        "score": 89
       },
       {
         "name": "ADP",
         "sector": null,
         "ticker": "ADP",
-        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=ADP%20ADP"
+        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=ADP%20ADP",
+        "score": 82
       },
       {
         "name": "AMAT",
         "sector": null,
         "ticker": "AMAT",
-        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=AMAT%20AMAT"
+        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=AMAT%20AMAT",
+        "score": 84
       },
       {
         "name": "AMD",
         "sector": "Technology",
         "ticker": "AMD",
-        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=AMD%20AMD"
+        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=AMD%20AMD",
+        "score": 90
       }
     ],
     "aggressive": [
@@ -169,13 +194,15 @@
         "name": "AMGN",
         "sector": null,
         "ticker": "AMGN",
-        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=AMGN%20AMGN"
+        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=AMGN%20AMGN",
+        "score": 69
       },
       {
         "name": "CrowdStrike",
         "sector": "Technology",
         "ticker": "CRWD",
-        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=CrowdStrike%20CRWD"
+        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=CrowdStrike%20CRWD",
+        "score": 77
       }
     ]
   },
@@ -185,31 +212,36 @@
         "name": "ADI",
         "sector": null,
         "ticker": "ADI",
-        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=ADI%20ADI"
+        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=ADI%20ADI",
+        "score": 80
       },
       {
         "name": "Alphabet",
         "sector": "Communication Services",
         "ticker": "GOOGL",
-        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=Alphabet%20GOOGL"
+        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=Alphabet%20GOOGL",
+        "score": 94
       },
       {
         "name": "Amazon",
         "sector": "Consumer Discretionary",
         "ticker": "AMZN",
-        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=Amazon%20AMZN"
+        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=Amazon%20AMZN",
+        "score": 93
       },
       {
         "name": "AVGO",
         "sector": null,
         "ticker": "AVGO",
-        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=AVGO%20AVGO"
+        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=AVGO%20AVGO",
+        "score": 85
       },
       {
         "name": "Microsoft",
         "sector": "Technology",
         "ticker": "MSFT",
-        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=Microsoft%20MSFT"
+        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=Microsoft%20MSFT",
+        "score": 97
       }
     ],
     "aggressive": [
@@ -217,31 +249,36 @@
         "name": "A",
         "sector": null,
         "ticker": "A",
-        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=A%20A"
+        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=A%20A",
+        "score": 62
       },
       {
         "name": "Apple",
         "sector": "Technology",
         "ticker": "AAPL",
-        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=Apple%20AAPL"
+        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=Apple%20AAPL",
+        "score": 96
       },
       {
         "name": "BBY",
         "sector": null,
         "ticker": "BBY",
-        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=BBY%20BBY"
+        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=BBY%20BBY",
+        "score": 63
       },
       {
         "name": "CPB",
         "sector": null,
         "ticker": "CPB",
-        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=CPB%20CPB"
+        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=CPB%20CPB",
+        "score": 61
       },
       {
         "name": "GOOG",
         "sector": null,
         "ticker": "GOOG",
-        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=GOOG%20GOOG"
+        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=GOOG%20GOOG",
+        "score": 90
       }
     ]
   },

--- a/src/template.html
+++ b/src/template.html
@@ -127,7 +127,8 @@
         pickNote: '안전주는 변동성이 낮고 최근 수익률이 안정적인 종목, 공격주는 모멘텀과 거래대금이 높은 종목입니다.',
         updated: '업데이트: ',
         visitsToday: '오늘 방문: {daily} | 총 방문: {total}',
-        noPicks: 'No picks available'
+        noPicks: 'No picks available',
+        scoreSuffix: '매력점수'
       },
       en: {
         title: 'Daily Stock Report Automation',
@@ -152,7 +153,8 @@
         pickNote: 'Safe Picks emphasise consistent performance and lower volatility; Aggressive Picks highlight higher momentum and volume.',
         updated: 'Updated: ',
         visitsToday: 'Visits today: {daily} | Total: {total}',
-        noPicks: 'No picks available'
+        noPicks: 'No picks available',
+        scoreSuffix: 'Attractiveness'
       }
     };
 
@@ -425,11 +427,12 @@
             const name = FULL_NAME_MAP[item.name] || item.name;
             const link = item.searchUrl ? `<a href="${item.searchUrl}" target="_blank" rel="noopener">${name}</a>` : name;
             const sector = item.sector ? `<span class="sector">${item.sector}</span>` : '';
-            return `<li>${link}${sector}</li>`;
+            const score = item.score != null ? `<span class="score">${item.score}</span>` : '';
+            return `<li>${link}${sector}${score}</li>`;
           });
           const list = itemsArr.length ? itemsArr.join('') : `<li class="empty">${translations[currentLang].noPicks}</li>`;
           const label = bucket === 'safe' ? translations[currentLang].safe : translations[currentLang].aggressive;
-          html.push(`<div class="portfolio-group"><h3>${m} ${label}</h3><ul>${list}</ul></div>`);
+          html.push(`<div class="portfolio-group"><h3>${m} ${label} / <span class="score-suffix">${translations[currentLang].scoreSuffix}</span></h3><ul>${list}</ul></div>`);
         }
         html.push(`<small class="tooltip">${translations[currentLang].pickNote}</small>`);
       }

--- a/stocks.css
+++ b/stocks.css
@@ -145,6 +145,17 @@ tr:hover {
   font-size: 0.85em;
 }
 
+.portfolio-group .score {
+  margin-left: 4px;
+  color: #2563eb;
+  font-size: 0.85em;
+}
+
+.portfolio-group .score-suffix {
+  color: #6b7280;
+  font-size: 0.85em;
+}
+
 .tooltip {
   display: block;
   color: #6b7280;

--- a/stocks.html
+++ b/stocks.html
@@ -61,7 +61,7 @@
 <body>
   <a href="index.html" class="home-button" aria-label="Home">&#x21A9;</a>
   <h1 data-i18n="title">데일리 주식 리포트 자동화</h1>
-  <p id="currentDate"><span id="datePrefix" data-i18n="today">오늘:</span> 2025년 8월 19일</p>
+  <p id="currentDate"><span id="datePrefix" data-i18n="today">오늘:</span> 2025년 8월 27일</p>
   
   <div id="debugInfo" class="debug" style="display: none;">
     <h4>디버그 정보:</h4>
@@ -127,7 +127,8 @@
         pickNote: '안전주는 변동성이 낮고 최근 수익률이 안정적인 종목, 공격주는 모멘텀과 거래대금이 높은 종목입니다.',
         updated: '업데이트: ',
         visitsToday: '오늘 방문: {daily} | 총 방문: {total}',
-        noPicks: 'No picks available'
+        noPicks: 'No picks available',
+        scoreSuffix: '매력점수'
       },
       en: {
         title: 'Daily Stock Report Automation',
@@ -152,7 +153,8 @@
         pickNote: 'Safe Picks emphasise consistent performance and lower volatility; Aggressive Picks highlight higher momentum and volume.',
         updated: 'Updated: ',
         visitsToday: 'Visits today: {daily} | Total: {total}',
-        noPicks: 'No picks available'
+        noPicks: 'No picks available',
+        scoreSuffix: 'Attractiveness'
       }
     };
 
@@ -425,11 +427,12 @@
             const name = FULL_NAME_MAP[item.name] || item.name;
             const link = item.searchUrl ? `<a href="${item.searchUrl}" target="_blank" rel="noopener">${name}</a>` : name;
             const sector = item.sector ? `<span class="sector">${item.sector}</span>` : '';
-            return `<li>${link}${sector}</li>`;
+            const score = item.score != null ? `<span class="score">${item.score}</span>` : '';
+            return `<li>${link}${sector}${score}</li>`;
           });
           const list = itemsArr.length ? itemsArr.join('') : `<li class="empty">${translations[currentLang].noPicks}</li>`;
           const label = bucket === 'safe' ? translations[currentLang].safe : translations[currentLang].aggressive;
-          html.push(`<div class="portfolio-group"><h3>${m} ${label}</h3><ul>${list}</ul></div>`);
+          html.push(`<div class="portfolio-group"><h3>${m} ${label} / <span class="score-suffix">${translations[currentLang].scoreSuffix}</span></h3><ul>${list}</ul></div>`);
         }
         html.push(`<small class="tooltip">${translations[currentLang].pickNote}</small>`);
       }


### PR DESCRIPTION
## Summary
- Clarify score suffix translation for headings and render as " / Attractiveness" in English
- Style score suffix in portfolio section headings and rebuild stock page

## Testing
- `node src/build.js`
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68aef8ade890832aada11b83919997b3