### PR TITLE
Improve stock index parsing and naming

### DIFF
--- a/fetchStockInfo.js
+++ b/fetchStockInfo.js
@@ -306,59 +306,6 @@ function normalizeKey(s) {
   return t.toUpperCase();
 }
 
-// ---------- Index lookups ----------
-let indexes = {};
-try {
-  indexes = JSON.parse(await readFile(new URL('./src/maps.indexes.json', import.meta.url), 'utf8'));
-} catch {}
-
-const rows = [
-  ...(indexes.sp500 || []),
-  ...(indexes.nasdaq100 || []),
-  ...(indexes.kospi200 || []),
-  ...(indexes.kosdaq100 || []),
-];
-
-const SYMBOL_TO_NAME = Object.fromEntries(rows.filter(r => r.symbol && r.name).map(r => [r.symbol, r.name]));
-
-const SECTOR_NORMALIZE = {
-  'Information Technology': 'Technology',
-  'Health Care': 'Healthcare',
-  'Communication Services': 'Communication Services',
-  'Consumer Discretionary': 'Consumer Discretionary',
-  'Consumer Staples': 'Consumer Staples',
-  'Financials': 'Financial Services',
-  'Industrials': 'Industrials',
-  'Materials': 'Materials',
-  'Utilities': 'Utilities',
-  'Real Estate': 'Real Estate',
-  'Energy': 'Energy',
-};
-const INDEX_SECTOR = Object.fromEntries(
-  rows
-    .filter(r => r.symbol && r.sector)
-    .map(r => [r.symbol, SECTOR_NORMALIZE[r.sector] || r.sector])
-);
-
-const INDEX_SYMBOL_SET = new Set(Object.keys(SYMBOL_TO_NAME));
-
-// Helpful canonicalizer for tickers with class separators
-function canonSymbol(s) {
-  if (!s) return s;
-  return String(s).toUpperCase().replace('/', '.').replace('-', '.');
-}
-
-// Merge your hard-coded TICKER_MAP with index map names so both directions exist.
-const STATIC_MAP = (() => {
-  const merged = { ...TICKER_MAP };
-  for (const [sym, nm] of Object.entries(SYMBOL_TO_NAME)) {
-    if (nm) merged[nm] = sym;
-  }
-  const out = {};
-  for (const [k, v] of Object.entries(merged)) out[normalizeKey(k)] = v;
-  return out;
-})();
-
 // Extended static sector mapping (consistent naming)
 const STATIC_SECTORS = {
   // KOSPI
@@ -379,13 +326,120 @@ const STATIC_SECTORS = {
   // US
   'MSFT': 'Technology', 'AAPL': 'Technology', 'NVDA': 'Technology', 'AMZN': 'Consumer Discretionary',
   'META': 'Communication Services', 'GOOGL': 'Communication Services', 'TSLA': 'Consumer Discretionary',
-  'NFLX': 'Communication Services', 'SMCI': 'Technology', 'AMD': 'Technology', 'PEP': 'Consumer Staples', 'PLTR': 'Technology', 'ARM': 'Technology',
+  'NFLX': 'Communication Services', 'SMCI': 'Technology', 'AMD': 'Technology', 'PEP': 'Consumer Staples', 'PLTR': 'Technology',
+  'ARM': 'Technology',
   'MU': 'Technology', 'PATH': 'Technology', 'CRWD': 'Technology', 'BRK-B': 'Financial Services',
   'JNJ': 'Healthcare', 'PG': 'Consumer Staples', 'V': 'Financial Services', 'KO': 'Consumer Staples',
   'NOW': 'Technology', 'LLY': 'Healthcare', 'UBER': 'Technology', 'NRG': 'Utilities',
   'JPM': 'Financial Services', 'UNH': 'Healthcare', 'MRNA': 'Healthcare', 'ZM': 'Technology',
   'MDB': 'Technology', 'SNOW': 'Technology'
 };
+
+// ---------- Index lookups (robust) ----------
+let indexes = {};
+try {
+  indexes = JSON.parse(await readFile(new URL('./src/maps.indexes.json', import.meta.url), 'utf8'));
+} catch {}
+
+const GICS_SECTORS = new Set([
+  'Communication Services','Consumer Discretionary','Consumer Staples','Energy',
+  'Financials','Health Care','Healthcare','Industrials','Information Technology','Technology',
+  'Materials','Real Estate','Utilities'
+].map(s => s.toUpperCase()));
+
+const SECTOR_NORMALIZE = {
+  'Information Technology': 'Technology',
+  'Health Care': 'Healthcare',
+  'Healthcare': 'Healthcare',
+  'Communication Services': 'Communication Services',
+  'Consumer Discretionary': 'Consumer Discretionary',
+  'Consumer Staples': 'Consumer Staples',
+  'Financials': 'Financial Services',
+  'Industrials': 'Industrials',
+  'Materials': 'Materials',
+  'Utilities': 'Utilities',
+  'Real Estate': 'Real Estate',
+  'Energy': 'Energy',
+};
+
+// Treat both slash and dash variants as the same symbol
+function canonSymbol(s) {
+  if (!s) return s;
+  return String(s).toUpperCase().replace('/', '.').replace('-', '.');
+}
+function looksLikeTickerShape(x) {
+  return /^[A-Z]{1,5}(\.[A-Z]{1,3})?$/.test(x || '') || /^\d{6}\.K[QS]$/.test(x || '');
+}
+const looksLikeTicker = s => looksLikeTickerShape(canonSymbol(s || ''));
+
+// Gather candidate rows from all supported lists if present
+const rawRows = [
+  ...(indexes.sp500 || []),
+  ...(indexes.nasdaq100 || []),
+  ...(indexes.kospi200 || []),
+  ...(indexes.kosdaq100 || []),
+];
+
+// Build robust maps from index data that may have swapped fields
+const INDEX_NAME = {};   // ticker -> company name
+const INDEX_SECTOR = {}; // ticker -> normalized sector
+
+for (const r of rawRows) {
+  // Pull and canonicalize
+  const s1 = canonSymbol(r.symbol);
+  const s2 = canonSymbol(r.name);
+
+  const s1IsTicker = looksLikeTicker(s1);
+  const s2IsTicker = looksLikeTicker(s2);
+
+  // Determine ticker
+  let ticker = null;
+  if (s1IsTicker && !s2IsTicker) ticker = s1;
+  else if (!s1IsTicker && s2IsTicker) ticker = s2;
+  else if (s1IsTicker && s2IsTicker) {
+    // Both look like tickers: pick s1 by default; if static sector knows s2 but not s1, prefer s2
+    ticker = s1;
+    if (STATIC_SECTORS?.[s2] && !STATIC_SECTORS?.[s1]) ticker = s2;
+  } else {
+    // Neither clearly ticker → skip; we can’t trust this row
+    continue;
+  }
+
+  // Determine company name: pick the non-ticker field; if both tickers, try r.sector if it looks like a name
+  let company = null;
+  if (s1IsTicker && !s2IsTicker) company = r.name?.toString().trim();
+  else if (!s1IsTicker && s2IsTicker) company = r.symbol?.toString().trim();
+  else if (s1IsTicker && s2IsTicker) {
+    const maybeName = (r.sector || '').toString().trim();
+    if (maybeName && !GICS_SECTORS.has(maybeName.toUpperCase())) company = maybeName;
+  }
+
+  // Determine sector (only accept if it looks like a real sector)
+  let sector = r.sector;
+  if (sector && typeof sector === 'string') {
+    sector = sector.trim();
+    if (!GICS_SECTORS.has(sector.toUpperCase())) sector = null;
+  } else {
+    sector = null;
+  }
+
+  if (company && !looksLikeTicker(company) && !GICS_SECTORS.has(company.toUpperCase())) INDEX_NAME[ticker] = company;
+  if (sector) INDEX_SECTOR[ticker] = SECTOR_NORMALIZE[sector] || sector;
+}
+
+const INDEX_SYMBOL_SET = new Set(Object.keys(INDEX_NAME));
+
+// Merge your hard-coded TICKER_MAP with index map names so both directions exist.
+const STATIC_MAP = (() => {
+  const merged = { ...TICKER_MAP };
+  for (const [sym, nm] of Object.entries(INDEX_NAME)) {
+    if (nm) merged[nm] = sym;
+  }
+  const out = {};
+  for (const [k, v] of Object.entries(merged)) out[normalizeKey(k)] = v;
+  return out;
+})();
+
 
 // Cache related functions
 async function loadCache() {
@@ -566,10 +620,6 @@ function pickSymbol(name, searchJson) {
   return quotes[0]?.symbol || null;
 }
 
-function looksLikeTickerShape(x) {
-  return /^[A-Z]{1,5}(\.[A-Z]{1,3})?$/.test(x) || /^\d{6}\.K[QS]$/.test(x);
-}
-
 async function resolveTicker(name, cache) {
   const raw = String(name);
   const nk = normalizeKey(raw);
@@ -651,11 +701,6 @@ async function fetchSector(name, cache) {
     console.warn(`[FETCH_SECTOR] ${name}: ${e.message}`);
     return { sector: null, ticker: null };
   }
-}
-
-// Utility functions
-function looksLikeTicker(s) {
-  return looksLikeTickerShape(canonSymbol(s || ''));
 }
 
 function inStatic(name) {
@@ -756,35 +801,35 @@ async function tryFetchAndEnrich() {
 
       const updated = [];
       for (const entry of entries) {
-        const name = typeof entry === 'string' ? entry : entry.name;
-        const prevSector = typeof entry === 'object' ? (entry.sector ?? null) : null;
+          const name = typeof entry === 'string' ? entry : entry.name;
 
-        try {
-          const { sector, ticker } = await fetchSector(name, cache);
-
-          // Build a SERP URL with fallback: Naver → Google → Yahoo
-          let searchUrl = null;
           try {
-            searchUrl = await fetchSearchUrl(name, ticker, cache);
-          } catch (e) {
-            console.warn(`[SEARCH_URL_FAIL] ${name}: ${e.message}`);
-          }
+            const { sector, ticker } = await fetchSector(name, cache);
+            const displayName =
+              INDEX_NAME[ticker] ||
+              (!looksLikeTicker(name) ? name : undefined) ||
+              name;
 
-          const displayName = (ticker && SYMBOL_TO_NAME[ticker]) || name;
+            let searchUrl = null;
+            try {
+              searchUrl = await fetchSearchUrl(displayName, ticker, cache);
+            } catch (e) {
+              console.warn(`[SEARCH_URL_FAIL] ${name}: ${e.message}`);
+            }
 
-          updated.push({
-            name: displayName,
-            sector: sector || prevSector || null,
-            ticker: ticker || null,
-            searchUrl: searchUrl || null,
-            rawScore: calcRawScore(market, group, displayName, ticker)
-          });
+            updated.push({
+              name: displayName,
+              sector: INDEX_SECTOR[ticker] || sector,
+              ticker,
+              searchUrl,
+              rawScore: calcRawScore(market, group, displayName, ticker)
+            });
 
-          if (sector) successCount++;
-        } catch (err) {
-          console.error(`[ERROR] ${name}: ${err.message}`);
-          updated.push({ name, sector: prevSector || null, ticker: null, searchUrl: null, rawScore: calcRawScore(market, group, name, null) });
-          noteStatus(err);
+            if (sector) successCount++;
+          } catch (err) {
+            console.error(`[ERROR] ${name}: ${err.message}`);
+            updated.push({ name, sector: null, ticker: null, searchUrl: null, rawScore: calcRawScore(market, group, name, null) });
+            noteStatus(err);
 
           if (consecutive429 >= 5) {
             throw new Error('Too many consecutive 429s, aborting');

--- a/recommendations.json
+++ b/recommendations.json
@@ -6,7 +6,7 @@
         "sector": "Communication Services",
         "ticker": "035900.KQ",
         "searchUrl": "https://www.google.com/search?tbm=nws&q=JYP%EC%97%94%ED%84%B0%ED%85%8C%EC%9D%B8%EB%A8%BC%ED%8A%B8%20035900.KQ",
-        "score": 61
+        "score": 99
       },
       {
         "name": "레인보우로보틱스",
@@ -27,14 +27,14 @@
         "sector": "Industrials",
         "ticker": "278280.KQ",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%EC%B2%9C%EB%B3%B4%20278280.KQ",
-        "score": 64
+        "score": 99
       },
       {
         "name": "펩트론",
         "sector": "Healthcare",
         "ticker": "087010.KQ",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%ED%8E%A9%ED%8A%B8%EB%A1%A0%20087010.KQ",
-        "score": 61
+        "score": 98
       }
     ],
     "aggressive": [
@@ -50,21 +50,21 @@
         "sector": null,
         "ticker": "HLB",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=HLB%20HLB",
-        "score": 52
+        "score": 50
       },
       {
         "name": "셀트리온헬스케어",
         "sector": "Healthcare",
         "ticker": "091990.KQ",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%EC%85%80%ED%8A%B8%EB%A6%AC%EC%98%A8%ED%97%AC%EC%8A%A4%EC%BC%80%EC%96%B4%20091990.KQ",
-        "score": 92
+        "score": 100
       },
       {
         "name": "알테오젠",
         "sector": "Healthcare",
         "ticker": "196170.KQ",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%EC%95%8C%ED%85%8C%EC%98%A4%EC%A0%A0%20196170.KQ",
-        "score": 98
+        "score": 100
       },
       {
         "name": "펄어비스",
@@ -89,28 +89,28 @@
         "sector": "Consumer Discretionary",
         "ticker": "000270.KS",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%EA%B8%B0%EC%95%84%20000270.KS",
-        "score": 57
+        "score": 100
       },
       {
         "name": "삼성전자",
         "sector": "Technology",
         "ticker": "005930.KS",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%EC%82%BC%EC%84%B1%EC%A0%84%EC%9E%90%20005930.KS",
-        "score": 100
+        "score": 93
       },
       {
         "name": "셀트리온",
         "sector": "Healthcare",
         "ticker": "068270.KS",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%EC%85%80%ED%8A%B8%EB%A6%AC%EC%98%A8%20068270.KS",
-        "score": 81
+        "score": 100
       },
       {
         "name": "카카오",
         "sector": "Communication Services",
         "ticker": "035720.KS",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%EC%B9%B4%EC%B9%B4%EC%98%A4%20035720.KS",
-        "score": 90
+        "score": 96
       }
     ],
     "aggressive": [
@@ -119,21 +119,21 @@
         "sector": "Industrials",
         "ticker": "267260.KS",
         "searchUrl": "https://www.google.com/search?tbm=nws&q=HD%ED%98%84%EB%8C%80%EC%9D%BC%EB%A0%89%ED%8A%B8%EB%A6%AD%20267260.KS",
-        "score": 97
+        "score": 84
       },
       {
         "name": "LG에너지솔루션",
         "sector": null,
         "ticker": "373220.KS",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=LG%EC%97%90%EB%84%88%EC%A7%80%EC%86%94%EB%A3%A8%EC%85%98%20373220.KS",
-        "score": 50
+        "score": 95
       },
       {
         "name": "POSCO퓨처엠",
         "sector": "Materials",
         "ticker": "003670.KS",
         "searchUrl": "https://www.google.com/search?tbm=nws&q=POSCO%ED%93%A8%EC%B2%98%EC%97%A0%20003670.KS",
-        "score": 52
+        "score": 50
       },
       {
         "name": "SK하이닉스",
@@ -147,7 +147,7 @@
         "sector": "Communication Services",
         "ticker": "035420.KS",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%EB%84%A4%EC%9D%B4%EB%B2%84%20035420.KS",
-        "score": 60
+        "score": 96
       }
     ]
   },
@@ -155,23 +155,23 @@
     "safe": [
       {
         "name": "Airbnb",
-        "sector": null,
+        "sector": "Consumer Discretionary",
         "ticker": "ABNB",
-        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=ABNB%20ABNB",
-        "score": 64
+        "searchUrl": "https://www.google.com/search?tbm=nws&q=Airbnb%20ABNB",
+        "score": 87
       },
       {
         "name": "Alphabet Inc.",
         "sector": "Communication Services",
         "ticker": "GOOGL",
-        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=Alphabet%20GOOGL",
-        "score": 55
+        "searchUrl": "https://www.google.com/search?tbm=nws&q=Alphabet%20Inc.%20GOOGL",
+        "score": 56
       },
       {
         "name": "Alphabet Inc.",
         "sector": null,
         "ticker": "GOOG",
-        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=GOOG%20GOOG",
+        "searchUrl": "https://www.google.com/search?tbm=nws&q=Alphabet%20Inc.%20GOOGL",
         "score": 55
       },
       {
@@ -185,8 +185,8 @@
         "name": "Applied Materials",
         "sector": null,
         "ticker": "AMAT",
-        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=AMAT%20AMAT",
-        "score": 69
+        "searchUrl": "https://www.google.com/search?tbm=nws&q=Applied%20Materials%20AMAT",
+        "score": 100
       }
     ],
     "aggressive": [
@@ -194,7 +194,7 @@
         "name": "American Electric Power",
         "sector": null,
         "ticker": "AEP",
-        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=AEP%20AEP",
+        "searchUrl": "https://www.google.com/search?tbm=nws&q=American%20Electric%20Power%20AEP",
         "score": 50
       }
     ]
@@ -202,78 +202,78 @@
   "S&P 500": {
     "safe": [
       {
-        "name": "ABT",
+        "name": "AbbVie",
         "sector": null,
         "ticker": "ABBV",
-        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=ABBV%20ABBV",
+        "searchUrl": "https://www.google.com/search?tbm=nws&q=AbbVie%20ABBV",
         "score": 100
       },
       {
         "name": "Adobe Inc.",
         "sector": null,
         "ticker": "ADBE",
-        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=ADBE%20ADBE",
-        "score": 99
+        "searchUrl": "https://www.google.com/search?tbm=nws&q=Adobe%20Inc.%20ADBE",
+        "score": 82
       },
       {
-        "name": "AKAM",
+        "name": "Albemarle Corporation",
         "sector": null,
         "ticker": "ALB",
-        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=ALB%20ALB",
-        "score": 100
+        "searchUrl": "https://www.google.com/search?tbm=nws&q=Albemarle%20Corporation%20ALB",
+        "score": 58
       },
       {
-        "name": "AXP",
-        "sector": "Consumer Finance",
-        "ticker": "FINANCIALS",
-        "searchUrl": "https://www.google.com/search?tbm=nws&q=AXP%20FINANCIALS",
-        "score": 55
+        "name": "American Express",
+        "sector": null,
+        "ticker": "AXP",
+        "searchUrl": "https://www.google.com/search?tbm=nws&q=American%20Express%20AXP",
+        "score": 81
       },
       {
         "name": "Nvidia",
         "sector": "Technology",
         "ticker": "NVDA",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=NVIDIA%20NVDA",
-        "score": 99
+        "score": 55
       }
     ],
-    "aggressive": [
+      "aggressive": [
+        {
+          "name": "Agilent Technologies",
+          "sector": null,
+          "ticker": "A",
+          "searchUrl": "https://www.google.com/search?tbm=nws&q=Agilent%20Technologies%20A",
+          "score": 50
+        },
+        {
+          "name": "Analog Devices",
+          "sector": null,
+          "ticker": "ADI",
+          "searchUrl": "https://www.google.com/search?tbm=nws&q=Analog%20Devices%20ADI",
+        "score": 94
+      },
       {
-        "name": "A",
-        "sector": "Air Products",
-        "ticker": "APD",
-        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=A%20APD",
+        "name": "BOSTON",
+        "sector": null,
+        "ticker": "AMT",
+        "searchUrl": "https://www.google.com/search?tbm=nws&q=BOSTON%20AMT",
         "score": 100
       },
       {
-        "name": "AMT",
-        "sector": "2007-11-19",
-        "ticker": "BOSTON",
-        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=AMT%20BOSTON",
-        "score": 50
-      },
-      {
-        "name": "Analog Devices",
-        "sector": null,
-        "ticker": "ADI",
-        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=ADI%20ADI",
-        "score": 98
-      },
-      {
         "name": "Broadcom",
-        "sector": null,
+        "sector": "Technology",
         "ticker": "AVGO",
-        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=AVGO%20AVGO",
-        "score": 99
+        "searchUrl": "https://www.google.com/search?tbm=nws&q=Broadcom%20AVGO",
+        "score": 95
       },
-      {
-        "name": "CPB",
-        "sector": "Capital One",
-        "ticker": "COF",
-        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=CPB%20COF",
-        "score": 50
-      }
-    ]
+        {
+          "name": "Campbell Soup Company",
+          "sector": null,
+          "ticker": "CPB",
+          "searchUrl": "https://www.google.com/search?tbm=nws&q=Campbell%20Soup%20Company%20CPB",
+          "score": 50
+        }
+      ]
   },
-  "lastUpdated": "2025-08-28T15:39:18+09:00"
+  "lastUpdated": "2025-08-28T16:13:26+09:00"
 }


### PR DESCRIPTION
## Summary
- parse index maps with heuristics to extract reliable ticker names and sectors
- prefer index-derived company names and normalized sectors when enriching recommendations
- refresh recommendations data with company display names

## Testing
- `node fetchStockInfo.js --force`
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68afffd8bbd0832a8208d124bdf19d57