### PR TITLE
fix: quote step name in stock recs workflow

### DIFF
--- a/.github/workflows/stock-recs.yml
+++ b/.github/workflows/stock-recs.yml
@@ -248,7 +248,7 @@ jobs:
             --data-urlencode "api_key=${SERP_API_KEY}" \
             -o /dev/null -w 'HTTP %{http_code}\n'
 
-      - name: Preflight: NewsData.io
+      - name: "Preflight: NewsData.io"
         shell: bash
         env:
           NEWSDATA_API_KEY: ${{ secrets.NEWSDATA_API_KEY }}


### PR DESCRIPTION
## Summary
- fix syntax error in stock recommendations workflow by quoting step name

## Testing
- `node tests/apple_association.test.js`
- `yamllint .github/workflows/stock-recs.yml`


------
https://chatgpt.com/codex/tasks/task_b_68b1c9fa059c832a957a060e3a34c4a2