### PR TITLE
Use index map for stock names and sectors

### DIFF
--- a/fetchStockInfo.js
+++ b/fetchStockInfo.js
@@ -173,7 +173,11 @@ function rotateFromPools(pools, prevData) {
         candidates = candidates.filter(n => !safeNames.has(n));
       }
       const picked = pickDeterministic(candidates, 5, `${seed}:${market}:${bucket}`);
-      out[market][bucket] = picked.map(n => ({ name: n }));
+      out[market][bucket] = picked.map(n => {
+        const sym = canonSymbol(n);
+        const displayName = INDEX_NAME[sym] || n;
+        return { name: displayName };
+      });
     }
   }
   return out;
@@ -415,20 +419,26 @@ for (const r of rawRows) {
     if (maybeName && !GICS_SECTORS.has(maybeName.toUpperCase())) company = maybeName;
   }
 
-  // Determine sector (only accept if it looks like a real sector)
+  // Determine sector – accept known English sectors or any Korean text
   let sector = r.sector;
   if (sector && typeof sector === 'string') {
     sector = sector.trim();
-    if (!GICS_SECTORS.has(sector.toUpperCase())) sector = null;
+    const upper = sector.toUpperCase();
+    const isKorean = /[\u3131-\uD79D]/.test(sector);
+    if (GICS_SECTORS.has(upper)) {
+      sector = SECTOR_NORMALIZE[sector] || sector;
+    } else if (!isKorean) {
+      sector = null;
+    }
   } else {
     sector = null;
   }
 
   if (company && !looksLikeTicker(company) && !GICS_SECTORS.has(company.toUpperCase())) INDEX_NAME[ticker] = company;
-  if (sector) INDEX_SECTOR[ticker] = SECTOR_NORMALIZE[sector] || sector;
+  if (sector) INDEX_SECTOR[ticker] = sector;
 }
 
