### PR TITLE
Add localized dashboard link below report title

### DIFF
--- a/src/template.html
+++ b/src/template.html
@@ -61,6 +61,7 @@
 <body>
   <a href="index.html" class="home-button" aria-label="Home">&#x21A9;</a>
   <h1 data-i18n="title">데일리 주식 리포트 자동화</h1>
+  <p class="dashboard-link"><a data-i18n="dashboardLink" href="stocks/index.html">Stock News Summary Dashboard</a></p>
   <p id="currentDate"><span id="datePrefix" data-i18n="today">오늘:</span> {{CURRENT_DATE}}</p>
   
   <div id="debugInfo" class="debug" style="display: none;">
@@ -119,6 +120,7 @@
         disclaimer: '본 페이지의 정보는 투자 참고용이며, 제공된 데이터의 정확성을 보장하지 않습니다. 투자 판단의 책임은 이용자에게 있습니다.',
         marketNews: '최신 마켓 뉴스',
         portfolioRecs: '포트폴리오 추천',
+        dashboardLink: '주식 시장 요약 대시보드',
         marketDataError: '마켓 데이터를 불러오지 못했습니다.',
         newsError: '뉴스를 불러오지 못했습니다.',
         recsError: '추천 데이터를 불러오지 못했습니다.',
@@ -145,6 +147,7 @@
         disclaimer: 'Information on this page is for reference only and accuracy is not guaranteed. Investment decisions are your responsibility.',
         marketNews: 'Latest Market News',
         portfolioRecs: 'Portfolio Recommendations',
+        dashboardLink: 'Stock News Summary Dashboard',
         marketDataError: 'Failed to load market data.',
         newsError: 'Failed to load news.',
         recsError: 'Failed to load recommendations.',

--- a/stocks.css
+++ b/stocks.css
@@ -16,6 +16,21 @@ h1 {
   margin-bottom: 20px;
 }
 
+.dashboard-link {
+  text-align: center;
+  margin: 10px 0;
+}
+
+.dashboard-link a {
+  color: #3498db;
+  font-weight: bold;
+  text-decoration: none;
+}
+
+.dashboard-link a:hover {
+  text-decoration: underline;
+}
+
 h2 {
   color: #34495e;
   border-left: 4px solid #3498db;

--- a/stocks.html
+++ b/stocks.html
@@ -61,6 +61,7 @@
 <body>
   <a href="index.html" class="home-button" aria-label="Home">&#x21A9;</a>
   <h1 data-i18n="title">데일리 주식 리포트 자동화</h1>
+  <p class="dashboard-link"><a data-i18n="dashboardLink" href="stocks/index.html">Stock News Summary Dashboard</a></p>
   <p id="currentDate"><span id="datePrefix" data-i18n="today">오늘:</span> 2025년 8월 27일</p>
   
   <div id="debugInfo" class="debug" style="display: none;">
@@ -119,6 +120,7 @@
         disclaimer: '본 페이지의 정보는 투자 참고용이며, 제공된 데이터의 정확성을 보장하지 않습니다. 투자 판단의 책임은 이용자에게 있습니다.',
         marketNews: '최신 마켓 뉴스',
         portfolioRecs: '포트폴리오 추천',
+        dashboardLink: '주식 시장 요약 대시보드',
         marketDataError: '마켓 데이터를 불러오지 못했습니다.',
         newsError: '뉴스를 불러오지 못했습니다.',
         recsError: '추천 데이터를 불러오지 못했습니다.',
@@ -145,6 +147,7 @@
         disclaimer: 'Information on this page is for reference only and accuracy is not guaranteed. Investment decisions are your responsibility.',
         marketNews: 'Latest Market News',
         portfolioRecs: 'Portfolio Recommendations',
+        dashboardLink: 'Stock News Summary Dashboard',
         marketDataError: 'Failed to load market data.',
         newsError: 'Failed to load news.',
         recsError: 'Failed to load recommendations.',
@@ -551,7 +554,6 @@
     <button id="btnEn">English</button>
   </div>
   <div id="visitCounts" style="text-align:center;margin-top:20px;font-size:0.8rem;color:#64748b;"></div>
-  <p style="text-align:center;margin-top:20px;"><a href="stocks/index.html">Stock News Summary Dashboard</a></p>
   <!-- FX ticker (below view count) -->
   <div id="fx-ticker" class="fx-ticker">
     <div id="fx-line" class="fx-track"></div>


### PR DESCRIPTION
## Summary
- Insert a prominent Stock News Summary Dashboard link beneath the "데일리 주식 리포트 자동화" heading.
- Localize the new link text for Korean and English visitors and add matching styles.
- Regenerate stock page from template.

## Testing
- `OFFLINE=1 node src/build.js`
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68af1080b60c832a915e3e52584492c5