### PR TITLE
fix: quote workflow step name

### DIFF
--- a/.github/workflows/stock-recs.yml
+++ b/.github/workflows/stock-recs.yml
@@ -163,7 +163,7 @@ jobs:
         env:
           FMP_KEY: ${{ secrets.FMP_KEY }}
 
-      - name: Preflight: DeepSearch
+      - name: "Preflight: DeepSearch"
         shell: bash
         run: |
           set -Eeuo pipefail


### PR DESCRIPTION
## Summary
- fix YAML syntax error in stock-recs workflow by quoting "Preflight: DeepSearch" step name

## Testing
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68b1b18bff10832a8ed8d18266db3676