### PR TITLE
Normalize metric weights when data missing

### DIFF
--- a/fetchStockInfo.js
+++ b/fetchStockInfo.js
@@ -4,6 +4,16 @@ import { existsSync } from 'fs';
 import path from 'node:path';
 import { nowKSTISO } from './utils/time.js';
 
+const poolsMetricsRaw = JSON.parse(
+  await readFile(new URL('./pools-metrics.json', import.meta.url), 'utf8')
+);
+const newsFeatures = JSON.parse(
+  await readFile(new URL('./data/news-features.json', import.meta.url), 'utf8')
+);
+const naverTrends = JSON.parse(
+  await readFile(new URL('./data/naver-trends.json', import.meta.url), 'utf8')
+);
+
 const OUT_FILE = path.resolve(process.cwd(), 'recommendations.json');
 const MAX_AGE_MS = 6 * 60 * 60 * 1000;
 const ARGS = new Set(process.argv.slice(2));
@@ -192,6 +202,43 @@ function totalCount(out) {
     n += (out[m]?.safe?.length || 0) + (out[m]?.aggressive?.length || 0);
   }
   return n;
+}
+
+function calcRawScore(market, tier, name, ticker) {
+  const marketData = poolsMetricsRaw.markets?.[market] || poolsMetricsRaw[market];
+  const metrics = marketData?.[name];
+  const base = typeof metrics?.score?.[tier] === 'number' ? metrics.score[tier] : 0;
+  const news = ticker ? (newsFeatures[ticker] || {}) : {};
+  const trend = ticker ? (naverTrends[ticker] || {}) : {};
+  const rnd = seededRandom(ticker || name);
+  const jitter = rnd() * 0.01;
+
+  const signals = [];
+  const baseWeights = { sentiment: 0.1, count: 0.01, blog: 0.15, naver: 0.3 };
+  if (typeof news.sentiment === 'number') signals.push({ v: news.sentiment, w: baseWeights.sentiment });
+  if (typeof news.count === 'number') signals.push({ v: news.count, w: baseWeights.count });
+  if (typeof news.blogMentions === 'number') signals.push({ v: news.blogMentions, w: baseWeights.blog });
+  if (typeof trend.naverPopularity === 'number') signals.push({ v: trend.naverPopularity, w: baseWeights.naver });
+
+  const totalOrig = baseWeights.sentiment + baseWeights.count + baseWeights.blog + baseWeights.naver;
+  const totalAvail = signals.reduce((s, x) => s + x.w, 0);
+  const scale = totalAvail > 0 ? totalOrig / totalAvail : 0;
+  const extra = signals.reduce((s, x) => s + x.v * x.w * scale, 0);
+
+  return base + extra + jitter;
+}
+
+function scaleScores(entries, tier) {
+  const raws = entries.map(e => e.rawScore);
+  const min = Math.min(...raws);
+  const max = Math.max(...raws);
+  for (const e of entries) {
+    const norm = (e.rawScore - min) / (max - min || 1);
+    let score = Math.round(50 + norm * 50);
+    if (tier === 'safe') score = Math.min(100, score + 5);
+    e.score = score;
+    delete e.rawScore;
+  }
 }
 
 // More stable headers
@@ -636,13 +683,14 @@ async function tryFetchAndEnrich() {
             name,
             sector: sector || prevSector || null,
             ticker: ticker || null,
-            searchUrl: searchUrl || null
+            searchUrl: searchUrl || null,
+            rawScore: calcRawScore(market, group, name, ticker)
           });
 
           if (sector) successCount++;
         } catch (err) {
           console.error(`[ERROR] ${name}: ${err.message}`);
-          updated.push({ name, sector: prevSector || null, ticker: null, searchUrl: null });
+          updated.push({ name, sector: prevSector || null, ticker: null, searchUrl: null, rawScore: calcRawScore(market, group, name, null) });
           noteStatus(err);
 
           if (consecutive429 >= 5) {
@@ -655,6 +703,7 @@ async function tryFetchAndEnrich() {
         await sleep(delay);
       }
 
+      scaleScores(updated, group);
       data[market][group] = updated;
     }
   }
