### PR TITLE
feat: integrate DeepSearch news signals

### DIFF
--- a/.github/workflows/stock-recs.yml
+++ b/.github/workflows/stock-recs.yml
@@ -53,6 +53,7 @@ jobs:
       GNEWS_API: ${{ secrets.GNEWS_API }}
       POLYGON_API_KEY: ${{ secrets.POLYGON_API_KEY }}
       NASDAQ_API_KEY: ${{ secrets.NASDAQ_API_KEY }}
+      DEEPS_API_KEY: ${{ secrets.DEEPS_API_KEY }}
       # Optional tuning for this module
       NEWS_CONCURRENCY: 2        # your code already defaults to 2; keep it small for SerpApi quotas
       NEWS_TTL_MS: 1800000       # 30m cache TTL (aligns with your comment)

--- a/src/news/deepsearch.js
+++ b/src/news/deepsearch.js
@@ -1,0 +1,143 @@
+const API = 'https://api-v2.deepsearch.com';
+const KEY = process.env.DEEPS_API_KEY || process.env.DEEPSEARCH_API_KEY || '';
+
+const HEADERS = KEY
+  ? { Authorization: `Bearer ${KEY}` }
+  : {};
+
+const DS_MAX_PAGES = +process.env.DS_MAX_PAGES || 2;
+const DS_RECENT_D = +process.env.DS_RECENT_D || 1;
+const DS_BASE_D = +process.env.DS_BASE_D || 7;
+
+export function toDeepsearchSymbol(ticker, market) {
+  if (!ticker) return null;
+  const mKr = ticker.match(/^(\d{6})\.(KS|KQ)$/i);
+  if (mKr) return `KRX:${mKr[1]}`;
+  if (/^[A-Z]+:[A-Z.\-]+$/.test(ticker)) return ticker;
+  if (market?.includes('NASDAQ')) return `NASDAQ:${ticker}`;
+  if (/^[A-Z.\-]{1,6}$/.test(ticker)) return `NYSE:${ticker}`;
+  return null;
+}
+
+function todayISO() {
+  const d = new Date();
+  return d.toISOString().slice(0,10);
+}
+function addDaysISO(iso, days) {
+  const d = new Date(iso);
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0,10);
+}
+function rangeISO(daysBack) {
+  const to = todayISO();
+  const from = addDaysISO(to, -daysBack);
+  return { from, to };
+}
+
+async function apiGet(path, params = {}) {
+  const url = new URL(API + path);
+  for (const [k,v] of Object.entries(params)) {
+    if (v !== undefined && v !== null && v !== '') url.searchParams.set(k, String(v));
+  }
+  const r = await fetch(url, { headers: HEADERS, redirect: 'follow' });
+  if (!r.ok) throw new Error(`DeepSearch ${r.status} ${await r.text()}`);
+  return r.json();
+}
+
+function pickBase(market) {
+  const isKR = /(KOSPI|KOSDAQ|KRX)/i.test(market || '');
+  return { isKR, base: isKR ? '/v1/articles' : '/v1/global-articles' };
+}
+
+function buildQueryArgs({ name, ticker, market }) {
+  const sym = toDeepsearchSymbol(ticker, market);
+  if (sym) return { symbols: sym };
+  if (name) return { company_name: name };
+  return { keyword: (name || ticker || '').trim() };
+}
+
+async function getDailyCounts({ name, ticker, market }, days) {
+  const { base } = pickBase(market);
+  const { from, to } = rangeISO(days);
+  const q = buildQueryArgs({ name, ticker, market });
+
+  const counts = new Map();
+  for (let page = 1; page <= DS_MAX_PAGES; page++) {
+    const js = await apiGet(`${base}`, {
+      ...q, date_from: from, date_to: to, page, page_size: 100, order: 'published_at'
+    }).catch(() => null);
+    if (!js?.data?.length) break;
+    for (const it of js.data) {
+      const dt = (it.published_at || it.date || it.created_at || '').slice(0,10);
+      if (dt) counts.set(dt, (counts.get(dt) || 0) + 1);
+    }
+    const totalPages = js.total_pages || page;
+    if (page >= totalPages) break;
+  }
+  const out = [];
+  for (let d = from; d <= to; d = addDaysISO(d, 1)) {
+    out.push({ date: d, count: counts.get(d) || 0 });
+  }
+  return out;
+}
+
+async function getTopicBoost({ name, ticker, market }) {
+  const { base } = pickBase(market);
+  const q = buildQueryArgs({ name, ticker, market });
+
+  const path = `${base}/topics/trending`;
+  const js = await apiGet(path, { ...q, order: 'published_at', page_size: 5 }).catch(() => null);
+  if (!js?.data?.length) return 0;
+
+  let score = 0;
+  for (const it of js.data) {
+    const r = Number(it.rank);
+    if (Number.isFinite(r) && r > 0) score += 1 / r;
+  }
+  const capped = Math.min(score, 1.5);
+  return capped / 1.5;
+}
+
+function featuresFromDaily(daily) {
+  if (!daily?.length) {
+    return { news1d:0, news7d:0, burst:0, slope7d:0 };
+  }
+  const n = daily.length;
+  const last = daily[n-1]?.count || 0;
+  const news7d = daily.reduce((s, x) => s + x.count, 0);
+  const recentDays = Math.max(1, Math.min(DS_RECENT_D, n));
+  const baseDays   = Math.max(1, Math.min(DS_BASE_D, n));
+
+  const news1d = daily.slice(-recentDays).reduce((s,x)=>s+x.count,0);
+  const prevBase = daily.slice(0, n - recentDays).slice(-(baseDays)).reduce((s,x)=>s+x.count,0) / baseDays;
+  const burst = prevBase > 0 ? (news1d / prevBase) : (news1d > 0 ? 1 : 0);
+
+  const arr = daily.slice(-baseDays).map(d => d.count);
+  const k = arr.length;
+  let sx=0, sy=0, sxx=0, sxy=0;
+  for (let i=0;i<k;i++){ const x=i+1, y=arr[i]; sx+=x; sy+=y; sxx+=x*x; sxy+=x*y; }
+  const denom = k*sxx - sx*sx;
+  const slope = denom !== 0 ? (k*sxy - sx*sy) / denom : 0;
+  const slope7d = Math.max(0, Math.min(1, slope / 10));
+
+  return { news1d, news7d, burst, slope7d };
+}
+
+export async function fetchDeepsearchFeatures({ name, ticker, market }) {
+  if (!KEY) {
+    return { ds_news7:0, ds_burst:0, ds_slope7:0, ds_topic:0, ds_trend:0 };
+  }
+  const daily = await getDailyCounts({ name, ticker, market }, Math.max(DS_BASE_D, 7)).catch(() => []);
+  const { news7d, burst, slope7d } = featuresFromDaily(daily);
+  const topic = await getTopicBoost({ name, ticker, market }).catch(() => 0);
+
+  const ds_trend = Math.max(0, Math.min(1, 0.5*(burst>0? Math.min(burst,3)/3 : 0) + 0.35*slope7d + 0.15*topic));
+
+  return {
+    ds_news7: news7d|0,
+    ds_burst: +burst.toFixed(3),
+    ds_slope7: +slope7d.toFixed(3),
+    ds_topic: +topic.toFixed(3),
+    ds_trend: +ds_trend.toFixed(3),
+  };
+}

