### PR TITLE
feat: add resilient index map updater

### DIFF
--- a/data/indexes/nasdaq100.offline.json
+++ b/data/indexes/nasdaq100.offline.json
@@ -1,0 +1,406 @@
+[
+  {
+    "symbol": "ADBE",
+    "name": "Adobe Inc."
+  },
+  {
+    "symbol": "AMD",
+    "name": "Advanced Micro Devices"
+  },
+  {
+    "symbol": "ABNB",
+    "name": "Airbnb"
+  },
+  {
+    "symbol": "GOOGL",
+    "name": "Alphabet Inc."
+  },
+  {
+    "symbol": "GOOG",
+    "name": "Alphabet Inc."
+  },
+  {
+    "symbol": "AMZN",
+    "name": "Amazon"
+  },
+  {
+    "symbol": "AEP",
+    "name": "American Electric Power"
+  },
+  {
+    "symbol": "AMGN",
+    "name": "Amgen"
+  },
+  {
+    "symbol": "ADI",
+    "name": "Analog Devices"
+  },
+  {
+    "symbol": "AAPL",
+    "name": "Apple Inc."
+  },
+  {
+    "symbol": "AMAT",
+    "name": "Applied Materials"
+  },
+  {
+    "symbol": "APP",
+    "name": "AppLovin"
+  },
+  {
+    "symbol": "ARM",
+    "name": "Arm Holdings"
+  },
+  {
+    "symbol": "ASML",
+    "name": "ASML Holding"
+  },
+  {
+    "symbol": "AZN",
+    "name": "AstraZeneca"
+  },
+  {
+    "symbol": "TEAM",
+    "name": "Atlassian"
+  },
+  {
+    "symbol": "ADSK",
+    "name": "Autodesk"
+  },
+  {
+    "symbol": "ADP",
+    "name": "Automatic Data Processing"
+  },
+  {
+    "symbol": "AXON",
+    "name": "Axon Enterprise"
+  },
+  {
+    "symbol": "BKR",
+    "name": "Baker Hughes"
+  },
+  {
+    "symbol": "BIIB",
+    "name": "Biogen"
+  },
+  {
+    "symbol": "BKNG",
+    "name": "Booking Holdings"
+  },
+  {
+    "symbol": "AVGO",
+    "name": "Broadcom"
+  },
+  {
+    "symbol": "CDNS",
+    "name": "Cadence Design Systems"
+  },
+  {
+    "symbol": "CDW",
+    "name": "CDW Corporation"
+  },
+  {
+    "symbol": "CHTR",
+    "name": "Charter Communications"
+  },
+  {
+    "symbol": "CTAS",
+    "name": "Cintas"
+  },
+  {
+    "symbol": "CSCO",
+    "name": "Cisco"
+  },
+  {
+    "symbol": "CCEP",
+    "name": "Coca-Cola Europacific Partners"
+  },
+  {
+    "symbol": "CTSH",
+    "name": "Cognizant"
+  },
+  {
+    "symbol": "CMCSA",
+    "name": "Comcast"
+  },
+  {
+    "symbol": "CEG",
+    "name": "Constellation Energy"
+  },
+  {
+    "symbol": "CPRT",
+    "name": "Copart"
+  },
+  {
+    "symbol": "CSGP",
+    "name": "CoStar Group"
+  },
+  {
+    "symbol": "COST",
+    "name": "Costco"
+  },
+  {
+    "symbol": "CRWD",
+    "name": "CrowdStrike"
+  },
+  {
+    "symbol": "CSX",
+    "name": "CSX Corporation"
+  },
+  {
+    "symbol": "DDOG",
+    "name": "Datadog"
+  },
+  {
+    "symbol": "DXCM",
+    "name": "DexCom"
+  },
+  {
+    "symbol": "FANG",
+    "name": "Diamondback Energy"
+  },
+  {
+    "symbol": "DASH",
+    "name": "DoorDash"
+  },
+  {
+    "symbol": "EA",
+    "name": "Electronic Arts"
+  },
+  {
+    "symbol": "EXC",
+    "name": "Exelon"
+  },
+  {
+    "symbol": "FAST",
+    "name": "Fastenal"
+  },
+  {
+    "symbol": "FTNT",
+    "name": "Fortinet"
+  },
+  {
+    "symbol": "GEHC",
+    "name": "GE HealthCare"
+  },
+  {
+    "symbol": "GILD",
+    "name": "Gilead Sciences"
+  },
+  {
+    "symbol": "GFS",
+    "name": "GlobalFoundries"
+  },
+  {
+    "symbol": "HON",
+    "name": "Honeywell"
+  },
+  {
+    "symbol": "IDXX",
+    "name": "Idexx Laboratories"
+  },
+  {
+    "symbol": "INTC",
+    "name": "Intel"
+  },
+  {
+    "symbol": "INTU",
+    "name": "Intuit"
+  },
+  {
+    "symbol": "ISRG",
+    "name": "Intuitive Surgical"
+  },
+  {
+    "symbol": "KDP",
+    "name": "Keurig Dr Pepper"
+  },
+  {
+    "symbol": "KLAC",
+    "name": "KLA Corporation"
+  },
+  {
+    "symbol": "KHC",
+    "name": "Kraft Heinz"
+  },
+  {
+    "symbol": "LRCX",
+    "name": "Lam Research"
+  },
+  {
+    "symbol": "LIN",
+    "name": "Linde plc"
+  },
+  {
+    "symbol": "LULU",
+    "name": "Lululemon"
+  },
+  {
+    "symbol": "MAR",
+    "name": "Marriott International"
+  },
+  {
+    "symbol": "MRVL",
+    "name": "Marvell Technology"
+  },
+  {
+    "symbol": "MELI",
+    "name": "Mercado Libre"
+  },
+  {
+    "symbol": "META",
+    "name": "Meta Platforms"
+  },
+  {
+    "symbol": "MCHP",
+    "name": "Microchip Technology"
+  },
+  {
+    "symbol": "MU",
+    "name": "Micron Technology"
+  },
+  {
+    "symbol": "MSFT",
+    "name": "Microsoft"
+  },
+  {
+    "symbol": "MSTR",
+    "name": "MicroStrategy"
+  },
+  {
+    "symbol": "MDLZ",
+    "name": "Mondelez International"
+  },
+  {
+    "symbol": "MNST",
+    "name": "Monster Beverage"
+  },
+  {
+    "symbol": "NFLX",
+    "name": "Netflix, Inc."
+  },
+  {
+    "symbol": "NVDA",
+    "name": "Nvidia"
+  },
+  {
+    "symbol": "NXPI",
+    "name": "NXP Semiconductors"
+  },
+  {
+    "symbol": "ORLY",
+    "name": "O'Reilly Automotive"
+  },
+  {
+    "symbol": "ODFL",
+    "name": "Old Dominion Freight Line"
+  },
+  {
+    "symbol": "ON",
+    "name": "Onsemi"
+  },
+  {
+    "symbol": "PCAR",
+    "name": "Paccar"
+  },
+  {
+    "symbol": "PLTR",
+    "name": "Palantir Technologies"
+  },
+  {
+    "symbol": "PANW",
+    "name": "Palo Alto Networks"
+  },
+  {
+    "symbol": "PAYX",
+    "name": "Paychex"
+  },
+  {
+    "symbol": "PYPL",
+    "name": "PayPal"
+  },
+  {
+    "symbol": "PDD",
+    "name": "PDD Holdings"
+  },
+  {
+    "symbol": "PEP",
+    "name": "PepsiCo"
+  },
+  {
+    "symbol": "QCOM",
+    "name": "Qualcomm"
+  },
+  {
+    "symbol": "REGN",
+    "name": "Regeneron Pharmaceuticals"
+  },
+  {
+    "symbol": "ROP",
+    "name": "Roper Technologies"
+  },
+  {
+    "symbol": "ROST",
+    "name": "Ross Stores"
+  },
+  {
+    "symbol": "SHOP",
+    "name": "Shopify"
+  },
+  {
+    "symbol": "SBUX",
+    "name": "Starbucks"
+  },
+  {
+    "symbol": "SNPS",
+    "name": "Synopsys"
+  },
+  {
+    "symbol": "TMUS",
+    "name": "T-Mobile US"
+  },
+  {
+    "symbol": "TTWO",
+    "name": "Take-Two Interactive"
+  },
+  {
+    "symbol": "TSLA",
+    "name": "Tesla, Inc."
+  },
+  {
+    "symbol": "TXN",
+    "name": "Texas Instruments"
+  },
+  {
+    "symbol": "TRI",
+    "name": "Thomson Reuters"
+  },
+  {
+    "symbol": "TTD",
+    "name": "Trade Desk (The)"
+  },
+  {
+    "symbol": "VRSK",
+    "name": "Verisk Analytics"
+  },
+  {
+    "symbol": "VRTX",
+    "name": "Vertex Pharmaceuticals"
+  },
+  {
+    "symbol": "WBD",
+    "name": "Warner Bros. Discovery"
+  },
+  {
+    "symbol": "WDAY",
+    "name": "Workday, Inc."
+  },
+  {
+    "symbol": "XEL",
+    "name": "Xcel Energy"
+  },
+  {
+    "symbol": "ZS",
+    "name": "Zscaler"
+  }
+]

