### PR TITLE
feat: add index ticker maps updater

### DIFF
--- a/.github/workflows/stock-recs.yml
+++ b/.github/workflows/stock-recs.yml
@@ -157,6 +157,11 @@ jobs:
           echo "npm ci failed after retries."
           exit 1
 
+      - name: Build index ticker maps
+        run: node tools/updateIndexMaps.mjs
+        env:
+          FMP_KEY: ${{ secrets.FMP_KEY }}
+
       - name: Build trend-aware pools
         env:
           FMP_KEY: ${{ secrets.FMP_KEY }}

--- a/fetchStockInfo.js
+++ b/fetchStockInfo.js
@@ -264,7 +264,7 @@ const HEADERS_JSON = {
 const normalizeForYahoo = s => s.replace(/\./g, '-'); // if you decide to use it later
 
 // Extended static ticker mapping including KOSDAQ
-const TICKER_MAP = {
+const TICKER_BASE = {
   // KOSPI
   '삼성전자': '005930.KS', 'SK하이닉스': '000660.KS', '삼성바이오로직스': '207940.KS',
   '현대차': '005380.KS', 'LG에너지솔루션': '373220.KS', '한화에어로스페이스': '012450.KS',
@@ -292,6 +292,31 @@ const TICKER_MAP = {
   'NRG Energy': 'NRG', 'JPMorgan Chase': 'JPM', 'UnitedHealth': 'UNH',
   'Moderna': 'MRNA', 'Zoom': 'ZM', 'MongoDB': 'MDB', 'Snowflake': 'SNOW'
 };
+
+// Load generated index map (if the updater ran)
+let INDEX_MAP = {};
+try {
+  INDEX_MAP = JSON.parse(
+    await readFile(new URL('./src/maps.indexes.json', import.meta.url), 'utf8')
+  );
+} catch { /* first run or offline: fine */ }
+
+// Optional: normalize lookup (so keys with extra spaces still hit)
+const normalizeKey = s =>
+  String(s || '')
+    .normalize('NFKC')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+// Final map the rest of the file will use:
+const TICKER_MAP = new Proxy({ ...INDEX_MAP, ...TICKER_BASE }, {
+  get(target, prop) {
+    if (typeof prop !== 'string') return target[prop];
+    const direct = target[prop]; if (direct) return direct;
+    const n = normalizeKey(prop);
+    return target[n] || undefined;
+  }
+});
 
 // Extended static sector mapping (consistent naming)
 const STATIC_SECTORS = {

--- a/tools/updateIndexMaps.mjs
+++ b/tools/updateIndexMaps.mjs
@@ -1,0 +1,104 @@
+// Build a name -> ticker dictionary for S&P 500 + Nasdaq 100
+import { writeFile, mkdir } from "fs/promises";
+
+const FMP = process.env.FMP_KEY || ""; // optional; falls back to Wikipedia if empty
+
+async function json(url) {
+  const r = await fetch(url, { headers: { "User-Agent": "stock-recs/ci" } });
+  if (!r.ok) throw new Error(`HTTP ${r.status} @ ${url}`);
+  return r.json();
+}
+async function text(url) {
+  const r = await fetch(url, { headers: { "User-Agent": "stock-recs/ci" } });
+  if (!r.ok) throw new Error(`HTTP ${r.status} @ ${url}`);
+  return r.text();
+}
+
+function normName(s) {
+  return String(s || "")
+    .normalize("NFKC")
+    .replace(/\u00AD|\u034F|\u061C|[\u200E\u200F\u202A-\u202E\u2060\u2066-\u2069]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+// Expand common name variants (Inc., Corp., PLC; “Class A/B/C”; & vs and)
+function expandVariants(name) {
+  const n = normName(name);
+  const variants = new Set([n]);
+  const base = n
+    .replace(/,?\s+(Inc\.?|Incorporated|Corp\.?|Corporation|Company|Co\.?|Ltd\.?|Limited|PLC|N\.V\.|S\.A\.|A\/S)$/i, "")
+    .trim();
+  variants.add(base);
+  variants.add(base.replace(/\s*&\s*/g, " and "));
+  variants.add(base.replace(/\s+and\s+/gi, " & "));
+  variants.add(base.replace(/\s+/g, "")); // super-lenient
+
+  // class shares
+  const m = base.match(/\b(Class|Series)\s+([ABCDEF])\b/i);
+  if (m) {
+    const cls = m[2].toUpperCase();
+    variants.add(base.replace(/\s*\(?(Class|Series)\s+[A-F]\)?/i, "").trim());
+    variants.add(`${base.replace(/\s*\(?(Class|Series)\s+[A-F]\)?/i, "").trim()} (${cls})`);
+  }
+  return [...variants];
+}
+
+async function fetchSP500() {
+  // 1) Try FMP (if available)
+  if (FMP) {
+    try {
+      // FMP endpoint commonly used in examples
+      const arr = await json(`https://financialmodelingprep.com/api/v3/sp500_constituent?apikey=${FMP}`);
+      return arr.map(x => ({ symbol: x.symbol, name: x.name }));
+    } catch {}
+  }
+  // 2) Wikipedia fallback (robust enough for CI)
+  const html = await text("https://en.wikipedia.org/wiki/List_of_S%26P_500_companies");
+  const rows = [...html.matchAll(/<tr>\s*<td><a[^>]+>([A-Z\.\-]+)<\/a><\/td>\s*<td><a[^>]*>([^<]+)<\/a>/g)];
+  return rows.map(([, symbol, name]) => ({ symbol, name }));
+}
+
+async function fetchNasdaq100() {
+  if (FMP) {
+    try {
+      // Many users mirror NASDAQ-100 here; keep the fallback just in case endpoint differs
+      const arr = await json(`https://financialmodelingprep.com/api/v3/nasdaq_constituent?apikey=${FMP}`);
+      if (Array.isArray(arr) && arr[0]?.symbol && arr[0]?.name) {
+        return arr.map(x => ({ symbol: x.symbol, name: x.name }));
+      }
+    } catch {}
+  }
+  const html = await text("https://en.wikipedia.org/wiki/Nasdaq-100");
+  // First wikitable with “Ticker” + “Company”
+  const rows = [...html.matchAll(/<tr>\s*<td><a[^>]*>([A-Z\.\-]+)<\/a><\/td>\s*<td>(?:<a[^>]*>)?([^<]+)</g)];
+  return rows.map(([, symbol, name]) => ({ symbol, name }));
+}
+
+function buildMap(pairs) {
+  const map = {};
+  for (const { symbol, name } of pairs) {
+    if (!symbol || !name) continue;
+    for (const v of expandVariants(name)) {
+      map[v] = symbol;
+    }
+  }
+  // Helpful manual aliases
+  map["Berkshire Hathaway (B)"] = "BRK-B";
+  map["Berkshire Hathaway (A)"] = "BRK-A";
+  map["Brown-Forman (B)"] = "BF-B";
+  map["Brown-Forman (A)"] = "BF-A";
+  return map;
+}
+
+const sp = await fetchSP500();
+const nd = await fetchNasdaq100();
+const mergedMap = buildMap([...sp, ...nd]);
+
+await mkdir("data/indexes", { recursive: true });
+await writeFile("data/indexes/sp500.json", JSON.stringify(sp, null, 2));
+await writeFile("data/indexes/nasdaq100.json", JSON.stringify(nd, null, 2));
+await mkdir("src", { recursive: true });
+await writeFile("src/maps.indexes.json", JSON.stringify(mergedMap, null, 2));
+
+console.log(`[index-maps] S&P 500: ${sp.length}, NASDAQ-100: ${nd.length}, merged keys: ${Object.keys(mergedMap).length}`);


### PR DESCRIPTION
## Summary
- add script to build S&P 500 and Nasdaq-100 ticker maps
- merge generated index map with existing hints in `fetchStockInfo.js`
- run map updater in CI before pool build

## Testing
- `node tests/apple_association.test.js`
- `node tools/updateIndexMaps.mjs` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_b_68afc7aaccd0832abe5ce1b10055cb8c