### PR TITLE
Improve ticker resolution and sector enrichment

### DIFF
--- a/fetchStockInfo.js
+++ b/fetchStockInfo.js
@@ -306,13 +306,56 @@ function normalizeKey(s) {
   return t.toUpperCase();
 }
 
-// Load generated S&P500/Nasdaq100 map and merge into a single static map
-let INDEX_MAP = {};
+// ---------- Index maps (S&P 500 + Nasdaq 100) ----------
+let INDEX_RAW = {};
 try {
-  INDEX_MAP = JSON.parse(await readFile(new URL('./src/maps.indexes.json', import.meta.url), 'utf8'));
+  // adjust the path if your file lives elsewhere
+  INDEX_RAW = JSON.parse(await readFile(new URL('./src/maps.indexes.json', import.meta.url), 'utf8'));
 } catch {}
+
+// Normalize various possible shapes into rows with {symbol, name, sector}
+function rowsFromIndex(raw) {
+  if (Array.isArray(raw)) return raw;
+  if (Array.isArray(raw.sp500) || Array.isArray(raw.nasdaq100)) {
+    return (raw.sp500 || []).concat(raw.nasdaq100 || []);
+  }
+  // object map: { "AAPL": {name, sector} } or { "AAPL": "Apple" }
+  return Object.entries(raw).map(([symbol, v]) => ({
+    symbol,
+    name: (v && (v.name || v.company || v.companyName || v.Name)) || (typeof v === 'string' ? v : null),
+    sector: (v && (v.sector || v.Sector)) || null
+  }));
+}
+
+const INDEX_ROWS = rowsFromIndex(INDEX_RAW);
+
+// Build reverse lookups
+const SYMBOL_TO_NAME = {};
+const SYMBOL_TO_SECTOR = {};
+for (const r of INDEX_ROWS) {
+  const sym = String(r.symbol || r.ticker || '').toUpperCase().replace('/', '.').replace('-', '.');
+  if (!sym) continue;
+  if (r.name)   SYMBOL_TO_NAME[sym]   = r.name;
+  if (r.sector) SYMBOL_TO_SECTOR[sym] = r.sector;
+}
+
+// A fast “known tickers” set for pass-through decisions
+const INDEX_SYMBOL_SET = new Set(Object.keys(SYMBOL_TO_NAME));
+
+// Helpful canonicalizer for tickers with class separators
+function canonSymbol(s) {
+  if (!s) return s;
+  return String(s).toUpperCase().replace('/', '.').replace('-', '.');
+}
+
+// Merge your hard-coded TICKER_MAP with index map names so both directions exist.
 const STATIC_MAP = (() => {
-  const merged = { ...TICKER_MAP, ...INDEX_MAP };
+  const merged = { ...TICKER_MAP };
+  // also allow reverse mapping when INDEX has full names
+  for (const [sym, nm] of Object.entries(SYMBOL_TO_NAME)) {
+    if (nm) merged[nm] = sym;
+  }
+  // normalize keys
   const out = {};
   for (const [k, v] of Object.entries(merged)) out[normalizeKey(k)] = v;
   return out;
@@ -525,65 +568,83 @@ function pickSymbol(name, searchJson) {
   return quotes[0]?.symbol || null;
 }
 
+function looksLikeTickerShape(x) {
+  return /^[A-Z]{1,5}(\.[A-Z]{1,3})?$/.test(x) || /^\d{6}\.K[QS]$/.test(x);
+}
+
 async function resolveTicker(name, cache) {
-  // direct ticker pass-through
-  if (/^[A-Z][A-Z.\-]{0,6}(\.[A-Z]{1,3})?$/.test(name) || /^\d{6}\.K[QS]$/.test(name)) return name;
+  const raw = String(name);
+  const nk = normalizeKey(raw);
 
-  const nk = normalizeKey(name);
+  // 1) If it's literally a KR/US ticker we already know from index or static, pass through (canon form).
+  const maybeTicker = canonSymbol(raw);
+  const isTickerShape = looksLikeTickerShape(maybeTicker);
+  if (isTickerShape && (INDEX_SYMBOL_SET.has(maybeTicker) || STATIC_SECTORS[maybeTicker] || TICKER_MAP[raw] || TICKER_MAP[nk])) {
+    return maybeTicker;
+  }
 
-  // static maps
-  if (STATIC_MAP[nk]) return STATIC_MAP[nk];
+  // 2) Static name->ticker first (your static + index map merged)
+  if (STATIC_MAP[nk]) return canonSymbol(STATIC_MAP[nk]);
 
-  // cache (store by normalized key)
-  if (cache[nk]) return cache[nk];
+  // 3) Cache by normalized key
+  if (cache[nk]) return canonSymbol(cache[nk]);
 
+  // 4) Yahoo fallback (name -> best ticker)
   try {
-    const lang = looksKorean(name) ? 'ko-KR' : 'en-US';
-    const region = looksKorean(name) ? 'KR' : 'US';
-    const data = await yahooSearchSymbol(name, lang, region);
-    const symbol = pickSymbol(name, data);
-    if (!symbol) throw new Error(`Could not resolve ticker for "${name}"`);
+    const lang = looksKorean(raw) ? 'ko-KR' : 'en-US';
+    const region = looksKorean(raw) ? 'KR' : 'US';
+    const data = await yahooSearchSymbol(raw, lang, region);
+    const symbol = canonSymbol(pickSymbol(raw, data));
+    if (!symbol) throw new Error(`Could not resolve ticker for "${raw}"`);
     cache[nk] = symbol;
     await saveCache(cache);
-    console.log(`[RESOLVE] ${name} -> ${symbol}`);
+    console.log(`[RESOLVE] ${raw} -> ${symbol}`);
     return symbol;
   } catch (e) {
-    console.warn(`[RESOLVE] ${name}: ${e.message}`);
+    console.warn(`[RESOLVE] ${raw}: ${e.message}`);
     throw e;
   }
 }
 
-// Sector fetching with static mapping priority
+// Sector fetching with index and static mapping priority
 async function fetchSectorByTicker(ticker, cache) {
+  const sym = canonSymbol(ticker);
+
   // Check cache first
-  const cached = cacheGetSector(cache, ticker);
+  const cached = cacheGetSector(cache, sym);
   if (cached !== undefined) return cached;
 
-  // Check static sector mapping first
-  if (STATIC_SECTORS[ticker]) {
-    const sector = STATIC_SECTORS[ticker];
-    cachePutSector(cache, ticker, sector);
+  // 0) Index sector first
+  if (SYMBOL_TO_SECTOR[sym]) {
+    cachePutSector(cache, sym, SYMBOL_TO_SECTOR[sym]);
     await saveCache(cache);
-    console.log(`[STATIC] ${ticker}: ${sector}`);
+    return SYMBOL_TO_SECTOR[sym];
+  }
+
+  // 1) Static fallback
+  if (STATIC_SECTORS[sym]) {
+    const sector = STATIC_SECTORS[sym];
+    cachePutSector(cache, sym, sector);
+    await saveCache(cache);
     return sector;
   }
 
-  // For Korean stocks, try Naver
-  if (/.K[QS]$/.test(ticker)) {
+  // 2) KR: NAVER scrape
+  if (/.K[QS]$/.test(sym)) {
     try {
-      const sector = await naverSectorKR(ticker);
+      const sector = await naverSectorKR(sym);
       if (sector) {
-        cachePutSector(cache, ticker, sector);
+        cachePutSector(cache, sym, sector);
         await saveCache(cache);
         return sector;
       }
     } catch (e) {
-      console.warn(`[NAVER_FAIL] ${ticker}: ${e.message}`);
+      console.warn(`[NAVER_FAIL] ${sym}: ${e.message}`);
     }
   }
 
-  // Cache null on failure
-  cachePutSector(cache, ticker, null);
+  // 3) Cache null on failure
+  cachePutSector(cache, sym, null);
   await saveCache(cache);
   return null;
 }
@@ -601,7 +662,7 @@ async function fetchSector(name, cache) {
 
 // Utility functions
 function looksLikeTicker(s) {
-  return /^[A-Z]{1,5}([.\-][A-Z]{1,3})?$/.test(s) || /^\d{6}\.K[QS]$/.test(s);
+  return looksLikeTickerShape(canonSymbol(s || ''));
 }
 
 function inStatic(name) {
@@ -716,12 +777,18 @@ async function tryFetchAndEnrich() {
             console.warn(`[SEARCH_URL_FAIL] ${name}: ${e.message}`);
           }
 
+          const sym = ticker ? canonSymbol(ticker) : null;
+          const displayName =
+            (sym && SYMBOL_TO_NAME[sym]) ||
+            (sym && sym.includes('.') ? sym.replace('.', '-') : null) ||
+            name;
+
           updated.push({
-            name,
-            sector: sector || prevSector || null,
-            ticker: ticker || null,
+            name: displayName,
+            sector: sector || prevSector || (sym ? SYMBOL_TO_SECTOR[sym] || null : null),
+            ticker: sym || null,
             searchUrl: searchUrl || null,
-            rawScore: calcRawScore(market, group, name, ticker)
+            rawScore: calcRawScore(market, group, displayName, sym)
           });
 
           if (sector) successCount++;

--- a/src/maps.indexes.json
+++ b/src/maps.indexes.json
@@ -1,6 +1,21 @@
-{
-  "Berkshire Hathaway (B)": "BRK-B",
-  "Berkshire Hathaway (A)": "BRK-A",
-  "Brown-Forman (B)": "BF-B",
-  "Brown-Forman (A)": "BF-A"
-}
+[
+  {"symbol":"BRK.B","name":"Berkshire Hathaway (B)","sector":"Financial Services"},
+  {"symbol":"BRK.A","name":"Berkshire Hathaway (A)","sector":"Financial Services"},
+  {"symbol":"BF.B","name":"Brown-Forman (B)","sector":"Consumer Staples"},
+  {"symbol":"BF.A","name":"Brown-Forman (A)","sector":"Consumer Staples"},
+  {"symbol":"ABBV","name":"AbbVie","sector":"Healthcare"},
+  {"symbol":"ALB","name":"Albemarle","sector":"Materials"},
+  {"symbol":"AXP","name":"American Express","sector":"Financial Services"},
+  {"symbol":"BBY","name":"Best Buy","sector":"Consumer Discretionary"},
+  {"symbol":"A","name":"Agilent Technologies","sector":"Healthcare"},
+  {"symbol":"ADI","name":"Analog Devices","sector":"Technology"},
+  {"symbol":"APA","name":"APA Corporation","sector":"Energy"},
+  {"symbol":"CPB","name":"Campbell Soup","sector":"Consumer Staples"},
+  {"symbol":"GOOG","name":"Alphabet (Class C)","sector":"Communication Services"},
+  {"symbol":"ADP","name":"Automatic Data Processing","sector":"Technology"},
+  {"symbol":"AMAT","name":"Applied Materials","sector":"Technology"},
+  {"symbol":"ABNB","name":"Airbnb","sector":"Consumer Discretionary"},
+  {"symbol":"ADSK","name":"Autodesk","sector":"Technology"},
+  {"symbol":"APP","name":"Applovin","sector":"Technology"},
+  {"symbol":"PDD","name":"PDD Holdings","sector":"Consumer Discretionary"}
+]


### PR DESCRIPTION
## Summary
- build reverse lookup from index maps to map tickers to company names and sectors
- tighten ticker resolution to prefer known symbols and canonical forms
- enrich recommendations with index-based display names and sectors

## Testing
- `node tests/apple_association.test.js`
- `node fetchStockInfo.js --force` *(fails: [YAHOO_SEARCH] MO: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_b_68afdc41b9f4832a9977ede4f875abe5