### PR TITLE
Fix S&P 500 parser for index map

### DIFF
--- a/src/maps.indexes.json
+++ b/src/maps.indexes.json
@@ -952,12 +952,12 @@
     },
     {
       "symbol": "FOX",
-      "name": "Fox Corporation (Class B)",
+      "name": "Fox Corporation",
       "sector": "Communication Services"
     },
     {
       "symbol": "FOXA",
-      "name": "Fox Corporation (Class A)",
+      "name": "Fox Corporation",
       "sector": "Communication Services"
     },
     {
@@ -1042,12 +1042,12 @@
     },
     {
       "symbol": "GOOG",
-      "name": "Alphabet Inc. (Class C)",
+      "name": "Alphabet Inc.",
       "sector": "Communication Services"
     },
     {
       "symbol": "GOOGL",
-      "name": "Alphabet Inc. (Class A)",
+      "name": "Alphabet Inc.",
       "sector": "Communication Services"
     },
     {
@@ -1169,6 +1169,11 @@
       "symbol": "HWM",
       "name": "Howmet Aerospace",
       "sector": "Industrials"
+    },
+    {
+      "symbol": "IBKR",
+      "name": "Interactive Brokers",
+      "sector": "Financials"
     },
     {
       "symbol": "IBM",
@@ -1722,12 +1727,12 @@
     },
     {
       "symbol": "NWS",
-      "name": "News Corp (Class B)",
+      "name": "News Corp",
       "sector": "Communication Services"
     },
     {
       "symbol": "NWSA",
-      "name": "News Corp (Class A)",
+      "name": "News Corp",
       "sector": "Communication Services"
     },
     {
@@ -2367,7 +2372,7 @@
     },
     {
       "symbol": "VST",
-      "name": "Vistra Corp.",
+      "name": "Vistra Corp",
       "sector": "Utilities"
     },
     {
@@ -4467,5 +4472,5 @@
       "sector": "헬스케어"
     }
   ],
-  "generatedAt": "2025-08-28T11:40:32Z"
+  "generatedAt": "2025-08-28T11:54:46.524Z"
 }

--- a/tools/updateIndexMaps.mjs
+++ b/tools/updateIndexMaps.mjs
@@ -68,18 +68,17 @@ function parseSp500(html) {
   if (!html) return [];
   let rows = [
     ...html.matchAll(
-      /<tr>\s*<td><a [^>]*>([^<]+)<\/a>[\s\S]*?<td[^>]*>\s*(?:<a [^>]*>)?([A-Z.\-]+)<\/(?:a|td)>[\s\S]*?<td[^>]*>\s*(?:<a [^>]*>)?([^<]+)<\/(?:a|td)>/gi
+      /<tr>\s*<td[^>]*>\s*(?:<a[^>]*>)?([A-Z.\-]+)<\/(?:a|td)>\s*<td[^>]*>\s*(?:<a[^>]*>)?([^<]+)<\/(?:a|td)>\s*<td[^>]*>[\s\S]*?<\/td>\s*<td[^>]*>\s*(?:<a[^>]*>)?([^<]+)<\/(?:a|td)>/gi
     ),
   ];
   if (rows.length < 300) {
     rows = [
       ...html.matchAll(
-        /<tr>\s*<td[^>]*>\s*(?:<a [^>]*>)?([A-Z.\-]+)<\/(?:a|td)>[\s\S]*?<td[^>]*>\s*(?:<a [^>]*>)?([^<]+)<\/(?:a|td)>[\s\S]*?<td[^>]*>\s*(?:<a [^>]*>)?([^<]+)<\/(?:a|td)>/gi
+        /<tr>\s*<td[^>]*>\s*(?:<a[^>]*>)?([A-Z.\-]+)<\/(?:a|td)>[\s\S]*?<td[^>]*>\s*(?:<a[^>]*>)?([^<]+)<\/(?:a|td)>[\s\S]*?<td[^>]*>\s*(?:<a[^>]*>)?([^<]+)<\/(?:a|td)>/gi
       ),
     ];
-    return rows.map(m => ({ symbol: canonUS(m[1]), name: clean(m[2]), sector: clean(m[3]) }));
   }
-  return rows.map(m => ({ symbol: canonUS(m[2]), name: clean(m[1]), sector: clean(m[3]) }));
+  return rows.map(m => ({ symbol: canonUS(m[1]), name: clean(m[2]), sector: clean(m[3]) }));
 }
 
 // Nasdaq-100: limit to constituents section to avoid extra tables


### PR DESCRIPTION
## Summary
- fix S&P 500 scraping logic in `updateIndexMaps.mjs`
- regenerate `src/maps.indexes.json`

## Testing
- `node tools/updateIndexMaps.mjs`
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68b04323ffb0832a83f21e65a64d2208