--- a/tools/buildPoolsTrendy.js
+++ b/tools/buildPoolsTrendy.js
@@ -14,6 +14,7 @@ import { buildUniverse } from '../src/universe/index.js';
 import { buildNewsFeatures } from '../src/news/fetchByTicker.js';
 import { fetchNaverTrends, buildBasketsFromUniverse } from '../src/trends/naverDatalab.js';
 import { buildKeywordDict } from '../src/trends/keywordBuilder.js';
+import { fetchDeepsearchFeatures } from '../src/news/deepsearch.js';
 
 fs.mkdirSync('cache', { recursive: true });
 
@@ -1032,7 +1033,7 @@ async function main(){
       if (!mappedOne || !mappedOne.sym) {
         console.warn('[map] skip (no symbol):', name);
         rememberMapping(name, null);
-        byName[name] = { ret5:null, ret20:null, vol20:null, turnover:null, adv20:null, close:null, newsCount:0, sentiment:null, naverPopularity:0, blogMentions:0, earn:false, offHi:0, offLo:0, sym:null, source:null, attempts:[], fetchMs:0 };
+        byName[name] = { ret5:null, ret20:null, vol20:null, turnover:null, adv20:null, close:null, newsCount:0, sentiment:null, naverPopularity:0, blogMentions:0, earn:false, offHi:0, offLo:0, sym:null, source:null, attempts:[], fetchMs:0, ds_news7:0, ds_burst:0, ds_slope7:0, ds_topic:0, ds_trend:0 };
         sanitizeSignals(byName[name]);
         return;
       }
@@ -1094,7 +1095,13 @@ async function main(){
       } catch (e) {
         tripOnError(e);
       }
-      byName[name] = { ret5, ret20, vol20, turnover, adv20, close, newsCount, sentiment, naverPopularity, naverAsvi, naverSpike, blogMentions, polygonTrend, nasdaqClose, earn, offHi, offLo, reputationScore: null, topKeywords: [], reputationHitIds: [], sym: sym || null, source: candles?.source || null, attempts: candles?.attempts || [], fetchMs: candles?.fetchMs || 0 };
+      byName[name] = { ret5, ret20, vol20, turnover, adv20, close, newsCount, sentiment, naverPopularity, naverAsvi, naverSpike, blogMentions, polygonTrend, nasdaqClose, earn, offHi, offLo, reputationScore: null, topKeywords: [], reputationHitIds: [], sym: sym || null, source: candles?.source || null, attempts: candles?.attempts || [], fetchMs: candles?.fetchMs || 0, ds_news7:0, ds_burst:0, ds_slope7:0, ds_topic:0, ds_trend:0 };
+      try {
+        const ds = await fetchDeepsearchFeatures({ name, ticker: sym, market });
+        Object.assign(byName[name], ds);
+      } catch (e) {
+        Object.assign(byName[name], { ds_news7:0, ds_burst:0, ds_slope7:0, ds_topic:0, ds_trend:0 });
+      }
       sanitizeSignals(byName[name]);
       processed.add(name);
     });