--- a/data/indexes/sp500.offline.json
+++ b/data/indexes/sp500.offline.json
@@ -1,0 +1,2018 @@
+[
+  {
+    "symbol": "MMM",
+    "name": "3M"
+  },
+  {
+    "symbol": "AOS",
+    "name": "A. O. Smith"
+  },
+  {
+    "symbol": "ABT",
+    "name": "Abbott Laboratories"
+  },
+  {
+    "symbol": "ABBV",
+    "name": "AbbVie"
+  },
+  {
+    "symbol": "ACN",
+    "name": "Accenture"
+  },
+  {
+    "symbol": "ADBE",
+    "name": "Adobe Inc."
+  },
+  {
+    "symbol": "AMD",
+    "name": "Advanced Micro Devices"
+  },
+  {
+    "symbol": "AES",
+    "name": "AES Corporation"
+  },
+  {
+    "symbol": "AFL",
+    "name": "Aflac"
+  },
+  {
+    "symbol": "A",
+    "name": "Agilent Technologies"
+  },
+  {
+    "symbol": "APD",
+    "name": "Air Products"
+  },
+  {
+    "symbol": "ABNB",
+    "name": "Airbnb"
+  },
+  {
+    "symbol": "AKAM",
+    "name": "Akamai Technologies"
+  },
+  {
+    "symbol": "ALB",
+    "name": "Albemarle Corporation"
+  },
+  {
+    "symbol": "ARE",
+    "name": "Alexandria Real Estate Equities"
+  },
+  {
+    "symbol": "ALGN",
+    "name": "Align Technology"
+  },
+  {
+    "symbol": "ALLE",
+    "name": "Allegion"
+  },
+  {
+    "symbol": "LNT",
+    "name": "Alliant Energy"
+  },
+  {
+    "symbol": "ALL",
+    "name": "Allstate"
+  },
+  {
+    "symbol": "GOOGL",
+    "name": "Alphabet Inc."
+  },
+  {
+    "symbol": "GOOG",
+    "name": "Alphabet Inc."
+  },
+  {
+    "symbol": "MO",
+    "name": "Altria"
+  },
+  {
+    "symbol": "AMZN",
+    "name": "Amazon"
+  },
+  {
+    "symbol": "AMCR",
+    "name": "Amcor"
+  },
+  {
+    "symbol": "AEE",
+    "name": "Ameren"
+  },
+  {
+    "symbol": "AEP",
+    "name": "American Electric Power"
+  },
+  {
+    "symbol": "AXP",
+    "name": "American Express"
+  },
+  {
+    "symbol": "AIG",
+    "name": "American International Group"
+  },
+  {
+    "symbol": "AMT",
+    "name": "American Tower"
+  },
+  {
+    "symbol": "AWK",
+    "name": "American Water Works"
+  },
+  {
+    "symbol": "AMP",
+    "name": "Ameriprise Financial"
+  },
+  {
+    "symbol": "AME",
+    "name": "Ametek"
+  },
+  {
+    "symbol": "AMGN",
+    "name": "Amgen"
+  },
+  {
+    "symbol": "APH",
+    "name": "Amphenol"
+  },
+  {
+    "symbol": "ADI",
+    "name": "Analog Devices"
+  },
+  {
+    "symbol": "AON",
+    "name": "Aon plc"
+  },
+  {
+    "symbol": "APA",
+    "name": "APA Corporation"
+  },
+  {
+    "symbol": "APO",
+    "name": "Apollo Global Management"
+  },
+  {
+    "symbol": "AAPL",
+    "name": "Apple Inc."
+  },
+  {
+    "symbol": "AMAT",
+    "name": "Applied Materials"
+  },
+  {
+    "symbol": "APTV",
+    "name": "Aptiv"
+  },
+  {
+    "symbol": "ACGL",
+    "name": "Arch Capital Group"
+  },
+  {
+    "symbol": "ADM",
+    "name": "Archer Daniels Midland"
+  },
+  {
+    "symbol": "ANET",
+    "name": "Arista Networks"
+  },
+  {
+    "symbol": "AJG",
+    "name": "Arthur J. Gallagher &amp; Co."
+  },
+  {
+    "symbol": "AIZ",
+    "name": "Assurant"
+  },
+  {
+    "symbol": "T",
+    "name": "AT&amp;T"
+  },
+  {
+    "symbol": "ATO",
+    "name": "Atmos Energy"
+  },
+  {
+    "symbol": "ADSK",
+    "name": "Autodesk"
+  },
+  {
+    "symbol": "ADP",
+    "name": "Automatic Data Processing"
+  },
+  {
+    "symbol": "AZO",
+    "name": "AutoZone"
+  },
+  {
+    "symbol": "AVB",
+    "name": "AvalonBay Communities"
+  },
+  {
+    "symbol": "AVY",
+    "name": "Avery Dennison"
+  },
+  {
+    "symbol": "AXON",
+    "name": "Axon Enterprise"
+  },
+  {
+    "symbol": "BKR",
+    "name": "Baker Hughes"
+  },
+  {
+    "symbol": "BALL",
+    "name": "Ball Corporation"
+  },
+  {
+    "symbol": "BAC",
+    "name": "Bank of America"
+  },
+  {
+    "symbol": "BAX",
+    "name": "Baxter International"
+  },
+  {
+    "symbol": "BDX",
+    "name": "Becton Dickinson"
+  },
+  {
+    "symbol": "BRK.B",
+    "name": "Berkshire Hathaway"
+  },
+  {
+    "symbol": "BBY",
+    "name": "Best Buy"
+  },
+  {
+    "symbol": "TECH",
+    "name": "Bio-Techne"
+  },
+  {
+    "symbol": "BIIB",
+    "name": "Biogen"
+  },
+  {
+    "symbol": "BLK",
+    "name": "BlackRock"
+  },
+  {
+    "symbol": "BX",
+    "name": "Blackstone Inc."
+  },
+  {
+    "symbol": "XYZ",
+    "name": "Block, Inc."
+  },
+  {
+    "symbol": "BK",
+    "name": "BNY Mellon"
+  },
+  {
+    "symbol": "BA",
+    "name": "Boeing"
+  },
+  {
+    "symbol": "BKNG",
+    "name": "Booking Holdings"
+  },
+  {
+    "symbol": "BSX",
+    "name": "Boston Scientific"
+  },
+  {
+    "symbol": "BMY",
+    "name": "Bristol Myers Squibb"
+  },
+  {
+    "symbol": "AVGO",
+    "name": "Broadcom"
+  },
+  {
+    "symbol": "BR",
+    "name": "Broadridge Financial Solutions"
+  },
+  {
+    "symbol": "BRO",
+    "name": "Brown &amp; Brown"
+  },
+  {
+    "symbol": "BF.B",
+    "name": "Brown–Forman"
+  },
+  {
+    "symbol": "BLDR",
+    "name": "Builders FirstSource"
+  },
+  {
+    "symbol": "BG",
+    "name": "Bunge Global"
+  },
+  {
+    "symbol": "BXP",
+    "name": "BXP, Inc."
+  },
+  {
+    "symbol": "CHRW",
+    "name": "C.H. Robinson"
+  },
+  {
+    "symbol": "CDNS",
+    "name": "Cadence Design Systems"
+  },
+  {
+    "symbol": "CZR",
+    "name": "Caesars Entertainment"
+  },
+  {
+    "symbol": "CPT",
+    "name": "Camden Property Trust"
+  },
+  {
+    "symbol": "CPB",
+    "name": "Campbell's Company (The)"
+  },
+  {
+    "symbol": "COF",
+    "name": "Capital One"
+  },
+  {
+    "symbol": "CAH",
+    "name": "Cardinal Health"
+  },
+  {
+    "symbol": "KMX",
+    "name": "CarMax"
+  },
+  {
+    "symbol": "CCL",
+    "name": "Carnival"
+  },
+  {
+    "symbol": "CARR",
+    "name": "Carrier Global"
+  },
+  {
+    "symbol": "CAT",
+    "name": "Caterpillar Inc."
+  },
+  {
+    "symbol": "CBOE",
+    "name": "Cboe Global Markets"
+  },
+  {
+    "symbol": "CBRE",
+    "name": "CBRE Group"
+  },
+  {
+    "symbol": "CDW",
+    "name": "CDW Corporation"
+  },
+  {
+    "symbol": "COR",
+    "name": "Cencora"
+  },
+  {
+    "symbol": "CNC",
+    "name": "Centene Corporation"
+  },
+  {
+    "symbol": "CNP",
+    "name": "CenterPoint Energy"
+  },
+  {
+    "symbol": "CF",
+    "name": "CF Industries"
+  },
+  {
+    "symbol": "CRL",
+    "name": "Charles River Laboratories"
+  },
+  {
+    "symbol": "SCHW",
+    "name": "Charles Schwab Corporation"
+  },
+  {
+    "symbol": "CHTR",
+    "name": "Charter Communications"
+  },
+  {
+    "symbol": "CVX",
+    "name": "Chevron Corporation"
+  },
+  {
+    "symbol": "CMG",
+    "name": "Chipotle Mexican Grill"
+  },
+  {
+    "symbol": "CB",
+    "name": "Chubb Limited"
+  },
+  {
+    "symbol": "CHD",
+    "name": "Church &amp; Dwight"
+  },
+  {
+    "symbol": "CI",
+    "name": "Cigna"
+  },
+  {
+    "symbol": "CINF",
+    "name": "Cincinnati Financial"
+  },
+  {
+    "symbol": "CTAS",
+    "name": "Cintas"
+  },
+  {
+    "symbol": "CSCO",
+    "name": "Cisco"
+  },
+  {
+    "symbol": "C",
+    "name": "Citigroup"
+  },
+  {
+    "symbol": "CFG",
+    "name": "Citizens Financial Group"
+  },
+  {
+    "symbol": "CLX",
+    "name": "Clorox"
+  },
+  {
+    "symbol": "CME",
+    "name": "CME Group"
+  },
+  {
+    "symbol": "CMS",
+    "name": "CMS Energy"
+  },
+  {
+    "symbol": "KO",
+    "name": "Coca-Cola Company (The)"
+  },
+  {
+    "symbol": "CTSH",
+    "name": "Cognizant"
+  },
+  {
+    "symbol": "COIN",
+    "name": "Coinbase"
+  },
+  {
+    "symbol": "CL",
+    "name": "Colgate-Palmolive"
+  },
+  {
+    "symbol": "CMCSA",
+    "name": "Comcast"
+  },
+  {
+    "symbol": "CAG",
+    "name": "Conagra Brands"
+  },
+  {
+    "symbol": "COP",
+    "name": "ConocoPhillips"
+  },
+  {
+    "symbol": "ED",
+    "name": "Consolidated Edison"
+  },
+  {
+    "symbol": "STZ",
+    "name": "Constellation Brands"
+  },
+  {
+    "symbol": "CEG",
+    "name": "Constellation Energy"
+  },
+  {
+    "symbol": "COO",
+    "name": "Cooper Companies (The)"
+  },
+  {
+    "symbol": "CPRT",
+    "name": "Copart"
+  },
+  {
+    "symbol": "GLW",
+    "name": "Corning Inc."
+  },
+  {
+    "symbol": "CPAY",
+    "name": "Corpay"
+  },
+  {
+    "symbol": "CTVA",
+    "name": "Corteva"
+  },
+  {
+    "symbol": "CSGP",
+    "name": "CoStar Group"
+  },
+  {
+    "symbol": "COST",
+    "name": "Costco"
+  },
+  {
+    "symbol": "CTRA",
+    "name": "Coterra"
+  },
+  {
+    "symbol": "CRWD",
+    "name": "CrowdStrike"
+  },
+  {
+    "symbol": "CCI",
+    "name": "Crown Castle"
+  },
+  {
+    "symbol": "CSX",
+    "name": "CSX Corporation"
+  },
+  {
+    "symbol": "CMI",
+    "name": "Cummins"
+  },
+  {
+    "symbol": "CVS",
+    "name": "CVS Health"
+  },
+  {
+    "symbol": "DHR",
+    "name": "Danaher Corporation"
+  },
+  {
+    "symbol": "DRI",
+    "name": "Darden Restaurants"
+  },
+  {
+    "symbol": "DDOG",
+    "name": "Datadog"
+  },
+  {
+    "symbol": "DVA",
+    "name": "DaVita"
+  },
+  {
+    "symbol": "DAY",
+    "name": "Dayforce"
+  },
+  {
+    "symbol": "DECK",
+    "name": "Deckers Brands"
+  },
+  {
+    "symbol": "DE",
+    "name": "Deere &amp; Company"
+  },
+  {
+    "symbol": "DELL",
+    "name": "Dell Technologies"
+  },
+  {
+    "symbol": "DAL",
+    "name": "Delta Air Lines"
+  },
+  {
+    "symbol": "DVN",
+    "name": "Devon Energy"
+  },
+  {
+    "symbol": "DXCM",
+    "name": "Dexcom"
+  },
+  {
+    "symbol": "FANG",
+    "name": "Diamondback Energy"
+  },
+  {
+    "symbol": "DLR",
+    "name": "Digital Realty"
+  },
+  {
+    "symbol": "DG",
+    "name": "Dollar General"
+  },
+  {
+    "symbol": "DLTR",
+    "name": "Dollar Tree"
+  },
+  {
+    "symbol": "D",
+    "name": "Dominion Energy"
+  },
+  {
+    "symbol": "DPZ",
+    "name": "Domino's"
+  },
+  {
+    "symbol": "DASH",
+    "name": "DoorDash"
+  },
+  {
+    "symbol": "DOV",
+    "name": "Dover Corporation"
+  },
+  {
+    "symbol": "DOW",
+    "name": "Dow Inc."
+  },
+  {
+    "symbol": "DHI",
+    "name": "D. R. Horton"
+  },
+  {
+    "symbol": "DTE",
+    "name": "DTE Energy"
+  },
+  {
+    "symbol": "DUK",
+    "name": "Duke Energy"
+  },
+  {
+    "symbol": "DD",
+    "name": "DuPont"
+  },
+  {
+    "symbol": "EMN",
+    "name": "Eastman Chemical Company"
+  },
+  {
+    "symbol": "ETN",
+    "name": "Eaton Corporation"
+  },
+  {
+    "symbol": "EBAY",
+    "name": "eBay Inc."
+  },
+  {
+    "symbol": "ECL",
+    "name": "Ecolab"
+  },
+  {
+    "symbol": "EIX",
+    "name": "Edison International"
+  },
+  {
+    "symbol": "EW",
+    "name": "Edwards Lifesciences"
+  },
+  {
+    "symbol": "EA",
+    "name": "Electronic Arts"
+  },
+  {
+    "symbol": "ELV",
+    "name": "Elevance Health"
+  },
+  {
+    "symbol": "EMR",
+    "name": "Emerson Electric"
+  },
+  {
+    "symbol": "ENPH",
+    "name": "Enphase Energy"
+  },
+  {
+    "symbol": "ETR",
+    "name": "Entergy"
+  },
+  {
+    "symbol": "EOG",
+    "name": "EOG Resources"
+  },
+  {
+    "symbol": "EPAM",
+    "name": "EPAM Systems"
+  },
+  {
+    "symbol": "EQT",
+    "name": "EQT Corporation"
+  },
+  {
+    "symbol": "EFX",
+    "name": "Equifax"
+  },
+  {
+    "symbol": "EQIX",
+    "name": "Equinix"
+  },
+  {
+    "symbol": "EQR",
+    "name": "Equity Residential"
+  },
+  {
+    "symbol": "ERIE",
+    "name": "Erie Indemnity"
+  },
+  {
+    "symbol": "ESS",
+    "name": "Essex Property Trust"
+  },
+  {
+    "symbol": "EL",
+    "name": "Estée Lauder Companies (The)"
+  },
+  {
+    "symbol": "EG",
+    "name": "Everest Group"
+  },
+  {
+    "symbol": "EVRG",
+    "name": "Evergy"
+  },
+  {
+    "symbol": "ES",
+    "name": "Eversource Energy"
+  },
+  {
+    "symbol": "EXC",
+    "name": "Exelon"
+  },
+  {
+    "symbol": "EXE",
+    "name": "Expand Energy"
+  },
+  {
+    "symbol": "EXPE",
+    "name": "Expedia Group"
+  },
+  {
+    "symbol": "EXPD",
+    "name": "Expeditors International"
+  },
+  {
+    "symbol": "EXR",
+    "name": "Extra Space Storage"
+  },
+  {
+    "symbol": "XOM",
+    "name": "ExxonMobil"
+  },
+  {
+    "symbol": "FFIV",
+    "name": "F5, Inc."
+  },
+  {
+    "symbol": "FDS",
+    "name": "FactSet"
+  },
+  {
+    "symbol": "FICO",
+    "name": "Fair Isaac"
+  },
+  {
+    "symbol": "FAST",
+    "name": "Fastenal"
+  },
+  {
+    "symbol": "FRT",
+    "name": "Federal Realty Investment Trust"
+  },
+  {
+    "symbol": "FDX",
+    "name": "FedEx"
+  },
+  {
+    "symbol": "FIS",
+    "name": "Fidelity National Information Services"
+  },
+  {
+    "symbol": "FITB",
+    "name": "Fifth Third Bancorp"
+  },
+  {
+    "symbol": "FSLR",
+    "name": "First Solar"
+  },
+  {
+    "symbol": "FE",
+    "name": "FirstEnergy"
+  },
+  {
+    "symbol": "FI",
+    "name": "Fiserv"
+  },
+  {
+    "symbol": "F",
+    "name": "Ford Motor Company"
+  },
+  {
+    "symbol": "FTNT",
+    "name": "Fortinet"
+  },
+  {
+    "symbol": "FTV",
+    "name": "Fortive"
+  },
+  {
+    "symbol": "FOXA",
+    "name": "Fox Corporation"
+  },
+  {
+    "symbol": "FOX",
+    "name": "Fox Corporation"
+  },
+  {
+    "symbol": "BEN",
+    "name": "Franklin Resources"
+  },
+  {
+    "symbol": "FCX",
+    "name": "Freeport-McMoRan"
+  },
+  {
+    "symbol": "GRMN",
+    "name": "Garmin"
+  },
+  {
+    "symbol": "IT",
+    "name": "Gartner"
+  },
+  {
+    "symbol": "GE",
+    "name": "GE Aerospace"
+  },
+  {
+    "symbol": "GEHC",
+    "name": "GE HealthCare"
+  },
+  {
+    "symbol": "GEV",
+    "name": "GE Vernova"
+  },
+  {
+    "symbol": "GEN",
+    "name": "Gen Digital"
+  },
+  {
+    "symbol": "GNRC",
+    "name": "Generac"
+  },
+  {
+    "symbol": "GD",
+    "name": "General Dynamics"
+  },
+  {
+    "symbol": "GIS",
+    "name": "General Mills"
+  },
+  {
+    "symbol": "GM",
+    "name": "General Motors"
+  },
+  {
+    "symbol": "GPC",
+    "name": "Genuine Parts Company"
+  },
+  {
+    "symbol": "GILD",
+    "name": "Gilead Sciences"
+  },
+  {
+    "symbol": "GPN",
+    "name": "Global Payments"
+  },
+  {
+    "symbol": "GL",
+    "name": "Globe Life"
+  },
+  {
+    "symbol": "GDDY",
+    "name": "GoDaddy"
+  },
+  {
+    "symbol": "GS",
+    "name": "Goldman Sachs"
+  },
+  {
+    "symbol": "HAL",
+    "name": "Halliburton"
+  },
+  {
+    "symbol": "HIG",
+    "name": "Hartford (The)"
+  },
+  {
+    "symbol": "HAS",
+    "name": "Hasbro"
+  },
+  {
+    "symbol": "HCA",
+    "name": "HCA Healthcare"
+  },
+  {
+    "symbol": "DOC",
+    "name": "Healthpeak Properties"
+  },
+  {
+    "symbol": "HSIC",
+    "name": "Henry Schein"
+  },
+  {
+    "symbol": "HSY",
+    "name": "Hershey Company (The)"
+  },
+  {
+    "symbol": "HPE",
+    "name": "Hewlett Packard Enterprise"
+  },
+  {
+    "symbol": "HLT",
+    "name": "Hilton Worldwide"
+  },
+  {
+    "symbol": "HOLX",
+    "name": "Hologic"
+  },
+  {
+    "symbol": "HD",
+    "name": "Home Depot (The)"
+  },
+  {
+    "symbol": "HON",
+    "name": "Honeywell"
+  },
+  {
+    "symbol": "HRL",
+    "name": "Hormel Foods"
+  },
+  {
+    "symbol": "HST",
+    "name": "Host Hotels &amp; Resorts"
+  },
+  {
+    "symbol": "HWM",
+    "name": "Howmet Aerospace"
+  },
+  {
+    "symbol": "HPQ",
+    "name": "HP Inc."
+  },
+  {
+    "symbol": "HUBB",
+    "name": "Hubbell Incorporated"
+  },
+  {
+    "symbol": "HUM",
+    "name": "Humana"
+  },
+  {
+    "symbol": "HBAN",
+    "name": "Huntington Bancshares"
+  },
+  {
+    "symbol": "HII",
+    "name": "Huntington Ingalls Industries"
+  },
+  {
+    "symbol": "IBM",
+    "name": "IBM"
+  },
+  {
+    "symbol": "IEX",
+    "name": "IDEX Corporation"
+  },
+  {
+    "symbol": "IDXX",
+    "name": "Idexx Laboratories"
+  },
+  {
+    "symbol": "ITW",
+    "name": "Illinois Tool Works"
+  },
+  {
+    "symbol": "INCY",
+    "name": "Incyte"
+  },
+  {
+    "symbol": "IR",
+    "name": "Ingersoll Rand"
+  },
+  {
+    "symbol": "PODD",
+    "name": "Insulet Corporation"
+  },
+  {
+    "symbol": "INTC",
+    "name": "Intel"
+  },
+  {
+    "symbol": "IBKR",
+    "name": "Interactive Brokers"
+  },
+  {
+    "symbol": "ICE",
+    "name": "Intercontinental Exchange"
+  },
+  {
+    "symbol": "IFF",
+    "name": "International Flavors &amp; Fragrances"
+  },
+  {
+    "symbol": "IP",
+    "name": "International Paper"
+  },
+  {
+    "symbol": "IPG",
+    "name": "Interpublic Group of Companies (The)"
+  },
+  {
+    "symbol": "INTU",
+    "name": "Intuit"
+  },
+  {
+    "symbol": "ISRG",
+    "name": "Intuitive Surgical"
+  },
+  {
+    "symbol": "IVZ",
+    "name": "Invesco"
+  },
+  {
+    "symbol": "INVH",
+    "name": "Invitation Homes"
+  },
+  {
+    "symbol": "IQV",
+    "name": "IQVIA"
+  },
+  {
+    "symbol": "IRM",
+    "name": "Iron Mountain"
+  },
+  {
+    "symbol": "JBHT",
+    "name": "J.B. Hunt"
+  },
+  {
+    "symbol": "JBL",
+    "name": "Jabil"
+  },
+  {
+    "symbol": "JKHY",
+    "name": "Jack Henry &amp; Associates"
+  },
+  {
+    "symbol": "J",
+    "name": "Jacobs Solutions"
+  },
+  {
+    "symbol": "JNJ",
+    "name": "Johnson &amp; Johnson"
+  },
+  {
+    "symbol": "JCI",
+    "name": "Johnson Controls"
+  },
+  {
+    "symbol": "JPM",
+    "name": "JPMorgan Chase"
+  },
+  {
+    "symbol": "K",
+    "name": "Kellanova"
+  },
+  {
+    "symbol": "KVUE",
+    "name": "Kenvue"
+  },
+  {
+    "symbol": "KDP",
+    "name": "Keurig Dr Pepper"
+  },
+  {
+    "symbol": "KEY",
+    "name": "KeyCorp"
+  },
+  {
+    "symbol": "KEYS",
+    "name": "Keysight Technologies"
+  },
+  {
+    "symbol": "KMB",
+    "name": "Kimberly-Clark"
+  },
+  {
+    "symbol": "KIM",
+    "name": "Kimco Realty"
+  },
+  {
+    "symbol": "KMI",
+    "name": "Kinder Morgan"
+  },
+  {
+    "symbol": "KKR",
+    "name": "KKR &amp; Co."
+  },
+  {
+    "symbol": "KLAC",
+    "name": "KLA Corporation"
+  },
+  {
+    "symbol": "KHC",
+    "name": "Kraft Heinz"
+  },
+  {
+    "symbol": "KR",
+    "name": "Kroger"
+  },
+  {
+    "symbol": "LHX",
+    "name": "L3Harris"
+  },
+  {
+    "symbol": "LH",
+    "name": "Labcorp"
+  },
+  {
+    "symbol": "LRCX",
+    "name": "Lam Research"
+  },
+  {
+    "symbol": "LW",
+    "name": "Lamb Weston"
+  },
+  {
+    "symbol": "LVS",
+    "name": "Las Vegas Sands"
+  },
+  {
+    "symbol": "LDOS",
+    "name": "Leidos"
+  },
+  {
+    "symbol": "LEN",
+    "name": "Lennar"
+  },
+  {
+    "symbol": "LII",
+    "name": "Lennox International"
+  },
+  {
+    "symbol": "LLY",
+    "name": "Lilly (Eli)"
+  },
+  {
+    "symbol": "LIN",
+    "name": "Linde plc"
+  },
+  {
+    "symbol": "LYV",
+    "name": "Live Nation Entertainment"
+  },
+  {
+    "symbol": "LKQ",
+    "name": "LKQ Corporation"
+  },
+  {
+    "symbol": "LMT",
+    "name": "Lockheed Martin"
+  },
+  {
+    "symbol": "L",
+    "name": "Loews Corporation"
+  },
+  {
+    "symbol": "LOW",
+    "name": "Lowe's"
+  },
+  {
+    "symbol": "LULU",
+    "name": "Lululemon Athletica"
+  },
+  {
+    "symbol": "LYB",
+    "name": "LyondellBasell"
+  },
+  {
+    "symbol": "MTB",
+    "name": "M&amp;T Bank"
+  },
+  {
+    "symbol": "MPC",
+    "name": "Marathon Petroleum"
+  },
+  {
+    "symbol": "MKTX",
+    "name": "MarketAxess"
+  },
+  {
+    "symbol": "MAR",
+    "name": "Marriott International"
+  },
+  {
+    "symbol": "MMC",
+    "name": "Marsh McLennan"
+  },
+  {
+    "symbol": "MLM",
+    "name": "Martin Marietta Materials"
+  },
+  {
+    "symbol": "MAS",
+    "name": "Masco"
+  },
+  {
+    "symbol": "MA",
+    "name": "Mastercard"
+  },
+  {
+    "symbol": "MTCH",
+    "name": "Match Group"
+  },
+  {
+    "symbol": "MKC",
+    "name": "McCormick &amp; Company"
+  },
+  {
+    "symbol": "MCD",
+    "name": "McDonald's"
+  },
+  {
+    "symbol": "MCK",
+    "name": "McKesson Corporation"
+  },
+  {
+    "symbol": "MDT",
+    "name": "Medtronic"
+  },
+  {
+    "symbol": "MRK",
+    "name": "Merck &amp; Co."
+  },
+  {
+    "symbol": "META",
+    "name": "Meta Platforms"
+  },
+  {
+    "symbol": "MET",
+    "name": "MetLife"
+  },
+  {
+    "symbol": "MTD",
+    "name": "Mettler Toledo"
+  },
+  {
+    "symbol": "MGM",
+    "name": "MGM Resorts"
+  },
+  {
+    "symbol": "MCHP",
+    "name": "Microchip Technology"
+  },
+  {
+    "symbol": "MU",
+    "name": "Micron Technology"
+  },
+  {
+    "symbol": "MSFT",
+    "name": "Microsoft"
+  },
+  {
+    "symbol": "MAA",
+    "name": "Mid-America Apartment Communities"
+  },
+  {
+    "symbol": "MRNA",
+    "name": "Moderna"
+  },
+  {
+    "symbol": "MHK",
+    "name": "Mohawk Industries"
+  },
+  {
+    "symbol": "MOH",
+    "name": "Molina Healthcare"
+  },
+  {
+    "symbol": "TAP",
+    "name": "Molson Coors Beverage Company"
+  },
+  {
+    "symbol": "MDLZ",
+    "name": "Mondelez International"
+  },
+  {
+    "symbol": "MPWR",
+    "name": "Monolithic Power Systems"
+  },
+  {
+    "symbol": "MNST",
+    "name": "Monster Beverage"
+  },
+  {
+    "symbol": "MCO",
+    "name": "Moody's Corporation"
+  },
+  {
+    "symbol": "MS",
+    "name": "Morgan Stanley"
+  },
+  {
+    "symbol": "MOS",
+    "name": "Mosaic Company (The)"
+  },
+  {
+    "symbol": "MSI",
+    "name": "Motorola Solutions"
+  },
+  {
+    "symbol": "MSCI",
+    "name": "MSCI Inc."
+  },
+  {
+    "symbol": "NDAQ",
+    "name": "Nasdaq, Inc."
+  },
+  {
+    "symbol": "NTAP",
+    "name": "NetApp"
+  },
+  {
+    "symbol": "NFLX",
+    "name": "Netflix"
+  },
+  {
+    "symbol": "NEM",
+    "name": "Newmont"
+  },
+  {
+    "symbol": "NWSA",
+    "name": "News Corp"
+  },
+  {
+    "symbol": "NWS",
+    "name": "News Corp"
+  },
+  {
+    "symbol": "NEE",
+    "name": "NextEra Energy"
+  },
+  {
+    "symbol": "NKE",
+    "name": "Nike, Inc."
+  },
+  {
+    "symbol": "NI",
+    "name": "NiSource"
+  },
+  {
+    "symbol": "NDSN",
+    "name": "Nordson Corporation"
+  },
+  {
+    "symbol": "NSC",
+    "name": "Norfolk Southern"
+  },
+  {
+    "symbol": "NTRS",
+    "name": "Northern Trust"
+  },
+  {
+    "symbol": "NOC",
+    "name": "Northrop Grumman"
+  },
+  {
+    "symbol": "NCLH",
+    "name": "Norwegian Cruise Line Holdings"
+  },
+  {
+    "symbol": "NRG",
+    "name": "NRG Energy"
+  },
+  {
+    "symbol": "NUE",
+    "name": "Nucor"
+  },
+  {
+    "symbol": "NVDA",
+    "name": "Nvidia"
+  },
+  {
+    "symbol": "NVR",
+    "name": "NVR, Inc."
+  },
+  {
+    "symbol": "NXPI",
+    "name": "NXP Semiconductors"
+  },
+  {
+    "symbol": "ORLY",
+    "name": "O’Reilly Automotive"
+  },
+  {
+    "symbol": "OXY",
+    "name": "Occidental Petroleum"
+  },
+  {
+    "symbol": "ODFL",
+    "name": "Old Dominion"
+  },
+  {
+    "symbol": "OMC",
+    "name": "Omnicom Group"
+  },
+  {
+    "symbol": "ON",
+    "name": "ON Semiconductor"
+  },
+  {
+    "symbol": "OKE",
+    "name": "Oneok"
+  },
+  {
+    "symbol": "ORCL",
+    "name": "Oracle Corporation"
+  },
+  {
+    "symbol": "OTIS",
+    "name": "Otis Worldwide"
+  },
+  {
+    "symbol": "PCAR",
+    "name": "Paccar"
+  },
+  {
+    "symbol": "PKG",
+    "name": "Packaging Corporation of America"
+  },
+  {
+    "symbol": "PLTR",
+    "name": "Palantir Technologies"
+  },
+  {
+    "symbol": "PANW",
+    "name": "Palo Alto Networks"
+  },
+  {
+    "symbol": "PSKY",
+    "name": "Paramount Skydance Corporation"
+  },
+  {
+    "symbol": "PH",
+    "name": "Parker Hannifin"
+  },
+  {
+    "symbol": "PAYX",
+    "name": "Paychex"
+  },
+  {
+    "symbol": "PAYC",
+    "name": "Paycom"
+  },
+  {
+    "symbol": "PYPL",
+    "name": "PayPal"
+  },
+  {
+    "symbol": "PNR",
+    "name": "Pentair"
+  },
+  {
+    "symbol": "PEP",
+    "name": "PepsiCo"
+  },
+  {
+    "symbol": "PFE",
+    "name": "Pfizer"
+  },
+  {
+    "symbol": "PCG",
+    "name": "PG&amp;E Corporation"
+  },
+  {
+    "symbol": "PM",
+    "name": "Philip Morris International"
+  },
+  {
+    "symbol": "PSX",
+    "name": "Phillips 66"
+  },
+  {
+    "symbol": "PNW",
+    "name": "Pinnacle West Capital"
+  },
+  {
+    "symbol": "PNC",
+    "name": "PNC Financial Services"
+  },
+  {
+    "symbol": "POOL",
+    "name": "Pool Corporation"
+  },
+  {
+    "symbol": "PPG",
+    "name": "PPG Industries"
+  },
+  {
+    "symbol": "PPL",
+    "name": "PPL Corporation"
+  },
+  {
+    "symbol": "PFG",
+    "name": "Principal Financial Group"
+  },
+  {
+    "symbol": "PG",
+    "name": "Procter &amp; Gamble"
+  },
+  {
+    "symbol": "PGR",
+    "name": "Progressive Corporation"
+  },
+  {
+    "symbol": "PLD",
+    "name": "Prologis"
+  },
+  {
+    "symbol": "PRU",
+    "name": "Prudential Financial"
+  },
+  {
+    "symbol": "PEG",
+    "name": "Public Service Enterprise Group"
+  },
+  {
+    "symbol": "PTC",
+    "name": "PTC Inc."
+  },
+  {
+    "symbol": "PSA",
+    "name": "Public Storage"
+  },
+  {
+    "symbol": "PHM",
+    "name": "PulteGroup"
+  },
+  {
+    "symbol": "PWR",
+    "name": "Quanta Services"
+  },
+  {
+    "symbol": "QCOM",
+    "name": "Qualcomm"
+  },
+  {
+    "symbol": "DGX",
+    "name": "Quest Diagnostics"
+  },
+  {
+    "symbol": "RL",
+    "name": "Ralph Lauren Corporation"
+  },
+  {
+    "symbol": "RJF",
+    "name": "Raymond James Financial"
+  },
+  {
+    "symbol": "RTX",
+    "name": "RTX Corporation"
+  },
+  {
+    "symbol": "O",
+    "name": "Realty Income"
+  },
+  {
+    "symbol": "REG",
+    "name": "Regency Centers"
+  },
+  {
+    "symbol": "REGN",
+    "name": "Regeneron Pharmaceuticals"
+  },
+  {
+    "symbol": "RF",
+    "name": "Regions Financial Corporation"
+  },
+  {
+    "symbol": "RSG",
+    "name": "Republic Services"
+  },
+  {
+    "symbol": "RMD",
+    "name": "ResMed"
+  },
+  {
+    "symbol": "RVTY",
+    "name": "Revvity"
+  },
+  {
+    "symbol": "ROK",
+    "name": "Rockwell Automation"
+  },
+  {
+    "symbol": "ROL",
+    "name": "Rollins, Inc."
+  },
+  {
+    "symbol": "ROP",
+    "name": "Roper Technologies"
+  },
+  {
+    "symbol": "ROST",
+    "name": "Ross Stores"
+  },
+  {
+    "symbol": "RCL",
+    "name": "Royal Caribbean Group"
+  },
+  {
+    "symbol": "SPGI",
+    "name": "S&amp;P Global"
+  },
+  {
+    "symbol": "CRM",
+    "name": "Salesforce"
+  },
+  {
+    "symbol": "SBAC",
+    "name": "SBA Communications"
+  },
+  {
+    "symbol": "SLB",
+    "name": "Schlumberger"
+  },
+  {
+    "symbol": "STX",
+    "name": "Seagate Technology"
+  },
+  {
+    "symbol": "SRE",
+    "name": "Sempra"
+  },
+  {
+    "symbol": "NOW",
+    "name": "ServiceNow"
+  },
+  {
+    "symbol": "SHW",
+    "name": "Sherwin-Williams"
+  },
+  {
+    "symbol": "SPG",
+    "name": "Simon Property Group"
+  },
+  {
+    "symbol": "SWKS",
+    "name": "Skyworks Solutions"
+  },
+  {
+    "symbol": "SJM",
+    "name": "J.M. Smucker Company (The)"
+  },
+  {
+    "symbol": "SW",
+    "name": "Smurfit Westrock"
+  },
+  {
+    "symbol": "SNA",
+    "name": "Snap-on"
+  },
+  {
+    "symbol": "SOLV",
+    "name": "Solventum"
+  },
+  {
+    "symbol": "SO",
+    "name": "Southern Company"
+  },
+  {
+    "symbol": "LUV",
+    "name": "Southwest Airlines"
+  },
+  {
+    "symbol": "SWK",
+    "name": "Stanley Black &amp; Decker"
+  },
+  {
+    "symbol": "SBUX",
+    "name": "Starbucks"
+  },
+  {
+    "symbol": "STT",
+    "name": "State Street Corporation"
+  },
+  {
+    "symbol": "STLD",
+    "name": "Steel Dynamics"
+  },
+  {
+    "symbol": "STE",
+    "name": "Steris"
+  },
+  {
+    "symbol": "SYK",
+    "name": "Stryker Corporation"
+  },
+  {
+    "symbol": "SMCI",
+    "name": "Supermicro"
+  },
+  {
+    "symbol": "SYF",
+    "name": "Synchrony Financial"
+  },
+  {
+    "symbol": "SNPS",
+    "name": "Synopsys"
+  },
+  {
+    "symbol": "SYY",
+    "name": "Sysco"
+  },
+  {
+    "symbol": "TMUS",
+    "name": "T-Mobile US"
+  },
+  {
+    "symbol": "TROW",
+    "name": "T. Rowe Price"
+  },
+  {
+    "symbol": "TTWO",
+    "name": "Take-Two Interactive"
+  },
+  {
+    "symbol": "TPR",
+    "name": "Tapestry, Inc."
+  },
+  {
+    "symbol": "TRGP",
+    "name": "Targa Resources"
+  },
+  {
+    "symbol": "TGT",
+    "name": "Target Corporation"
+  },
+  {
+    "symbol": "TEL",
+    "name": "TE Connectivity"
+  },
+  {
+    "symbol": "TDY",
+    "name": "Teledyne Technologies"
+  },
+  {
+    "symbol": "TER",
+    "name": "Teradyne"
+  },
+  {
+    "symbol": "TSLA",
+    "name": "Tesla, Inc."
+  },
+  {
+    "symbol": "TXN",
+    "name": "Texas Instruments"
+  },
+  {
+    "symbol": "TPL",
+    "name": "Texas Pacific Land Corporation"
+  },
+  {
+    "symbol": "TXT",
+    "name": "Textron"
+  },
+  {
+    "symbol": "TMO",
+    "name": "Thermo Fisher Scientific"
+  },
+  {
+    "symbol": "TJX",
+    "name": "TJX Companies"
+  },
+  {
+    "symbol": "TKO",
+    "name": "TKO Group Holdings"
+  },
+  {
+    "symbol": "TTD",
+    "name": "Trade Desk (The)"
+  },
+  {
+    "symbol": "TSCO",
+    "name": "Tractor Supply"
+  },
+  {
+    "symbol": "TT",
+    "name": "Trane Technologies"
+  },
+  {
+    "symbol": "TDG",
+    "name": "TransDigm Group"
+  },
+  {
+    "symbol": "TRV",
+    "name": "Travelers Companies (The)"
+  },
+  {
+    "symbol": "TRMB",
+    "name": "Trimble Inc."
+  },
+  {
+    "symbol": "TFC",
+    "name": "Truist Financial"
+  },
+  {
+    "symbol": "TYL",
+    "name": "Tyler Technologies"
+  },
+  {
+    "symbol": "TSN",
+    "name": "Tyson Foods"
+  },
+  {
+    "symbol": "USB",
+    "name": "U.S. Bancorp"
+  },
+  {
+    "symbol": "UBER",
+    "name": "Uber"
+  },
+  {
+    "symbol": "UDR",
+    "name": "UDR, Inc."
+  },
+  {
+    "symbol": "ULTA",
+    "name": "Ulta Beauty"
+  },
+  {
+    "symbol": "UNP",
+    "name": "Union Pacific Corporation"
+  },
+  {
+    "symbol": "UAL",
+    "name": "United Airlines Holdings"
+  },
+  {
+    "symbol": "UPS",
+    "name": "United Parcel Service"
+  },
+  {
+    "symbol": "URI",
+    "name": "United Rentals"
+  },
+  {
+    "symbol": "UNH",
+    "name": "UnitedHealth Group"
+  },
+  {
+    "symbol": "UHS",
+    "name": "Universal Health Services"
+  },
+  {
+    "symbol": "VLO",
+    "name": "Valero Energy"
+  },
+  {
+    "symbol": "VTR",
+    "name": "Ventas"
+  },
+  {
+    "symbol": "VLTO",
+    "name": "Veralto"
+  },
+  {
+    "symbol": "VRSN",
+    "name": "Verisign"
+  },
+  {
+    "symbol": "VRSK",
+    "name": "Verisk Analytics"
+  },
+  {
+    "symbol": "VZ",
+    "name": "Verizon"
+  },
+  {
+    "symbol": "VRTX",
+    "name": "Vertex Pharmaceuticals"
+  },
+  {
+    "symbol": "VTRS",
+    "name": "Viatris"
+  },
+  {
+    "symbol": "VICI",
+    "name": "Vici Properties"
+  },
+  {
+    "symbol": "V",
+    "name": "Visa Inc."
+  },
+  {
+    "symbol": "VST",
+    "name": "Vistra Corp"
+  },
+  {
+    "symbol": "VMC",
+    "name": "Vulcan Materials Company"
+  },
+  {
+    "symbol": "WRB",
+    "name": "W. R. Berkley Corporation"
+  },
+  {
+    "symbol": "GWW",
+    "name": "W. W. Grainger"
+  },
+  {
+    "symbol": "WAB",
+    "name": "Wabtec"
+  },
+  {
+    "symbol": "WBA",
+    "name": "Walgreens Boots Alliance"
+  },
+  {
+    "symbol": "WMT",
+    "name": "Walmart"
+  },
+  {
+    "symbol": "DIS",
+    "name": "Walt Disney Company (The)"
+  },
+  {
+    "symbol": "WBD",
+    "name": "Warner Bros. Discovery"
+  },
+  {
+    "symbol": "WM",
+    "name": "Waste Management"
+  },
+  {
+    "symbol": "WAT",
+    "name": "Waters Corporation"
+  },
+  {
+    "symbol": "WEC",
+    "name": "WEC Energy Group"
+  },
+  {
+    "symbol": "WFC",
+    "name": "Wells Fargo"
+  },
+  {
+    "symbol": "WELL",
+    "name": "Welltower"
+  },
+  {
+    "symbol": "WST",
+    "name": "West Pharmaceutical Services"
+  },
+  {
+    "symbol": "WDC",
+    "name": "Western Digital"
+  },
+  {
+    "symbol": "WY",
+    "name": "Weyerhaeuser"
+  },
+  {
+    "symbol": "WSM",
+    "name": "Williams-Sonoma, Inc."
+  },
+  {
+    "symbol": "WMB",
+    "name": "Williams Companies"
+  },
+  {
+    "symbol": "WTW",
+    "name": "Willis Towers Watson"
+  },
+  {
+    "symbol": "WDAY",
+    "name": "Workday, Inc."
+  },
+  {
+    "symbol": "WYNN",
+    "name": "Wynn Resorts"
+  },
+  {
+    "symbol": "XEL",
+    "name": "Xcel Energy"
+  },
+  {
+    "symbol": "XYL",
+    "name": "Xylem Inc."
+  },
+  {
+    "symbol": "YUM",
+    "name": "Yum! Brands"
+  },
+  {
+    "symbol": "ZBRA",
+    "name": "Zebra Technologies"
+  },
+  {
+    "symbol": "ZBH",
+    "name": "Zimmer Biomet"
+  },
+  {
+    "symbol": "ZTS",
+    "name": "Zoetis"
+  }
+]