@@ -702,6 +751,15 @@ async function main() {
 
     const pools = await loadPools();
     const rotated = sortData(rotateFromPools(pools, prev));
+    for (const [market, bucket] of Object.entries(rotated)) {
+      for (const tier of ['safe', 'aggressive']) {
+        const arr = bucket[tier] || [];
+        for (const entry of arr) {
+          entry.rawScore = calcRawScore(market, tier, entry.name, null);
+        }
+        scaleScores(arr, tier);
+      }
+    }
     let out = { ...rotated, lastUpdated: nowKSTISO() };
     pruneEmptyMarkets(out);
     ensureNonEmpty(out);

--- a/recommendations.json
+++ b/recommendations.json
@@ -6,35 +6,35 @@
         "sector": "Industrials",
         "ticker": "277810.KQ",
         "searchUrl": "https://www.google.com/search?tbm=nws&q=%EB%A0%88%EC%9D%B8%EB%B3%B4%EC%9A%B0%EB%A1%9C%EB%B3%B4%ED%8B%B1%EC%8A%A4%20277810.KQ",
-        "score": 92
+        "score": 59
       },
       {
         "name": "리노공업",
         "sector": "Industrials",
         "ticker": "058470.KQ",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%EB%A6%AC%EB%85%B8%EA%B3%B5%EC%97%85%20058470.KQ",
-        "score": 86
+        "score": 61
       },
       {
         "name": "알테오젠",
         "sector": "Healthcare",
         "ticker": "196170.KQ",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%EC%95%8C%ED%85%8C%EC%98%A4%EC%A0%A0%20196170.KQ",
-        "score": 84
+        "score": 100
       },
       {
         "name": "에코프로비엠",
         "sector": "Materials",
         "ticker": "247540.KQ",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%EC%97%90%EC%BD%94%ED%94%84%EB%A1%9C%EB%B9%84%EC%97%A0%20247540.KQ",
-        "score": 90
+        "score": 63
       },
       {
         "name": "펩트론",
         "sector": "Healthcare",
         "ticker": "087010.KQ",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%ED%8E%A9%ED%8A%B8%EB%A1%A0%20087010.KQ",
-        "score": 82
+        "score": 55
       }
     ],
     "aggressive": [
@@ -43,35 +43,35 @@
         "sector": "Communication Services",
         "ticker": "035760.KQ",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=CJ%20ENM%20035760.KQ",
-        "score": 75
+        "score": 100
       },
       {
         "name": "HLB",
         "sector": null,
         "ticker": "HLB",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=HLB%20HLB",
-        "score": 60
+        "score": 90
       },
       {
         "name": "JYP엔터테인먼트",
         "sector": "Communication Services",
         "ticker": "035900.KQ",
         "searchUrl": "https://www.google.com/search?tbm=nws&q=JYP%EC%97%94%ED%84%B0%ED%85%8C%EC%9D%B8%EB%A8%BC%ED%8A%B8%20035900.KQ",
-        "score": 73
+        "score": 86
       },
       {
         "name": "셀트리온헬스케어",
         "sector": "Healthcare",
         "ticker": "091990.KQ",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%EC%85%80%ED%8A%B8%EB%A6%AC%EC%98%A8%ED%97%AC%EC%8A%A4%EC%BC%80%EC%96%B4%20091990.KQ",
-        "score": 68
+        "score": 50
       },
       {
         "name": "펄어비스",
         "sector": "Communication Services",
         "ticker": "263750.KQ",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%ED%8E%84%EC%96%B4%EB%B9%84%EC%8A%A4%20263750.KQ",
-        "score": 70
+        "score": 88
       }
     ]
   },
@@ -82,35 +82,35 @@
         "sector": null,
         "ticker": "373220.KS",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=LG%EC%97%90%EB%84%88%EC%A7%80%EC%86%94%EB%A3%A8%EC%85%98%20373220.KS",
-        "score": 88
+        "score": 55
       },
       {
         "name": "LG화학",
         "sector": "Materials",
         "ticker": "051910.KS",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=LG%ED%99%94%ED%95%99%20051910.KS",
-        "score": 91
+        "score": 78
       },
       {
         "name": "기아",
         "sector": "Consumer Discretionary",
         "ticker": "000270.KS",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%EA%B8%B0%EC%95%84%20000270.KS",
-        "score": 83
+        "score": 56
       },
       {
         "name": "삼성전자",
         "sector": "Technology",
         "ticker": "005930.KS",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%EC%82%BC%EC%84%B1%EC%A0%84%EC%9E%90%20005930.KS",
-        "score": 95
+        "score": 100
       },
       {
         "name": "셀트리온",
         "sector": "Healthcare",
         "ticker": "068270.KS",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%EC%85%80%ED%8A%B8%EB%A6%AC%EC%98%A8%20068270.KS",
-        "score": 87
+        "score": 56
       }
     ],
     "aggressive": [
@@ -119,35 +119,35 @@
         "sector": "Industrials",
         "ticker": "267260.KS",
         "searchUrl": "https://www.google.com/search?tbm=nws&q=HD%ED%98%84%EB%8C%80%EC%9D%BC%EB%A0%89%ED%8A%B8%EB%A6%AD%20267260.KS",
-        "score": 72
+        "score": 71
       },
       {
         "name": "네이버",
         "sector": "Communication Services",
         "ticker": "035420.KS",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%EB%84%A4%EC%9D%B4%EB%B2%84%20035420.KS",
-        "score": 76
+        "score": 64
       },
       {
         "name": "두산에너빌리티",
         "sector": "Industrials",
         "ticker": "034020.KS",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%EB%91%90%EC%82%B0%EC%97%90%EB%84%88%EB%B9%8C%EB%A6%AC%ED%8B%B0%20034020.KS",
-        "score": 67
+        "score": 100
       },
       {
         "name": "에코프로",
         "sector": "Materials",
         "ticker": "086520.KS",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%EC%97%90%EC%BD%94%ED%94%84%EB%A1%9C%20086520.KS",
-        "score": 74
+        "score": 50
       },
       {
         "name": "카카오",
         "sector": "Communication Services",
         "ticker": "035720.KS",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%EC%B9%B4%EC%B9%B4%EC%98%A4%20035720.KS",
-        "score": 70
+        "score": 53
       }
     ]
   },