@@ -1104,7 +1111,8 @@ async function main(){
           ret5:null, ret20:null, vol20:null, turnover:null, adv20:null, close:null,
           newsCount:0, sentiment:null, naverPopularity:0, naverAsvi:null, naverSpike:null, blogMentions:0, polygonTrend:null, nasdaqClose:null, earn:false, offHi:0, offLo:0,
           reputationScore:null, topKeywords:[], reputationHitIds:[],
-          sym:null, source:null, attempts:[], fetchMs:0
+          sym:null, source:null, attempts:[], fetchMs:0,
+          ds_news7:0, ds_burst:0, ds_slope7:0, ds_topic:0, ds_trend:0
         };
       }
       const sym = byName[n].sym || nameToSymbol(n) || n;
@@ -1246,17 +1254,18 @@ async function main(){
     const LIQ_W = +process.env.LIQ_WEIGHT || 4;
     const EARN_BOOST = +process.env.EARNINGS_BOOST || 0.04; // +4% of 0..1 scale
     if (HOT > 0 || LIQ_W > 0) {
-      const newsP  = rank01(names.map(n => byName[n].newsCount));
-      const trendP = rank01(names.map(n => computeTrendMomentum(byName[n], PREV_METRICS?.[market]?.[n])));
+      const newsP  = rank01(names.map(n => (byName[n].ds_news7 ?? byName[n].newsCount ?? 0)));
+      const trendP = rank01(names.map(n => (byName[n].ds_trend ?? computeTrendMomentum(byName[n], PREV_METRICS?.[market]?.[n]) ?? 0)));
       const turnP  = rank01(names.map(n => byName[n].turnover));
       const offLP  = rank01(names.map(n => byName[n].offLo ?? 0));
       const offHP  = rank01(names.map(n => byName[n].offHi ?? 0));
       const liqP   = names.map(n => structuralPrior(byName[n].sym || nameToSymbol(n) || n));
 
       names.forEach((n, i) => {
-        let hot01 = 0.5*newsP[i] + 0.3*trendP[i] + 0.2*turnP[i];
+        let hot01 = 0.45*newsP[i] + 0.35*trendP[i] + 0.20*turnP[i];
         hot01 += 0.1*offLP[i] - 0.05*offHP[i];
-        const bump = (HOT/100) * hot01 + (LIQ_W/100) * liqP[i];
+        const burstKick = Math.min(0.05, 0.05 * (byName[n].ds_burst ?? 0));
+        const bump = (HOT/100) * Math.min(1, hot01 + burstKick) + (LIQ_W/100) * liqP[i];
         scoreSafe[n] = Math.min(1, scoreSafe[n] + bump + (byName[n].earn ? EARN_BOOST : 0));
         scoreAggr[n] = Math.min(1, scoreAggr[n] + bump*0.8 + (byName[n].earn ? EARN_BOOST*0.8 : 0));
         byName[n].totalScore = Math.min(100, Math.round(FLOOR + (CEIL - FLOOR) * scoreSafe[n]));
@@ -1371,6 +1380,11 @@ async function main(){
         fetchMs: byName[n].fetchMs,
         components: byName[n].componentScores,
         score: byName[n].totalScore,
+        ds_news7: byName[n].ds_news7,
+        ds_burst: byName[n].ds_burst,
+        ds_slope7: byName[n].ds_slope7,
+        ds_topic: byName[n].ds_topic,
+        ds_trend: byName[n].ds_trend,
         eligible: eligibility[n]
       };
       return acc;


### PR DESCRIPTION
## Summary
- add DeepSearch fetcher to gather news momentum and topic scores
- blend DeepSearch signals into pool builder hotness ranking
- expose DEEPS_API_KEY in workflow env

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b18175f89c832a925e6f0d7ab10ade