--- a/tools/updateIndexMaps.mjs
+++ b/tools/updateIndexMaps.mjs
@@ -1,24 +1,18 @@
-// Build a name -> ticker dictionary for S&P 500 + Nasdaq 100
-import { writeFile, mkdir } from "fs/promises";
-import { load } from "cheerio";
+// tools/updateIndexMaps.mjs
+// Builds name->ticker map for S&P 500 + Nasdaq-100 with retries, IPv4 preference, and offline fallbacks.
 
-const FMP = process.env.FMP_KEY || ""; // optional; falls back to Wikipedia if empty
+import { writeFile, mkdir, readFile } from "fs/promises";
+import path from "node:path";
+import url from "node:url";
+import dns from "node:dns";
+import { Agent, setGlobalDispatcher } from "undici";
 
-async function json(url) {
-  const r = await fetch(url, { headers: { "User-Agent": "stock-recs/ci" } });
-  if (!r.ok) throw new Error(`HTTP ${r.status} @ ${url}`);
-  return r.json();
-}
-async function text(url) {
-  const r = await fetch(url, { headers: { "User-Agent": "stock-recs/ci" } });
-  if (!r.ok) throw new Error(`HTTP ${r.status} @ ${url}`);
-  return r.text();
-}
+dns.setDefaultResultOrder?.("ipv4first");
+setGlobalDispatcher(new Agent({ connect: { family: 4 } }));
 
