### PR TITLE
feat: fetch 5‑ and 20‑day returns from multiple APIs

### DIFF
--- a/.github/workflows/stock-recs.yml
+++ b/.github/workflows/stock-recs.yml
@@ -196,6 +196,9 @@ jobs:
             validate_json
           fi
 
+      - name: Fetch price returns
+        run: node fetchReturns.js
+
       # ⬇️ Added from daily-build.yml
       - name: "Preflight: outbound connectivity (SerpApi/GDELT)"
         shell: bash
@@ -259,7 +262,7 @@ jobs:
       - name: Stage new data files
         shell: bash
         run: |
-          git add data/market_news.json data/fx_rates.json summary.json summary.md data/articles || true
+          git add data/market_news.json data/fx_rates.json summary.json summary.md data/articles pools-metrics.json || true
           echo "Files staged for commit"
 
       - name: "Commit & push changes"

--- a/fetchReturns.js
+++ b/fetchReturns.js
@@ -1,0 +1,35 @@
+import fs from 'fs/promises';
+import { getCandles } from './src/data/candles.js';
+
+const rec = JSON.parse(await fs.readFile('recommendations.json', 'utf8'));
+const out = {};
+
+for (const [market, buckets] of Object.entries(rec)) {
+  if (market === 'lastUpdated') continue;
+  out[market] = {};
+  for (const bucket of ['safe', 'aggressive']) {
+    const list = Array.isArray(buckets[bucket]) ? buckets[bucket] : [];
+    for (const entry of list) {
+      const name = entry.name;
+      const ticker = entry.ticker;
+      if (!ticker) continue;
+      try {
+        const candles = await getCandles(ticker);
+        if (!candles || !Array.isArray(candles.c)) continue;
+        const c = candles.c;
+        const n = c.length;
+        const latest = c[n-1];
+        const c5 = c[n-6];
+        const c20 = c[n-21];
+        const ret5 = (c5 != null && latest != null) ? ((latest - c5) / c5 * 100) : null;
+        const ret20 = (c20 != null && latest != null) ? ((latest - c20) / c20 * 100) : null;
+        out[market][name] = { ret5, ret20 };
+      } catch (e) {
+        console.warn(`[returns] ${ticker} failed: ${e.message}`);
+      }
+    }
+  }
+}
+
+await fs.writeFile('pools-metrics.json', JSON.stringify(out, null, 2));
+console.log('Wrote pools-metrics.json');

--- a/src/data/candles.js
+++ b/src/data/candles.js
@@ -4,6 +4,7 @@ import path from 'path';
 const FINNHUB = process.env.FINNHUB_API_KEY || '';
 const TWELVE = process.env.TWELVEDATA_API_KEY || '';
 const FMP = process.env.FMP_KEY || '';
+const POLYGON = process.env.POLYGON_API_KEY || '';
 
 const REQ_TIMEOUT_MS = Number(process.env.REQ_TIMEOUT_MS || 8000);
 const CIRCUIT_MAX_ERRORS = Number(process.env.CIRCUIT_MAX_ERRORS || 8);