-const INDEX_SYMBOL_SET = new Set(Object.keys(INDEX_NAME));
+const INDEX_SYMBOL_SET = new Set([...new Set([...Object.keys(INDEX_NAME), ...Object.keys(INDEX_SECTOR)])]);
 
 // Merge your hard-coded TICKER_MAP with index map names so both directions exist.
 const STATIC_MAP = (() => {
@@ -802,56 +812,66 @@ async function tryFetchAndEnrich() {
 
       const updated = [];
       for (const entry of entries) {
-          const name = typeof entry === 'string' ? entry : entry.name;
+        const rawName = typeof entry === 'string' ? entry : entry.name;
 
-          try {
-            const { sector, ticker } = await fetchSector(name, cache);
-            const displayName =
-              INDEX_NAME[ticker] ||
-              (!looksLikeTicker(name) ? name : undefined) ||
-              name;
+        try {
+          const sym = canonSymbol(rawName);
+          let ticker = null;
+          let sector = null;
+          let displayName = rawName;
 
-            let searchUrl = null;
-            try {
-              searchUrl = await fetchSearchUrl(displayName, ticker, cache);
-            } catch (e) {
-              console.warn(`[SEARCH_URL_FAIL] ${name}: ${e.message}`);
-            }
-
-            const news = ticker ? (newsFeatures[ticker] || {}) : {};
-            const trend = ticker ? (naverTrends[ticker] || {}) : {};
-            updated.push({
-              name: displayName,
-              sector: INDEX_SECTOR[ticker] || sector,
-              ticker,
-              searchUrl,
-              rawScore: calcRawScore(market, group, displayName, ticker),
-              reasons: {
-                reputationScore: news.reputationScore ?? null,
-                topKeywords: news.topKeywords || [],
-                signals: {
-                  sentiment: typeof news.sentiment === 'number' ? news.sentiment : null,
-                  blog: typeof news.blogMentions === 'number' ? news.blogMentions : null,
-                  naver: typeof trend.naverPopularity === 'number' ? trend.naverPopularity : null
-                }
-              }
-            });
-
-            if (sector) successCount++;
-          } catch (err) {
-            console.error(`[ERROR] ${name}: ${err.message}`);
-            updated.push({ name, sector: null, ticker: null, searchUrl: null, rawScore: calcRawScore(market, group, name, null), reasons: { reputationScore: null, topKeywords: [], signals: { sentiment: null, blog: null, naver: null } } });
-            noteStatus(err);
-
-          if (consecutive429 >= 5) {
-            throw new Error('Too many consecutive 429s, aborting');
+          if (INDEX_NAME[sym] || INDEX_SECTOR[sym]) {
+            ticker = sym;
+            displayName = INDEX_NAME[sym] || rawName;
+            sector = INDEX_SECTOR[sym] || null;
+          } else {
+            const res = await fetchSector(rawName, cache);
+            ticker = res.ticker;
+            sector = INDEX_SECTOR[ticker] || res.sector;
+            displayName = INDEX_NAME[ticker] || (!looksLikeTicker(rawName) ? rawName : undefined) || rawName;
           }
+
+          let searchUrl = null;
+          try {
+            searchUrl = await fetchSearchUrl(displayName, ticker, cache);
+          } catch (e) {
+            console.warn(`[SEARCH_URL_FAIL] ${rawName}: ${e.message}`);
+          }
+
+          const news = ticker ? (newsFeatures[ticker] || {}) : {};
+          const trend = ticker ? (naverTrends[ticker] || {}) : {};
+          updated.push({
+            name: displayName,
+            sector,
+            ticker,
+            searchUrl,
+            rawScore: calcRawScore(market, group, displayName, ticker),
+            reasons: {
+              reputationScore: news.reputationScore ?? null,
+              topKeywords: news.topKeywords || [],
+              signals: {
+                sentiment: typeof news.sentiment === 'number' ? news.sentiment : null,
+                blog: typeof news.blogMentions === 'number' ? news.blogMentions : null,
+                naver: typeof trend.naverPopularity === 'number' ? trend.naverPopularity : null
+              }
+            }
+          });
+
+          if (sector) successCount++;
+        } catch (err) {
+          console.error(`[ERROR] ${rawName}: ${err.message}`);
+          updated.push({ name: rawName, sector: null, ticker: null, searchUrl: null, rawScore: calcRawScore(market, group, rawName, null), reasons: { reputationScore: null, topKeywords: [], signals: { sentiment: null, blog: null, naver: null } } });
+          noteStatus(err);
         }
 
-        // Adaptive delay based on consecutive 429s
-        const delay = consecutive429 >= 3 ? nextDelay() * 2 : nextDelay();
-        await sleep(delay);
+        if (consecutive429 >= 5) {
+          throw new Error('Too many consecutive 429s, aborting');
+        }
       }
+
+      // Adaptive delay based on consecutive 429s
+      const delay = consecutive429 >= 3 ? nextDelay() * 2 : nextDelay();
+      await sleep(delay);
 
       scaleScores(updated, group);
       data[market][group] = updated;

--- a/recommendations.json
+++ b/recommendations.json
@@ -3,57 +3,9 @@
     "safe": [
       {
         "name": "비에이치",
-        "sector": null,
+        "sector": "정보기술",
         "ticker": "090460.KQ",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%EB%B9%84%EC%97%90%EC%9D%B4%EC%B9%98%20090460.KQ",
-        "reasons": {
-          "reputationScore": null,
-          "topKeywords": [],
-          "signals": {
-            "sentiment": null,
-            "blog": null,
-            "naver": null
-          }
-        },
-        "score": 56
-      },
-      {
-        "name": "상아프론테크",
-        "sector": null,
-        "ticker": "089980.KQ",
-        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%EC%83%81%EC%95%84%ED%94%84%EB%A1%A0%ED%85%8C%ED%81%AC%20089980.KQ",
-        "reasons": {
-          "reputationScore": null,
-          "topKeywords": [],
-          "signals": {
-            "sentiment": null,
-            "blog": null,
-            "naver": null
-          }
-        },
-        "score": 56
-      },
-      {
-        "name": "에스앤에스텍",
-        "sector": null,
-        "ticker": "101490.KQ",
-        "searchUrl": "https://www.google.com/search?tbm=nws&q=%EC%97%90%EC%8A%A4%EC%95%A4%EC%97%90%EC%8A%A4%ED%85%8D%20101490.KQ",
-        "reasons": {
-          "reputationScore": null,
-          "topKeywords": [],
-          "signals": {
-            "sentiment": null,
-            "blog": null,
-            "naver": null
-          }
-        },
-        "score": 55
-      },
-      {
-        "name": "에코프로",
-        "sector": null,
-        "ticker": "086520.KQ",
-        "searchUrl": "https://www.google.com/search?tbm=nws&q=%EC%97%90%EC%BD%94%ED%94%84%EB%A1%9C%20086520.KQ",
         "reasons": {
           "reputationScore": null,
           "topKeywords": [],
@@ -66,8 +18,56 @@
         "score": 100
       },
       {
+        "name": "상아프론테크",
+        "sector": "정보기술",
+        "ticker": "089980.KQ",
+        "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%EC%83%81%EC%95%84%ED%94%84%EB%A1%A0%ED%85%8C%ED%81%AC%20089980.KQ",
+        "reasons": {
+          "reputationScore": null,
+          "topKeywords": [],
+          "signals": {
+            "sentiment": null,
+            "blog": null,
+            "naver": null
+          }
+        },
+        "score": 90
+      },
+      {
+        "name": "에스앤에스텍",
+        "sector": "정보기술",
+        "ticker": "101490.KQ",
+        "searchUrl": "https://www.google.com/search?tbm=nws&q=%EC%97%90%EC%8A%A4%EC%95%A4%EC%97%90%EC%8A%A4%ED%85%8D%20101490.KQ",
+        "reasons": {
+          "reputationScore": null,
+          "topKeywords": [],
+          "signals": {
+            "sentiment": null,
+            "blog": null,
+            "naver": null
+          }
+        },
+        "score": 75
+      },
+      {
+        "name": "에코프로",
+        "sector": "산업재",
+        "ticker": "086520.KQ",
+        "searchUrl": "https://www.google.com/search?tbm=nws&q=%EC%97%90%EC%BD%94%ED%94%84%EB%A1%9C%20086520.KQ",
+        "reasons": {
+          "reputationScore": null,
+          "topKeywords": [],
+          "signals": {
+            "sentiment": null,
+            "blog": null,
+            "naver": null
+          }
+        },
+        "score": 55
+      },
+      {
         "name": "코미코",
-        "sector": null,
+        "sector": "정보기술",
         "ticker": "183300.KQ",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%EC%BD%94%EB%AF%B8%EC%BD%94%20183300.KQ",
         "reasons": {
@@ -79,13 +79,13 @@
             "naver": null
           }
         },
-        "score": 55
+        "score": 68
       }
     ],
     "aggressive": [
       {
         "name": "더블유씨피",
-        "sector": null,
+        "sector": "소재",
         "ticker": "393890.KQ",
         "searchUrl": "https://www.google.com/search?tbm=nws&q=%EB%8D%94%EB%B8%94%EC%9C%A0%EC%94%A8%ED%94%BC%20393890.KQ",
         "reasons": {
@@ -113,11 +113,11 @@
             "naver": null
           }
         },
-        "score": 50
+        "score": 71
       },
       {
         "name": "리노공업",
-        "sector": "Industrials",
+        "sector": "정보기술",
         "ticker": "058470.KQ",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%EB%A6%AC%EB%85%B8%EA%B3%B5%EC%97%85%20058470.KQ",
         "reasons": {
@@ -129,11 +129,11 @@
             "naver": null
           }
         },
-        "score": 59
+        "score": 88
       },
       {
         "name": "케어젠",
-        "sector": null,
+        "sector": "헬스케어",
         "ticker": "214370.KQ",
         "searchUrl": "https://www.google.com/search?tbm=nws&q=%EC%BC%80%EC%96%B4%EC%A0%A0%20214370.KQ",
         "reasons": {
@@ -145,11 +145,11 @@
             "naver": null
           }
         },
-        "score": 76
+        "score": 55
       },
       {
         "name": "피에스케이",
-        "sector": null,
+        "sector": "정보기술",
         "ticker": "319660.KQ",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%ED%94%BC%EC%97%90%EC%8A%A4%EC%BC%80%EC%9D%B4%20319660.KQ",
         "reasons": {
@@ -161,7 +161,7 @@
             "naver": null
           }
         },
-        "score": 73
+        "score": 50
       }
     ]
   },