@@ -158,35 +158,35 @@
         "sector": null,
         "ticker": "ABNB",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=ABNB%20ABNB",
-        "score": 81
+        "score": 66
       },
       {
         "name": "ADBE",
         "sector": null,
         "ticker": "ADBE",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=ADBE%20ADBE",
-        "score": 89
+        "score": 100
       },
       {
         "name": "ADP",
         "sector": null,
         "ticker": "ADP",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=ADP%20ADP",
-        "score": 82
+        "score": 55
       },
       {
         "name": "AMAT",
         "sector": null,
         "ticker": "AMAT",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=AMAT%20AMAT",
-        "score": 84
+        "score": 89
       },
       {
         "name": "AMD",
         "sector": "Technology",
         "ticker": "AMD",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=AMD%20AMD",
-        "score": 90
+        "score": 85
       }
     ],
     "aggressive": [
@@ -195,14 +195,14 @@
         "sector": null,
         "ticker": "AMGN",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=AMGN%20AMGN",
-        "score": 69
+        "score": 100
       },
       {
         "name": "CrowdStrike",
         "sector": "Technology",
         "ticker": "CRWD",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=CrowdStrike%20CRWD",
-        "score": 77
+        "score": 50
       }
     ]
   },
@@ -213,35 +213,35 @@
         "sector": null,
         "ticker": "ADI",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=ADI%20ADI",
-        "score": 80
+        "score": 55
       },
       {
         "name": "Alphabet",
         "sector": "Communication Services",
         "ticker": "GOOGL",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=Alphabet%20GOOGL",
-        "score": 94
+        "score": 75
       },
       {
         "name": "Amazon",
         "sector": "Consumer Discretionary",
         "ticker": "AMZN",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=Amazon%20AMZN",
-        "score": 93
+        "score": 100
       },
       {
         "name": "AVGO",
         "sector": null,
         "ticker": "AVGO",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=AVGO%20AVGO",
-        "score": 85
+        "score": 95
       },
       {
         "name": "Microsoft",
         "sector": "Technology",
         "ticker": "MSFT",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=Microsoft%20MSFT",
-        "score": 97
+        "score": 91
       }
     ],
     "aggressive": [
@@ -250,37 +250,37 @@
         "sector": null,
         "ticker": "A",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=A%20A",
-        "score": 62
+        "score": 98
       },
       {
         "name": "Apple",
         "sector": "Technology",
         "ticker": "AAPL",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=Apple%20AAPL",
-        "score": 96
+        "score": 100
       },
       {
         "name": "BBY",
         "sector": null,
         "ticker": "BBY",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=BBY%20BBY",
-        "score": 63
+        "score": 61
       },
       {
         "name": "CPB",
         "sector": null,
         "ticker": "CPB",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=CPB%20CPB",
-        "score": 61
+        "score": 54
       },
       {
         "name": "GOOG",
         "sector": null,
         "ticker": "GOOG",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=GOOG%20GOOG",
-        "score": 90
+        "score": 50
       }
     ]
   },
-  "lastUpdated": "2025-08-27T19:25:14+09:00"
+  "lastUpdated": "2025-08-27T22:24:30+09:00"
 }