@@ -16,6 +17,10 @@ const state = {
   finnhub:    { errors: 0, coolUntil: 0, count: 0, ok: 0, err: 0, '429': 0 },
   twelvedata: { errors: 0, coolUntil: 0, count: 0, ok: 0, err: 0, '429': 0 },
   fmp:        { errors: 0, coolUntil: 0, count: 0, ok: 0, err: 0, '429': 0 },
+  yahoo:      { errors: 0, coolUntil: 0, count: 0, ok: 0, err: 0, '429': 0 },
+  polygon:    { errors: 0, coolUntil: 0, count: 0, ok: 0, err: 0, '429': 0 },
+  naver:      { errors: 0, coolUntil: 0, count: 0, ok: 0, err: 0, '429': 0 },
+  google:     { errors: 0, coolUntil: 0, count: 0, ok: 0, err: 0, '429': 0 },
 };
 
 function toTwelveSymbol(sym){
@@ -114,18 +119,82 @@ async function fmpCandles(symbol){
   return { c: close, v: volumes };
 }
 
-const adapters = { finnhub: finnhubCandles, twelvedata: twelveCandles, fmp: fmpCandles };
+async function yahooCandles(symbol){
+  const url = `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(symbol)}?range=1mo&interval=1d`;
+  const j = await fetchJSON(url);
+  const res = j?.chart?.result?.[0];
+  if (!res) throw new Error('bad yahoo');
+  const close = res.indicators?.quote?.[0]?.close || [];
+  const vol = res.indicators?.quote?.[0]?.volume || [];
+  return { c: close, v: vol };
+}
+
+async function polygonCandles(symbol){
+  const to = new Date();
+  const from = new Date(Date.now() - 40*24*60*60*1000);
+  const fmt = d => d.toISOString().slice(0,10);
+  const url = `https://api.polygon.io/v2/aggs/ticker/${encodeURIComponent(symbol)}/range/1/day/${fmt(from)}/${fmt(to)}?adjusted=true&apiKey=${POLYGON}`;
+  const j = await fetchJSON(url);
+  if (!Array.isArray(j?.results)) throw new Error('bad polygon');
+  const close = j.results.map(r=>Number(r.c));
+  const vol = j.results.map(r=>Number(r.v||0));
+  return { c: close, v: vol };
+}
+
+async function naverCandles(symbol){
+  const m = String(symbol).match(/^(\d{6})\.(K[QS])$/);
+  if (!m) throw new Error('naver supports only KR');
+  const sym = m[1];
+  const url = `https://api.stock.naver.com/chart/domestic/item/${sym}?timeframe=day&count=40`;
+  const res = await fetch(url, { headers: { 'User-Agent': 'Mozilla/5.0', 'Referer': 'https://stock.naver.com' }});
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const j = await res.json();
+  const data = j?.data;
+  if (!Array.isArray(data)) throw new Error('bad naver');
+  const close = data.map(d=>Number(d.closePrice));
+  const vol = data.map(d=>Number(d.tradeVolume||0));
+  return { c: close, v: vol };
+}
+
+async function googleCandles(symbol){
+  const url = `https://www.google.com/finance/quote/${encodeURIComponent(symbol)}?window=1M`;
+  const res = await fetch(url, { headers: { 'User-Agent': 'Mozilla/5.0' }});
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const text = await res.text();
+  const m = text.match(/"prices":(\[[^\]]+\])/);
+  if (!m) throw new Error('bad google');
+  const arr = JSON.parse(m[1]);
+  const close = arr.map(p=>Number(p[1]));
+  const vol = arr.map(p=>Number(p[2]||0));
+  return { c: close, v: vol };
+}
+
+const adapters = {
+  finnhub: finnhubCandles,
+  twelvedata: twelveCandles,
+  fmp: fmpCandles,
+  yahoo: yahooCandles,
+  polygon: polygonCandles,
+  naver: naverCandles,
+  google: googleCandles,
+};
 
 function hasKey(provider){
   if (provider === 'finnhub') return !!FINNHUB;
   if (provider === 'twelvedata') return !!TWELVE;
   if (provider === 'fmp') return !!FMP;
+  if (provider === 'polygon') return !!POLYGON;
+  // yahoo, naver and google do not require keys
+  if (provider === 'yahoo') return true;
+  if (provider === 'naver') return true;
+  if (provider === 'google') return true;
   return false;
 }
 
 export async function getCandles(symbol, opts={}){
   const isKR = /\.K[QS]$/.test(symbol);
-  const order = isKR ? ['twelvedata','fmp'] : ['finnhub','twelvedata','fmp'];
+  const order = isKR ? ['naver','yahoo','polygon','twelvedata','fmp','google','finnhub']
+                      : ['finnhub','yahoo','polygon','twelvedata','fmp','google','naver'];
   const attempts = [];
   const ttl = Number(opts.cacheTtlMs || CACHE_TTL_MS);
   const maxPer = Number.isFinite(opts.maxPerProvider) ? opts.maxPerProvider : Infinity;


### PR DESCRIPTION
## Summary
- add Yahoo, Polygon, Naver and Google candle adapters to price fetcher
- compute 5d/20d returns for recommendations via new fetchReturns script
- run return fetching step in stock-recs workflow and stage metrics

## Testing
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68af9540e1b0832a8cf5de4c20c92db2