### PR TITLE
feat: add index ticker maps updater

### DIFF
--- a/tools/updateIndexMaps.mjs
+++ b/tools/updateIndexMaps.mjs
@@ -16,7 +16,8 @@ async function text(url) {
 }
 
 function decodeEntities(s) {
-  return load(s || "").text();
+  // Only parse with Cheerio when the string contains HTML entities
+  return s && s.includes("&") ? load(s).text() : s || "";
 }
 
 function normName(s) {


### PR DESCRIPTION
## Summary
- add script to build S&P 500 and Nasdaq-100 ticker maps
- merge generated index map with existing hints in `fetchStockInfo.js`
- run map updater in CI before pool build
- optimize HTML entity decoding to avoid unnecessary parsing when no entities

## Testing
- `node tests/apple_association.test.js`
- `node tools/updateIndexMaps.mjs` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_b_68afce5c0b58832a9231cc7d2aed8025