-function decodeEntities(s) {
-  // Only parse with Cheerio when the string contains HTML entities
-  return s && s.includes("&") ? load(s).text() : s || "";
-}
+const FMP = process.env.FMP_KEY || "";
+const OFFLINE = process.env.OFFLINE === "1";
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 
 function normName(s) {
   return String(s || "")
@@ -27,69 +21,101 @@ function normName(s) {
     .replace(/\s+/g, " ")
     .trim();
 }
-
-// Expand common name variants (Inc., Corp., PLC; “Class A/B/C”; & vs and)
 function expandVariants(name) {
   const n = normName(name);
   const variants = new Set([n]);
-  const base = n
-    .replace(/,?\s+(Inc\.?|Incorporated|Corp\.?|Corporation|Company|Co\.?|Ltd\.?|Limited|PLC|N\.V\.|S\.A\.|A\/S)$/i, "")
-    .trim();
+  const base = n.replace(/,?\s+(Inc\.?|Incorporated|Corp\.?|Corporation|Company|Co\.?|Ltd\.?|Limited|PLC|N\.V\.|S\.A\.|A\/S)$/i, "").trim();
   variants.add(base);
   variants.add(base.replace(/\s*&\s*/g, " and "));
   variants.add(base.replace(/\s+and\s+/gi, " & "));
-  variants.add(base.replace(/\s+/g, "")); // super-lenient
-
-  // class shares
+  variants.add(base.replace(/\s+/g, "")); // ultra-lenient
   const m = base.match(/\b(Class|Series)\s+([ABCDEF])\b/i);
   if (m) {
     const cls = m[2].toUpperCase();
-    variants.add(base.replace(/\s*\(?(Class|Series)\s+[A-F]\)?/i, "").trim());
-    variants.add(`${base.replace(/\s*\(?(Class|Series)\s+[A-F]\)?/i, "").trim()} (${cls})`);
+    const noClass = base.replace(/\s*\(?(Class|Series)\s+[A-F]\)?/i, "").trim();
+    variants.add(noClass);
+    variants.add(`${noClass} (${cls})`);
   }
   return [...variants];
 }
 
+async function get(url, kind = "text", { timeoutMs = 8000, retries = 2 } = {}) {
+  if (OFFLINE) throw new Error("offline");
+  let last;
+  for (let i = 0; i <= retries; i++) {
+    const ac = new AbortController();
+    const t = setTimeout(() => ac.abort(), timeoutMs);
+    try {
+      const r = await fetch(url, {
+        signal: ac.signal,
+        headers: { "User-Agent": "stock-recs/ci" },
+      });
+      clearTimeout(t);
+      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      return kind === "json" ? r.json() : r.text();
+    } catch (e) {
+      clearTimeout(t);
+      last = e;
+      if (i < retries) await new Promise(r => setTimeout(r, 500 * (i + 1)));
+    }
+  }
+  throw last;
+}
+
+async function readOffline(name) {
+  try {
+    const p = path.resolve(__dirname, "../data/indexes", `${name}.offline.json`);
+    const txt = await readFile(p, "utf8");
+    return JSON.parse(txt);
+  } catch {
+    return [];
+  }
+}
+
 async function fetchSP500() {
-  // 1) Try FMP (if available)
+  // 1) FMP (if available)
   if (FMP) {
     try {
-      // FMP endpoint commonly used in examples
-      const arr = await json(`https://financialmodelingprep.com/api/v3/sp500_constituent?apikey=${FMP}`);
-      return arr.map(x => ({ symbol: x.symbol, name: decodeEntities(x.name) }));
+      const arr = await get(`https://financialmodelingprep.com/api/v3/sp500_constituent?apikey=${FMP}`, "json");
+      if (Array.isArray(arr)) return arr.map(x => ({ symbol: x.symbol, name: x.name }));
     } catch {}
   }
-  // 2) Wikipedia fallback (robust enough for CI)
-  const html = await text("https://en.wikipedia.org/wiki/List_of_S%26P_500_companies");
-  const rows = [...html.matchAll(/<tr>\s*<td><a[^>]+>([A-Z\.\-]+)<\/a><\/td>\s*<td><a[^>]*>([^<]+)<\/a>/g)];
-  return rows.map(([, symbol, name]) => ({ symbol, name: decodeEntities(name) }));
+  // 2) Wikipedia
+  try {
+    const html = await get("https://en.wikipedia.org/wiki/List_of_S%26P_500_companies", "text");
+    const rows = [...html.matchAll(/<tr>\s*<td><a[^>]+>([A-Z.\-]+)<\/a><\/td>\s*<td><a[^>]*>([^<]+)<\/a>/g)];
+    return rows.map(([, symbol, name]) => ({ symbol, name }));
+  } catch {}
+  // 3) Offline snapshot
+  const off = await readOffline("sp500");
+  return off;
 }
 
 async function fetchNasdaq100() {
   if (FMP) {
     try {
-      // Many users mirror NASDAQ-100 here; keep the fallback just in case endpoint differs
-      const arr = await json(`https://financialmodelingprep.com/api/v3/nasdaq_constituent?apikey=${FMP}`);
+      const arr = await get(`https://financialmodelingprep.com/api/v3/nasdaq_constituent?apikey=${FMP}`, "json");
       if (Array.isArray(arr) && arr[0]?.symbol && arr[0]?.name) {
-        return arr.map(x => ({ symbol: x.symbol, name: decodeEntities(x.name) }));
+        return arr.map(x => ({ symbol: x.symbol, name: x.name }));
       }
     } catch {}
   }
-  const html = await text("https://en.wikipedia.org/wiki/Nasdaq-100");
-  // First wikitable with “Ticker” + “Company”
-  const rows = [...html.matchAll(/<tr>\s*<td><a[^>]*>([A-Z\.\-]+)<\/a><\/td>\s*<td>(?:<a[^>]*>)?([^<]+)</g)];
-  return rows.map(([, symbol, name]) => ({ symbol, name: decodeEntities(name) }));
+  try {
+    const html = await get("https://en.wikipedia.org/wiki/Nasdaq-100", "text");
+    const rows = [...html.matchAll(/<tr>\s*<td><a[^>]*>([A-Z.\-]+)<\/a><\/td>\s*<td>(?:<a[^>]*>)?([^<]+)</g)];
+    return rows.map(([, symbol, name]) => ({ symbol, name }));
+  } catch {}
+  const off = await readOffline("nasdaq100");
+  return off;
 }
 
 function buildMap(pairs) {
   const map = {};
   for (const { symbol, name } of pairs) {
     if (!symbol || !name) continue;
-    for (const v of expandVariants(decodeEntities(name))) {
-      map[v] = symbol;
-    }
+    for (const v of expandVariants(name)) map[v] = symbol;
   }
-  // Helpful manual aliases
+  // helpful class-share aliases
   map["Berkshire Hathaway (B)"] = "BRK-B";
   map["Berkshire Hathaway (A)"] = "BRK-A";
   map["Brown-Forman (B)"] = "BF-B";
@@ -99,6 +125,7 @@ function buildMap(pairs) {
 
 const sp = await fetchSP500();
 const nd = await fetchNasdaq100();
+
 const mergedMap = buildMap([...sp, ...nd]);
 
 await mkdir("data/indexes", { recursive: true });
@@ -108,3 +135,7 @@ await mkdir("src", { recursive: true });
 await writeFile("src/maps.indexes.json", JSON.stringify(mergedMap, null, 2));
 
 console.log(`[index-maps] S&P 500: ${sp.length}, NASDAQ-100: ${nd.length}, merged keys: ${Object.keys(mergedMap).length}`);
+if (!sp.length || !nd.length) {
+  console.warn("[index-maps] Network failed; used offline snapshots where available.");
+}
+


### PR DESCRIPTION
## Summary
- replace `updateIndexMaps.mjs` with robust version that retries, prefers IPv4, and falls back to offline data
- add offline S&P 500 and Nasdaq-100 constituent snapshots

## Testing
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68afd572fdc8832a9409629723711ceb