### PR TITLE
feat: add keyword-based reputation scoring

### DIFF
--- a/fetchStockInfo.js
+++ b/fetchStockInfo.js
@@ -214,13 +214,14 @@ function calcRawScore(market, tier, name, ticker) {
   const jitter = rnd() * 0.01;
 
   const signals = [];
-  const baseWeights = { sentiment: 0.1, count: 0.01, blog: 0.15, naver: 0.3 };
+  const baseWeights = { sentiment: 0.10, count: 0.01, blog: 0.15, naver: 0.30, reputation: 0.25 };
   if (typeof news.sentiment === 'number') signals.push({ v: news.sentiment, w: baseWeights.sentiment });
   if (typeof news.count === 'number') signals.push({ v: news.count, w: baseWeights.count });
   if (typeof news.blogMentions === 'number') signals.push({ v: news.blogMentions, w: baseWeights.blog });
   if (typeof trend.naverPopularity === 'number') signals.push({ v: trend.naverPopularity, w: baseWeights.naver });
+  if (typeof news.reputationScore === 'number') signals.push({ v: news.reputationScore, w: baseWeights.reputation });
 
-  const totalOrig = baseWeights.sentiment + baseWeights.count + baseWeights.blog + baseWeights.naver;
+  const totalOrig = baseWeights.sentiment + baseWeights.count + baseWeights.blog + baseWeights.naver + baseWeights.reputation;
   const totalAvail = signals.reduce((s, x) => s + x.w, 0);
   const scale = totalAvail > 0 ? totalOrig / totalAvail : 0;
   const extra = signals.reduce((s, x) => s + x.v * x.w * scale, 0);
@@ -817,18 +818,29 @@ async function tryFetchAndEnrich() {
               console.warn(`[SEARCH_URL_FAIL] ${name}: ${e.message}`);
             }
 
+            const news = ticker ? (newsFeatures[ticker] || {}) : {};
+            const trend = ticker ? (naverTrends[ticker] || {}) : {};
             updated.push({
               name: displayName,
               sector: INDEX_SECTOR[ticker] || sector,
               ticker,
               searchUrl,
-              rawScore: calcRawScore(market, group, displayName, ticker)
+              rawScore: calcRawScore(market, group, displayName, ticker),
+              reasons: {
+                reputationScore: news.reputationScore ?? null,
+                topKeywords: news.topKeywords || [],
+                signals: {
+                  sentiment: typeof news.sentiment === 'number' ? news.sentiment : null,
+                  blog: typeof news.blogMentions === 'number' ? news.blogMentions : null,
+                  naver: typeof trend.naverPopularity === 'number' ? trend.naverPopularity : null
+                }
+              }
             });
 
             if (sector) successCount++;
           } catch (err) {
             console.error(`[ERROR] ${name}: ${err.message}`);
-            updated.push({ name, sector: null, ticker: null, searchUrl: null, rawScore: calcRawScore(market, group, name, null) });
+            updated.push({ name, sector: null, ticker: null, searchUrl: null, rawScore: calcRawScore(market, group, name, null), reasons: { reputationScore: null, topKeywords: [], signals: { sentiment: null, blog: null, naver: null } } });
             noteStatus(err);
 
           if (consecutive429 >= 5) {

--- a/src/news/fetchByTicker.js
+++ b/src/news/fetchByTicker.js
@@ -4,6 +4,7 @@ import { restClient } from '@polygon.io/client-js';
 import { fetchKotraRecent } from "./kotraOverseas.js";
 import { getCompanyNameByYahooSymbol } from "../data/krxDirectory.js";
 import { tokenBucket, circuitBreaker } from "./helpers/rate.js";
+import { computeReputation } from './reputation.js';
 
 const CACHE_DIR = 'cache';
 const NEWS_TTL_MS = Number(process.env.NEWS_TTL_MS || 30 * 60 * 1000); // 30m
@@ -30,6 +31,8 @@ const buckets = {
   polygon: tokenBucket({capacity:2, refillPerSec:1}),
 };
 const cb = circuitBreaker({cooldownMs:20*60_000});
+const ALIAS_PATH = path.join(process.cwd(), 'src/news/symbol-aliases.json');
+const SYMBOL_ALIASES = (()=>{ try { return JSON.parse(fs.readFileSync(ALIAS_PATH, 'utf8')); } catch { return {}; }})();
 
 async function guardedCall(name, fn){
   if (cb.isOpen(name)) return null;
@@ -429,8 +432,8 @@ export async function buildNewsFeatures(symbols, opts={}){
           if (close != null) v.nasdaqClose = close;
           if (v.count === 0 && (v.polygonTrend != null || v.nasdaqClose != null)) v.count = 1;
           if (v.count > 0) {
-            baseOut[baseSymbol(sym)] = v;
-            return;
+            feat = v;
+            break;
           }
         }
       } catch (e) {
@@ -438,18 +441,33 @@ export async function buildNewsFeatures(symbols, opts={}){
         console.warn(`[news] ${sym} provider ${p} failed: ${e.message}`);
       }
     }
-    if (lastErr) console.warn(`[news] providers exhausted for ${sym}. Last: ${lastErr.message}`);
-    const trend = await fetchPolygonTrend(sym);
-    if (trend != null) feat.polygonTrend = trend;
-    const close = await fetchPrevClose(sym);
-    if (close != null) feat.nasdaqClose = close;
-    if (feat.count === 0 && (feat.polygonTrend != null || feat.nasdaqClose != null)) feat.count = 1;
+    if (feat.count === 0) {
+      if (lastErr) console.warn(`[news] providers exhausted for ${sym}. Last: ${lastErr.message}`);
+      const trend = await fetchPolygonTrend(sym);
+      if (trend != null) feat.polygonTrend = trend;
+      const close = await fetchPrevClose(sym);
+      if (close != null) feat.nasdaqClose = close;
+      if (feat.count === 0 && (feat.polygonTrend != null || feat.nasdaqClose != null)) feat.count = 1;
+    }
+
+    let items = [];
+    try {
+      items = await getTickerArticles(sym);
+    } catch {}
+    try {
+      const aliases = SYMBOL_ALIASES[sym] || [];
+      const rep = computeReputation({ items, company: { ticker: sym, names: [symbolToName[sym], ...aliases].filter(Boolean) } });
+      feat.reputationScore = rep.reputationScore;
+      feat.topKeywords = rep.topKeywords;
+      feat.reputationHitIds = rep.hitIds;
+    } catch {}
+
     baseOut[baseSymbol(sym)] = feat;
   });
 
   const out = {};
   for (const s of symbols){
-    out[s] = baseOut[baseSymbol(s)] || { count:0, sentiment:0, blogMentions:0, polygonTrend:0, nasdaqClose:null };
+    out[s] = baseOut[baseSymbol(s)] || { count:0, sentiment:0, blogMentions:0, polygonTrend:0, nasdaqClose:null, reputationScore:null, topKeywords:[], reputationHitIds:[] };
   }
   return out;
 }