@@ -169,7 +169,7 @@
     "safe": [
       {
         "name": "LG화학",
-        "sector": "Materials",
+        "sector": "소재",
         "ticker": "051910.KS",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=LG%ED%99%94%ED%95%99%20051910.KS",
         "reasons": {
@@ -185,7 +185,7 @@
       },
       {
         "name": "기아",
-        "sector": "Consumer Discretionary",
+        "sector": "경기소비재",
         "ticker": "000270.KS",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%EA%B8%B0%EC%95%84%20000270.KS",
         "reasons": {
@@ -201,7 +201,7 @@
       },
       {
         "name": "삼성전자",
-        "sector": "Technology",
+        "sector": "정보기술",
         "ticker": "005930.KS",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%EC%82%BC%EC%84%B1%EC%A0%84%EC%9E%90%20005930.KS",
         "reasons": {
@@ -217,7 +217,7 @@
       },
       {
         "name": "셀트리온",
-        "sector": "Healthcare",
+        "sector": "헬스케어",
         "ticker": "068270.KS",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%EC%85%80%ED%8A%B8%EB%A6%AC%EC%98%A8%20068270.KS",
         "reasons": {
@@ -233,7 +233,7 @@
       },
       {
         "name": "카카오",
-        "sector": null,
+        "sector": "커뮤니케이션서비스",
         "ticker": "035720.KQ",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%EC%B9%B4%EC%B9%B4%EC%98%A4%20035720.KQ",
         "reasons": {
@@ -251,7 +251,7 @@
     "aggressive": [
       {
         "name": "LG에너지솔루션",
-        "sector": null,
+        "sector": "산업재",
         "ticker": "373220.KS",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=LG%EC%97%90%EB%84%88%EC%A7%80%EC%86%94%EB%A3%A8%EC%85%98%20373220.KS",
         "reasons": {
@@ -263,11 +263,11 @@
             "naver": null
           }
         },
-        "score": 99
+        "score": 52
       },
       {
         "name": "POSCO홀딩스",
-        "sector": "Materials",
+        "sector": "소재",
         "ticker": "005490.KS",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=POSCO%ED%99%80%EB%94%A9%EC%8A%A4%20005490.KS",
         "reasons": {
@@ -283,7 +283,7 @@
       },
       {
         "name": "유한양행",
-        "sector": null,
+        "sector": "헬스케어",
         "ticker": "000100.KS",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%EC%9C%A0%ED%95%9C%EC%96%91%ED%96%89%20000100.KS",
         "reasons": {
@@ -295,11 +295,11 @@
             "naver": null
           }
         },
-        "score": 100
+        "score": 92
       },
       {
         "name": "커뮤니케이션서비스",
-        "sector": "Communication Services",
+        "sector": "커뮤니케이션서비스",
         "ticker": "035420.KS",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%EC%BB%A4%EB%AE%A4%EB%8B%88%EC%BC%80%EC%9D%B4%EC%85%98%EC%84%9C%EB%B9%84%EC%8A%A4%20035420.KS",
         "reasons": {
@@ -311,11 +311,11 @@
             "naver": null
           }
         },
-        "score": 50
+        "score": 60
       },
       {
         "name": "하이트진로",
-        "sector": null,
+        "sector": "필수소비재",
         "ticker": "000080.KS",
         "searchUrl": "https://search.naver.com/search.naver?where=news&sm=tab_jum&query=%ED%95%98%EC%9D%B4%ED%8A%B8%EC%A7%84%EB%A1%9C%20000080.KS",
         "reasons": {
@@ -327,7 +327,7 @@
             "naver": null
           }
         },
-        "score": 99
+        "score": 50
       }
     ]
   },
@@ -347,7 +347,7 @@
             "naver": null
           }
         },
-        "score": 100
+        "score": 67
       },
       {
         "name": "Intuit",
@@ -379,7 +379,7 @@
             "naver": null
           }
         },
