### PR TITLE
Add DeepSearch preflight and guard Polygon for non-US tickers

### DIFF
--- a/.github/workflows/stock-recs.yml
+++ b/.github/workflows/stock-recs.yml
@@ -163,12 +163,23 @@ jobs:
         env:
           FMP_KEY: ${{ secrets.FMP_KEY }}
 
+      - name: Preflight: DeepSearch
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          curl -4sS -I https://api-v2.deepsearch.com | head -n 1
+          curl -4sS --get 'https://api-v2.deepsearch.com/v1/global-articles' \
+            -H "Authorization: Bearer ${DEEPS_API_KEY}" \
+            --data-urlencode 'page_size=1' \
+            -o /dev/null -w 'HTTP %{http_code}\n'
+
       - name: Build trend-aware pools
         env:
           FMP_KEY: ${{ secrets.FMP_KEY }}
           ALPHA_VANTAGE_KEY: ${{ secrets.ALPHA_VANTAGE_KEY }}
           FINNHUB_API_KEY: ${{ secrets.FINNHUB_API_KEY }}
           TWELVEDATA_API_KEY: ${{ secrets.TWELVEDATA_API_KEY }}
+          DEEPS_API_KEY: ${{ secrets.DEEPS_API_KEY }}
           GLOBAL_BUDGET_MS: ${{ env.GLOBAL_BUDGET_MS }}
           MAX_CONCURRENCY: ${{ env.MAX_CONCURRENCY }}
           REQ_TIMEOUT_MS: ${{ env.REQ_TIMEOUT_MS }}

--- a/src/news/fetchByTicker.js
+++ b/src/news/fetchByTicker.js
@@ -104,6 +104,7 @@ async function safeGetJson(url, headers={}, timeoutMs=REQ_TIMEOUT_MS){
 }
 
 function isKR(sym){ return /\.K[QS]$/.test(sym); }
+function isUS(sym){ return /^[A-Z]+$/.test(sym) && !/\.K[QS]$/i.test(sym); }
 
 function baseSymbol(sym){ return String(sym||'').replace(/[\.\-]/g,'').toUpperCase(); }
 
@@ -135,7 +136,7 @@ function slope01(arr){ // returns slope normalized-ish (−1..+1)
 }
 
 async function fetchPolygonTrend(ticker) {
-  if (!POLYGON_API_KEY) return null;
+  if (!POLYGON_API_KEY || !isUS(ticker)) return null;
   try {
     const rest = restClient(POLYGON_API_KEY);
     const end = new Date();
@@ -164,7 +165,7 @@ async function fetchPolygonTrend(ticker) {
 }
 
 async function fetchPrevClose(ticker) {
-  if (!POLYGON_API_KEY) return null;
+  if (!POLYGON_API_KEY || !isUS(ticker)) return null;
   try {
     const rest = restClient(POLYGON_API_KEY);
     const res = await rest.stocks.previousClose(ticker, { adjusted: true });


### PR DESCRIPTION
## Summary
- skip Polygon API calls for non-US tickers
- add DeepSearch connectivity preflight and expose API key in build step

## Testing
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68b1b05b5668832aa10e881eeebedd9d