--- a/src/news/keyword-taxonomy.json
+++ b/src/news/keyword-taxonomy.json
@@ -1,0 +1,78 @@
+{
+  "version": 1,
+  "halfLifeDays": 14,
+  "alpha": 1.1,
+  "defaultBias": 0.0,
+  "sourceWeights": {
+    "major": 1.2,
+    "wire": 1.1,
+    "default": 1.0,
+    "blog": 0.75,
+    "forum": 0.6,
+    "unknown": 0.6
+  },
+  "intensity": {
+    "strong": 1.5,
+    "normal": 1.0,
+    "weak": 0.75
+  },
+  "classes": [
+    {
+      "id": "contract_win",
+      "polarity": "positive",
+      "weight": 1.0,
+      "terms_kr": ["수주", "대형 수주", "계약 체결", "장기 공급계약"],
+      "terms_en": ["contract win", "wins contract", "award(ed) contract", "long-term supply"],
+      "sectors": ["industrial", "defense", "semiconductor", "energy"]
+    },
+    {
+      "id": "guidance_up",
+      "polarity": "positive",
+      "weight": 1.0,
+      "terms_kr": ["가이던스 상향", "실적 전망 상향"],
+      "terms_en": ["guidance raise", "raises guidance", "outlook raised", "upgrades outlook"]
+    },
+    {
+      "id": "buyback_dividend",
+      "polarity": "positive",
+      "weight": 0.9,
+      "terms_kr": ["자사주 매입", "배당 증액"],
+      "terms_en": ["share buyback", "repurchase", "dividend hike", "special dividend"]
+    },
+    {
+      "id": "regulatory_approval",
+      "polarity": "positive",
+      "weight": 1.1,
+      "terms_kr": ["허가 승인", "식약처 승인", "인허가 승인"],
+      "terms_en": ["approval granted", "FDA approval", "regulatory approval"]
+    },
+    {
+      "id": "recall_investigation",
+      "polarity": "negative",
+      "weight": 1.1,
+      "terms_kr": ["리콜", "조사 착수", "조사 대상"],
+      "terms_en": ["recall", "under investigation", "probe launched"]
+    },
+    {
+      "id": "guidance_down",
+      "polarity": "negative",
+      "weight": 1.0,
+      "terms_kr": ["가이던스 하향", "실적 전망 하향"],
+      "terms_en": ["cuts guidance", "guidance cut", "lowers outlook"]
+    },
+    {
+      "id": "fraud_accounting",
+      "polarity": "negative",
+      "weight": 1.3,
+      "terms_kr": ["회계 부정", "분식회계", "사기 의혹"],
+      "terms_en": ["accounting fraud", "fraud probe", "improper accounting"]
+    },
+    {
+      "id": "security_breach",
+      "polarity": "negative",
+      "weight": 1.0,
+      "terms_kr": ["보안 침해", "해킹", "개인정보 유출"],
+      "terms_en": ["security breach", "hacked", "data leak", "data breach"]
+    }
+  ]
+}