-        "score": 55
+        "score": 64
       },
       {
         "name": "Keurig Dr Pepper",
@@ -395,7 +395,7 @@
             "naver": null
           }
         },
-        "score": 56
+        "score": 100
       },
       {
         "name": "Old Dominion Freight Line",
@@ -411,7 +411,7 @@
             "naver": null
           }
         },
-        "score": 56
+        "score": 100
       }
     ],
     "aggressive": [
@@ -513,7 +513,7 @@
             "naver": null
           }
         },
-        "score": 55
+        "score": 63
       },
       {
         "name": "BK",
@@ -529,7 +529,7 @@
             "naver": null
           }
         },
-        "score": 100
+        "score": 55
       },
       {
         "name": "CINF",
@@ -545,7 +545,7 @@
             "naver": null
           }
         },
-        "score": 100
+        "score": 95
       },
       {
         "name": "MMM",
@@ -561,7 +561,7 @@
             "naver": null
           }
         },
-        "score": 100
+        "score": 88
       }
     ],
     "aggressive": [
@@ -595,7 +595,7 @@
             "naver": null
           }
         },
-        "score": 100
+        "score": 62
       },
       {
         "name": "DAYFORCE",
@@ -611,7 +611,7 @@
             "naver": null
           }
         },
-        "score": 52
+        "score": 100
       },
       {
         "name": "Dominion Energy",
@@ -627,7 +627,7 @@
             "naver": null
           }
         },
-        "score": 52
+        "score": 100
       },
       {
         "name": "STZ",
@@ -643,9 +643,9 @@
             "naver": null
           }
         },
-        "score": 100
+        "score": 73
       }
     ]
   },
-  "lastUpdated": "2025-08-28T19:59:13+09:00"
+  "lastUpdated": "2025-08-28T20:27:44+09:00"
 }


### PR DESCRIPTION
## Summary
- Accept Korean sector names and merge index sector/name keys for robust ticker lookup
- Prefer index map data when resolving tickers and convert pool symbols to their official names
- Refresh recommendations with proper names and sectors

## Testing
- `node tests/apple_association.test.js`
- `node fetchStockInfo.js --force`


------
https://chatgpt.com/codex/tasks/task_b_68b03c784a34832aa6694a861689bf29