--- a/ticker-cache.json
+++ b/ticker-cache.json
@@ -6,7 +6,7 @@
     },
     "005930.KS": {
       "value": "Technology",
-      "ts": 1755689573941
+      "ts": 1756299676354
     },
     "000660.KS": {
       "value": "Technology",
@@ -14,31 +14,31 @@
     },
     "035720.KS": {
       "value": "Communication Services",
-      "ts": 1755689575276
+      "ts": 1756299679392
     },
     "035420.KS": {
       "value": "Communication Services",
-      "ts": 1755689575908
+      "ts": 1756299678758
     },
     "091990.KQ": {
       "value": "Healthcare",
-      "ts": 1755689576466
+      "ts": 1756299685396
     },
     "263750.KQ": {
       "value": "Communication Services",
-      "ts": 1755689577151
+      "ts": 1756299684848
     },
     "277810.KQ": {
       "value": "Industrials",
-      "ts": 1755689577684
+      "ts": 1756299683564
     },
     "035760.KQ": {
       "value": "Communication Services",
-      "ts": 1755689578354
+      "ts": 1756299684198
     },
     "058470.KQ": {
       "value": "Industrials",
-      "ts": 1755689579034
+      "ts": 1756299681779
     },
     "UNH": {
       "value": "Healthcare",
@@ -54,11 +54,11 @@
     },
     "GOOGL": {
       "value": "Communication Services",
-      "ts": 1755689581687
+      "ts": 1756299688553
     },
     "AAPL": {
       "value": "Technology",
-      "ts": 1755689582218
+      "ts": 1756299692244
     },
     "BRK-B": {
       "value": "Financial Services",
@@ -86,7 +86,7 @@
     },
     "MSFT": {
       "value": "Technology",
-      "ts": 1755689586457
+      "ts": 1756299689226
     },
     "PEP": {
       "value": "Consumer Staples",
@@ -94,19 +94,19 @@
     },
     "AMD": {
       "value": "Technology",
-      "ts": 1755689588394
+      "ts": 1756299693428
     },
     "068270.KS": {
       "value": "Healthcare",
-      "ts": 1755689631848
+      "ts": 1756299675138
     },
     "267260.KS": {
       "value": "Industrials",
-      "ts": 1755689632415
+      "ts": 1756299680582
     },
     "086520.KS": {
       "value": "Materials",
-      "ts": 1755689632955
+      "ts": 1756299680061
     },
     "278280.KQ": {
       "value": "Industrials",
@@ -114,11 +114,11 @@
     },
     "247540.KQ": {
       "value": "Materials",
-      "ts": 1755689637096
+      "ts": 1756299682458
     },
     "CRWD": {
       "value": "Technology",
-      "ts": 1755689646770
+      "ts": 1756299696494
     },
     "MDB": {
       "value": "Technology",

--- a/tools/buildPoolsTrendy.js
+++ b/tools/buildPoolsTrendy.js
@@ -920,7 +920,22 @@ async function main(){
       const sentimentNorm = ((byName[n].sentiment ?? 0) + 1) / 2;
       const pop = byName[n].naverPopularity ?? 0;
       const blogNorm = nBlog[i];
-      const newsBoost = newsCountNorm * 0.12 + (sentimentNorm - 0.5) * 0.08 + (isKRName ? pop * 0.20 : 0) + blogNorm * 0.05;
+
+      const weights = {
+        count: 0.12,
+        sentiment: 0.08,
+        naver: isKRName ? 0.30 : 0,
+        blog: 0.15,
+      };
+      const totalOrig = weights.count + weights.sentiment + weights.naver + weights.blog;
+      let totalAvail = 0;
+      let newsBoost = 0;
+      if (byName[n].newsCount != null) { newsBoost += newsCountNorm * weights.count; totalAvail += weights.count; }
+      if (byName[n].sentiment != null) { newsBoost += (sentimentNorm - 0.5) * weights.sentiment; totalAvail += weights.sentiment; }
+      if (isKRName && byName[n].naverPopularity != null) { newsBoost += pop * weights.naver; totalAvail += weights.naver; }
+      if (byName[n].blogMentions != null) { newsBoost += blogNorm * weights.blog; totalAvail += weights.blog; }
+      const scale = totalAvail > 0 ? totalOrig / totalAvail : 0;
+      newsBoost *= scale;
 
       const safe = clamp01(baseKR + 0.40*nRet20[i] + 0.30*(1 - nVol[i]) + newsBoost + 0.10*earnBonus);
       const aggr = clamp01(baseKR + 0.40*nRet5[i]  + 0.30*nTurn[i]     + 0.20*nVol[i] + newsBoost + earnBonus);


### PR DESCRIPTION
## Summary
- normalize news/trend signal weights in pool trending builder so missing Naver or blog metrics don't drag scores
- scale recommendation raw-score weights to available signals before computing final attractiveness

## Testing
- `node tools/buildPoolsTrendy.js --offline`
- `node fetchStockInfo.js --force`
- `OFFLINE=1 node src/build.js`
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68af01122a5c832a9b795ac5b4e04d66