--- a/src/news/reputation.js
+++ b/src/news/reputation.js
@@ -1,0 +1,105 @@
+import fs from 'fs';
+import path from 'path';
+
+// --- load taxonomy once
+const TAX_PATH = path.join(process.cwd(), 'src/news/keyword-taxonomy.json');
+const TAX = JSON.parse(fs.readFileSync(TAX_PATH, 'utf8'));
+const HALF_LIFE_D = TAX.halfLifeDays ?? 14;
+const ALPHA = TAX.alpha ?? 1.1;
+const BIAS = TAX.defaultBias ?? 0;
+
+// Precompile regexes
+function esc(s){return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');}
+function makeRegex(terms){
+  if (!terms?.length) return null;
+  const pat = terms.map(t => esc(t)).join('|');
+  return new RegExp(`(${pat})`, 'iu');
+}
+const CLASSES = TAX.classes.map(c => ({
+  ...c,
+  rxKR: makeRegex(c.terms_kr),
+  rxEN: makeRegex(c.terms_en)
+}));
+
+function decayWeight(publishedAtIso){
+  const t = new Date(publishedAtIso).getTime();
+  if (!Number.isFinite(t)) return 0.8;
+  const ageDays = Math.max(0, (Date.now() - t) / 86400000);
+  const lambda = Math.log(2) / HALF_LIFE_D;
+  return Math.exp(-lambda * ageDays);
+}
+
+function sourceWeight(tier){
+  return TAX.sourceWeights?.[tier] ?? TAX.sourceWeights?.default ?? 1.0;
+}
+
+/**
+ * @param {Object} args
+ * @param {Array<Object>} args.items - news items for ONE symbol
+ *   shape: {
+ *     id, headline, snippet, lang?: 'ko'|'en'|..., publishedAt, sourceTier?: 'major'|'wire'|'blog'|'forum'|'default'|'unknown'
+ *   }
+ * @param {Object} args.company
+ *   shape: { ticker: '005930.KS', names: ['삼성전자','Samsung Electronics','Samsung'] }
+ * @returns {{ reputationScore:number, topKeywords:Array, tallies:Object, hitIds:Array }}
+ */
+export function computeReputation({ items = [], company }){
+  const nameRegex = company?.names?.length
+    ? new RegExp(company.names.map(esc).join('|'), 'iu')
+    : null;
+  const tickerRegex = company?.ticker ? new RegExp(esc(company.ticker), 'i') : null;
+
+  let pos = 0, neg = 0;
+  const keywordTallies = new Map();
+  const hitIds = new Set();
+
+  for (const it of items){
+    const text = [it.headline, it.snippet].filter(Boolean).join('  ').slice(0, 600);
+    if (!text) continue;
+
+    const inScope = !nameRegex && !tickerRegex ? true : (
+      (nameRegex ? nameRegex.test(text) : false) || (tickerRegex ? tickerRegex.test(text) : false)
+    );
+    if (!inScope) continue;
+
+    const wDecay = decayWeight(it.publishedAt);
+    const wSource = sourceWeight(it.sourceTier);
+    const baseW = wDecay * wSource;
+
+    for (const cls of CLASSES){
+      const rx = (it.lang && /^ko/i.test(it.lang)) ? (cls.rxKR || cls.rxEN) : (cls.rxEN || cls.rxKR);
+      if (!rx) continue;
+      let m;
+      if ((m = rx.exec(text))){
+        const intensity = TAX.intensity?.normal ?? 1.0;
+        const contribution = (cls.weight ?? 1.0) * baseW * intensity;
+
+        const keyShown = m[1] || cls.id;
+        const entry = keywordTallies.get(keyShown) || { polarity: cls.polarity, score: 0, count: 0, lastSeen: null };
+        entry.score += contribution;
+        entry.count += 1;
+        entry.lastSeen = it.publishedAt || entry.lastSeen;
+        keywordTallies.set(keyShown, entry);
+
+        const hid = it.id || it.url;
+        if (hid) hitIds.add(hid);
+
+        if (cls.polarity === 'positive') pos += contribution;
+        else neg += contribution;
+      }
+    }
+  }
+
+  const raw = (pos - neg) + BIAS;
+  const reputationScore = 1 / (1 + Math.exp(-ALPHA * raw));
+
+  const topKeywords = [...keywordTallies.entries()]
+    .sort((a,b)=>Math.abs(b[1].score) - Math.abs(a[1].score))
+    .slice(0, 5)
+    .map(([term, v]) => ({ term, polarity: v.polarity, weight: +v.score.toFixed(3), count: v.count, lastSeen: v.lastSeen }));
+
+  const tallies = Object.fromEntries([...keywordTallies.entries()].map(([k,v])=>[k,v]));
+  const hitIdsArr = [...hitIds];
+
+  return { reputationScore, topKeywords, tallies, hitIds: hitIdsArr };
+}

--- a/src/news/symbol-aliases.json
+++ b/src/news/symbol-aliases.json
@@ -1,0 +1,6 @@
+{
+  "005930.KS": ["삼성전자", "Samsung Electronics", "Samsung"],
+  "000660.KS": ["SK하이닉스", "SK hynix"],
+  "AAPL": ["Apple", "애플"],
+  "MSFT": ["Microsoft", "마이크로소프트"]
+}

--- a/tools/buildPoolsTrendy.js
+++ b/tools/buildPoolsTrendy.js
@@ -920,7 +920,7 @@ async function main(){
       } catch (e) {
         tripOnError(e);
       }
-      byName[name] = { ret5, ret20, vol20, turnover, adv20, close, newsCount, sentiment, naverPopularity, blogMentions, polygonTrend, nasdaqClose, earn, sym: sym || null, source: candles?.source || null, attempts: candles?.attempts || [], fetchMs: candles?.fetchMs || 0 };
+      byName[name] = { ret5, ret20, vol20, turnover, adv20, close, newsCount, sentiment, naverPopularity, blogMentions, polygonTrend, nasdaqClose, earn, reputationScore: null, topKeywords: [], reputationHitIds: [], sym: sym || null, source: candles?.source || null, attempts: candles?.attempts || [], fetchMs: candles?.fetchMs || 0 };
       processed.add(name);
     });
     for (const n of names) {
@@ -928,6 +928,7 @@ async function main(){
         byName[n] = {
           ret5:null, ret20:null, vol20:null, turnover:null, adv20:null, close:null,
           newsCount:0, sentiment:null, naverPopularity:0, blogMentions:0, polygonTrend:null, nasdaqClose:null, earn:false,
+          reputationScore:null, topKeywords:[], reputationHitIds:[],
           sym:null, source:null, attempts:[], fetchMs:0
         };
       }
@@ -940,6 +941,9 @@ async function main(){
         byName[n].blogMentions    = nf.blogMentions ?? byName[n].blogMentions;
         byName[n].polygonTrend    = nf.polygonTrend ?? byName[n].polygonTrend;
         byName[n].nasdaqClose     = nf.nasdaqClose ?? byName[n].nasdaqClose;
+        byName[n].reputationScore = nf.reputationScore ?? byName[n].reputationScore;
+        byName[n].topKeywords     = nf.topKeywords ?? byName[n].topKeywords;
+        byName[n].reputationHitIds = nf.reputationHitIds ?? byName[n].reputationHitIds;
       }
     }
 
@@ -984,14 +988,16 @@ async function main(){
         sentiment: 0.08,
         naver: isKRName ? 0.30 : 0,
         blog: 0.15,
+        reputation: 0.25,
       };
-      const totalOrig = weights.count + weights.sentiment + weights.naver + weights.blog;
+      const totalOrig = weights.count + weights.sentiment + weights.naver + weights.blog + weights.reputation;
       let totalAvail = 0;
       let newsBoost = 0;
       if (byName[n].newsCount != null) { newsBoost += newsCountNorm * weights.count; totalAvail += weights.count; }
       if (byName[n].sentiment != null) { newsBoost += (sentimentNorm - 0.5) * weights.sentiment; totalAvail += weights.sentiment; }
       if (isKRName && byName[n].naverPopularity != null) { newsBoost += pop * weights.naver; totalAvail += weights.naver; }
       if (byName[n].blogMentions != null) { newsBoost += blogNorm * weights.blog; totalAvail += weights.blog; }
+      if (byName[n].reputationScore != null) { newsBoost += byName[n].reputationScore * weights.reputation; totalAvail += weights.reputation; }
       const scale = totalAvail > 0 ? totalOrig / totalAvail : 0;
       newsBoost *= scale;
 
@@ -1113,6 +1119,7 @@ async function main(){
       acc[n] = {
         ret5: byName[n].ret5, ret20: byName[n].ret20, vol20: byName[n].vol20, turnover: byName[n].turnover,
         adv20: byName[n].adv20, close: byName[n].close, newsCount: byName[n].newsCount, sentiment: byName[n].sentiment, naverPopularity: byName[n].naverPopularity, blogMentions: byName[n].blogMentions, polygonTrend: byName[n].polygonTrend, nasdaqClose: byName[n].nasdaqClose, recentEarnings: byName[n].earn,
+        reputationScore: byName[n].reputationScore, topKeywords: (byName[n].topKeywords || []).slice(0,3), reputationHitIds: byName[n].reputationHitIds || [],
         source: byName[n].source, attempts: byName[n].attempts, fetchMs: byName[n].fetchMs,
         norm: { ret5: nRet5[i], ret20: nRet20[i], vol20: nVol[i], turnover: nTurn[i], newsCount: newsCountNorm, sentiment: sentimentNorm, popularity: pop, blogMentions: blogNorm },
         score: { safe: scoreSafe[n], aggressive: scoreAggr[n] }


### PR DESCRIPTION
## Summary
- score headlines with a time-decayed keyword taxonomy
- track per-symbol reputation and top keywords in news and pool builders
- surface reputation details in recommendation scoring and explanations

## Testing
- `node tests/apple_association.test.js`
- `node fetchStockInfo.js --skip-fresh --force` *(fails: terminated early due to time/outstanding network calls)*

------
https://chatgpt.com/codex/tasks/task_b_68b025733b44832ab47e5038121d1d26