### PR TITLE
feat: weight Naver news in scoring

### DIFF
--- a/.github/workflows/stock-recs.yml
+++ b/.github/workflows/stock-recs.yml
@@ -28,6 +28,10 @@ jobs:
       HARD_DEADLINE_MS: "55000"           # news deadline (now enforced)
       SKIP_NAVER: "0"
       PREFER_NAVER: "1"
+      NAVER_WEIGHT: "1.6"
+      OTHER_NEWS_WEIGHT: "1.0"
+      NAVER_BLOG_WEIGHT: "0.5"
+      NAVER_REP_BONUS: "1.1"
       IS_CRON: ${{ github.event_name == 'schedule' }}
       # FX backup via Korea Eximbank (oapi.koreaexim.go.kr)
       USE_EXIM_FX_BACKUP: "1"

--- a/src/news/fetchByTicker.js
+++ b/src/news/fetchByTicker.js
@@ -25,6 +25,22 @@ const DEEPS_API_KEY = process.env.DEEPS_API_KEY || '';
 const DEEPS_US_EXCHANGE = process.env.DEEPS_US_EXCHANGE || 'NASDAQ';
 const NEWSDATA_API_KEY = process.env.NEWSDATA_API_KEY || '';
 
+const NAVER_WEIGHT = Number(process.env.NAVER_WEIGHT || 1.6);
+const OTHER_NEWS_WEIGHT = Number(process.env.OTHER_NEWS_WEIGHT || 1.0);
+const NAVER_BLOG_WEIGHT = Number(process.env.NAVER_BLOG_WEIGHT || 0.5);
+const NAVER_REP_BONUS = Number(process.env.NAVER_REP_BONUS || 1.1);
+
+function to01(x){ return Math.max(0, Math.min(1, x)); }
+
+export function newsScoreFromFeatures(f) {
+  if (typeof f?.newsScore === 'number') return f.newsScore;
+  const naver = Number(f?.naverCount || 0);
+  const other = Number(f?.otherCount || ((f?._source === 'naver') ? 0 : (f?.count || 0)));
+  const blogs = Number(f?.blogMentions || 0);
+  const weighted = NAVER_WEIGHT*naver + OTHER_NEWS_WEIGHT*other + NAVER_BLOG_WEIGHT*blogs;
+  return to01(Math.tanh(weighted / 10));
+}
+
 const buckets = {
   deepsearch: tokenBucket({capacity:3, refillPerSec:2}),
   newsapi: tokenBucket({capacity:3, refillPerSec:2}),
@@ -580,6 +596,7 @@ export async function buildNewsFeatures(symbols, opts={}){
         else if (p === 'kotra') v = await guardedCall('kotra', () => newsFromKotra(sym, q));
         else if (p === 'gdelt') v = await guardedCall('gdelt', () => newsFromGdelt(sym, q));
         else if (p === 'naver') v = await guardedCall('naver', () => newsFromNaver(name, NAVER_ID, NAVER_SECRET, { sym }));
+        if (v) v._source = p;
         if (v) {
           if (!SKIP_NAVER && v.count > 0 && (v.blogMentions||0) === 0) {
             try {
@@ -613,6 +630,23 @@ export async function buildNewsFeatures(symbols, opts={}){
       if (feat.count === 0 && (feat.polygonTrend != null || feat.nasdaqClose != null)) feat.count = 1;
     }
 
+    feat.naverCount = (feat._source === 'naver') ? feat.count : 0;
+    feat.otherCount = (feat._source && feat._source !== 'naver') ? feat.count : 0;
+
+    if (preferNaver && (!feat.naverCount || feat.naverCount === 0)) {
+      try {
+        const nv = await newsFromNaver(name, NAVER_ID, NAVER_SECRET, { sym });
+        if (nv) feat.naverCount = nv.count;
+      } catch {}
+    }
+
+    const blogs = Number(feat.blogMentions || 0);
+    const weightedCount =
+      NAVER_WEIGHT * feat.naverCount +
+      OTHER_NEWS_WEIGHT * feat.otherCount +
+      NAVER_BLOG_WEIGHT * blogs;
+    feat.newsScore = to01(Math.tanh(weightedCount / 10));
+
     let items = [];
     try {
       items = await getTickerArticles(sym);
@@ -620,7 +654,12 @@ export async function buildNewsFeatures(symbols, opts={}){
     try {
       const aliases = SYMBOL_ALIASES[sym] || [];
       const rep = computeReputation({ items, company: { ticker: sym, names: [symbolToName[sym], ...aliases].filter(Boolean) } });
-      feat.reputationScore = rep.reputationScore;
+      let repScore = rep.reputationScore;
+      const nTotal = items.length || 1;
+      const nNaver = items.reduce((n, it) => n + (it?.source === 'Naver' ? 1 : 0), 0);
+      const naverShare = nNaver / nTotal;
+      repScore = repScore * (1 + (NAVER_REP_BONUS - 1) * naverShare);
+      feat.reputationScore = repScore;
       feat.topKeywords = rep.topKeywords;
       feat.reputationHitIds = rep.hitIds;
     } catch {}
@@ -635,6 +674,9 @@ export async function buildNewsFeatures(symbols, opts={}){
       count:             Number(f.count || 0),
       sentiment:         Number(f.sentiment || 0),
       blogMentions:      Number(f.blogMentions || 0),
+      naverCount:        Number(f.naverCount || 0),
+      otherCount:        Number(f.otherCount || 0),
+      newsScore:         Number(f.newsScore || 0),
       polygonTrend:      Number.isFinite(f.polygonTrend) ? f.polygonTrend : 0,
       nasdaqClose:       Number.isFinite(f.nasdaqClose) ? f.nasdaqClose : 0,
       reputationScore:   Number.isFinite(f.reputationScore) ? f.reputationScore : 0,
@@ -753,13 +795,10 @@ function dedupeArticles(items) {
 
 async function getTickerArticlesPrimary(ticker) {
   const out = [];
-  const dsItems = await getTickerArticlesFromDS(ticker, ticker.replace(/\.[A-Z]+$/,''));
-  out.push(...dsItems);
   const NAVER_ID = process.env.NAVER_CLIENT_ID || "";
   const NAVER_SECRET = process.env.NAVER_CLIENT_SECRET || "";
   if (!SKIP_NAVER && NAVER_ID && NAVER_SECRET) {
     try {
-      // Try to enrich query with company name if we have it cached
       let display = ticker;
       try {
         const nm = (require('./symbolNames.json') || {})[ticker];
@@ -767,14 +806,23 @@ async function getTickerArticlesPrimary(ticker) {
       } catch {}
       const q = /\.K[QS]$/.test(ticker) ? `${display} 증권 OR 투자` : display;
 
-      const url = `https://openapi.naver.com/v1/search/news.json?query=${encodeURIComponent(q)}&display=20&sort=date`;
       const headers = { 'X-Naver-Client-Id': NAVER_ID, 'X-Naver-Client-Secret': NAVER_SECRET };
-      const res = await fetch(url, { headers });
-      const j = await res.json();
-      const arr = Array.isArray(j?.items) ? j.items : [];
+      const page1 = `https://openapi.naver.com/v1/search/news.json?query=${encodeURIComponent(q)}&display=20&start=1&sort=date`;
+      const page2 = `https://openapi.naver.com/v1/search/news.json?query=${encodeURIComponent(q)}&display=20&start=21&sort=date`;
+
+      const [r1, r2] = await Promise.all([
+        fetch(page1, { headers }).then(r=>r.json()).catch(()=>({items:[]})),
+        fetch(page2, { headers }).then(r=>r.json()).catch(()=>({items:[]})),
+      ]);
+
+      const arr = []
+        .concat(Array.isArray(r1?.items) ? r1.items : [])
+        .concat(Array.isArray(r2?.items) ? r2.items : []);
       out.push(...arr.map(normalizeNaverArticle).filter(Boolean));
     } catch {}
   }
+  const dsItems = await getTickerArticlesFromDS(ticker, ticker.replace(/\.[A-Z]+$/,''));
+  out.push(...dsItems);
   const NEWSAPI = process.env.NEWSAPI_KEY || "";
   if (NEWSAPI) {
     try {

--- a/tools/buildPoolsTrendy.js
+++ b/tools/buildPoolsTrendy.js
@@ -11,7 +11,7 @@ import { execSync } from 'node:child_process';
 import { TICKER_MAP } from '../src/maps.js';
 import { getCandles, providerState } from '../src/data/candles.js';
 import { buildUniverse } from '../src/universe/index.js';
-import { buildNewsFeatures } from '../src/news/fetchByTicker.js';
+import { buildNewsFeatures, newsScoreFromFeatures } from '../src/news/fetchByTicker.js';
 import { fetchNaverTrends, buildBasketsFromUniverse } from '../src/trends/naverDatalab.js';
 import { buildKeywordDict } from '../src/trends/keywordBuilder.js';
 import { fetchDeepsearchFeatures } from '../src/news/deepsearch.js';
@@ -745,12 +745,12 @@ function namesOnlyRank(universe, features) {
       const sym = nameToSymbol(n) || n;
       rememberMapping(n, sym);
       const nf = features[sym] || {};
-      const count = Math.min(nf.count || 0, 30) / 30;
+      const newsScore = newsScoreFromFeatures(nf);
       const sentiment = ((nf.sentiment ?? 0) + 1) / 2;
       const pop = nf.naverPopularity ?? 0;
       const trendBoost = (typeof nf.polygonTrend === 'number' ? clamp01(nf.polygonTrend) * 0.05 : 0);
       const nasdaqBoost = nf.nasdaqClose != null ? 0.02 : 0;
-      const score = count * 0.12 + (sentiment - 0.5) * 0.08 + (/\.K[QS]$/.test(sym) ? pop * 0.20 : 0) + trendBoost + nasdaqBoost;
+      const score = newsScore * 0.12 + (sentiment - 0.5) * 0.08 + (/\.K[QS]$/.test(sym) ? pop * 0.20 : 0) + trendBoost + nasdaqBoost;
       return { name: n, score };
     }).sort((a,b)=>b.score-a.score).map(s=>s.name);
     out[m] = { safe: scored.slice(0, kSafe), aggressive: scored.slice(kSafe, kSafe + kAggr) };
@@ -805,7 +805,7 @@ function coverageRatio(metrics) {
   const vals = Object.values(metrics || {});
   if (!vals.length) return 0;
   const ok = vals.filter(m => {
-    return [m.ret5, m.ret20, m.vol20, m.turnover].some(x => Number.isFinite(x)) || m.newsCount > 0 || m.earn === true;
+    return [m.ret5, m.ret20, m.vol20, m.turnover].some(x => Number.isFinite(x)) || m.newsScore > 0 || m.newsCount > 0 || m.earn === true;
   }).length;
   return ok / vals.length;
 }
@@ -815,6 +815,7 @@ function nz(x, def = 0) { return Number.isFinite(x) ? x : def; }
 
 function sanitizeSignals(row) {
   row.newsCount       = nz(row.newsCount, 0);
+  row.newsScore       = nz(row.newsScore, 0);
   row.sentiment       = Number.isFinite(row.sentiment) ? row.sentiment : 0;
   row.blogMentions    = nz(row.blogMentions, 0);
   row.naverPopularity = nz(row.naverPopularity, 0);
@@ -830,7 +831,7 @@ function sanitizeSignals(row) {
 function carryForwardIfEmpty(byName, n, market){
   const prev = PREV_METRICS?.[market]?.[n];
   if (!prev) return;
-  const fields = ['ret5','ret20','turnover','newsCount','sentiment','naverPopularity','naverAsvi','naverSpike'];
+  const fields = ['ret5','ret20','turnover','newsCount','newsScore','sentiment','naverPopularity','naverAsvi','naverSpike'];
   for (const f of fields){
     const cur = byName[n][f];
     if (!Number.isFinite(cur) || cur === 0){
@@ -841,7 +842,7 @@ function carryForwardIfEmpty(byName, n, market){
 }
 
 function sectorMedians(names, byName){
-  const fields = ['sentiment','newsCount','naverPopularity','ret5','ret20','turnover'];
+  const fields = ['sentiment','newsCount','newsScore','naverPopularity','ret5','ret20','turnover'];
   const buckets = new Map();
   for (const n of names){
     const s = byName[n].sector || 'UNKNOWN';
@@ -1061,7 +1062,7 @@ async function main(){
       if (!mappedOne || !mappedOne.sym) {
         console.warn('[map] skip (no symbol):', name);
         rememberMapping(name, null);
-        byName[name] = { ret5:null, ret20:null, vol20:null, turnover:null, adv20:null, close:null, newsCount:0, sentiment:null, naverPopularity:0, blogMentions:0, earn:false, offHi:0, offLo:0, sym:null, source:null, attempts:[], fetchMs:0, ds_news7:0, ds_burst:0, ds_slope7:0, ds_topic:0, ds_trend:0 };
+        byName[name] = { ret5:null, ret20:null, vol20:null, turnover:null, adv20:null, close:null, newsCount:0, newsScore:0, sentiment:null, naverPopularity:0, blogMentions:0, earn:false, offHi:0, offLo:0, sym:null, source:null, attempts:[], fetchMs:0, ds_news7:0, ds_burst:0, ds_slope7:0, ds_topic:0, ds_trend:0 };
         sanitizeSignals(byName[name]);
         return;
       }
@@ -1085,7 +1086,7 @@ async function main(){
       }
       log(`[buildPools] ${market} :: ${name} ${route}${routeDetail}`);
 
-      let ret5=null, ret20=null, vol20=null, turnover=null, adv20=null, close=null; let newsCount=0; let sentiment=null; let naverPopularity=0; let naverAsvi=null; let naverSpike=null; let blogMentions=0; let polygonTrend=null; let nasdaqClose=null; let earn=false; let candles=null; let offHi=0; let offLo=0;
+      let ret5=null, ret20=null, vol20=null, turnover=null, adv20=null, close=null; let newsCount=0; let newsScore=0; let sentiment=null; let naverPopularity=0; let naverAsvi=null; let naverSpike=null; let blogMentions=0; let polygonTrend=null; let nasdaqClose=null; let earn=false; let candles=null; let offHi=0; let offLo=0;
       try {
         const countsBefore = Object.fromEntries(Object.entries(providerState).map(([p,s])=>[p, s.count||0]));
         candles = (sym && budgetOk(REQ_TIMEOUT_MS) && !circuitOpen())
@@ -1111,6 +1112,7 @@ async function main(){
         const nf = NEWS_FEATURES[sym] || NEWS_FEATURES[name];
         if (nf) {
           newsCount = nf.count || 0;
+          newsScore = newsScoreFromFeatures(nf);
           sentiment = typeof nf.sentiment === 'number' ? nf.sentiment : null;
           naverPopularity = typeof nf.naverPopularity === 'number' ? nf.naverPopularity : 0;
           blogMentions = typeof nf.blogMentions === 'number' ? nf.blogMentions : 0;
@@ -1123,7 +1125,7 @@ async function main(){
       } catch (e) {
         tripOnError(e);
       }
-      byName[name] = { ret5, ret20, vol20, turnover, adv20, close, newsCount, sentiment, naverPopularity, naverAsvi, naverSpike, blogMentions, polygonTrend, nasdaqClose, earn, offHi, offLo, reputationScore: null, topKeywords: [], reputationHitIds: [], sym: sym || null, source: candles?.source || null, attempts: candles?.attempts || [], fetchMs: candles?.fetchMs || 0, ds_news7:0, ds_burst:0, ds_slope7:0, ds_topic:0, ds_trend:0 };
+      byName[name] = { ret5, ret20, vol20, turnover, adv20, close, newsCount, newsScore, sentiment, naverPopularity, naverAsvi, naverSpike, blogMentions, polygonTrend, nasdaqClose, earn, offHi, offLo, reputationScore: null, topKeywords: [], reputationHitIds: [], sym: sym || null, source: candles?.source || null, attempts: candles?.attempts || [], fetchMs: candles?.fetchMs || 0, ds_news7:0, ds_burst:0, ds_slope7:0, ds_topic:0, ds_trend:0 };
       try {
         const ds = await fetchDeepsearchFeatures({ name, ticker: sym, market });
         Object.assign(byName[name], ds);
@@ -1137,7 +1139,7 @@ async function main(){
       if (!byName[n]) {
         byName[n] = {
           ret5:null, ret20:null, vol20:null, turnover:null, adv20:null, close:null,
-          newsCount:0, sentiment:null, naverPopularity:0, naverAsvi:null, naverSpike:null, blogMentions:0, polygonTrend:null, nasdaqClose:null, earn:false, offHi:0, offLo:0,
+          newsCount:0, newsScore:0, sentiment:null, naverPopularity:0, naverAsvi:null, naverSpike:null, blogMentions:0, polygonTrend:null, nasdaqClose:null, earn:false, offHi:0, offLo:0,
           reputationScore:null, topKeywords:[], reputationHitIds:[],
           sym:null, source:null, attempts:[], fetchMs:0,
           ds_news7:0, ds_burst:0, ds_slope7:0, ds_topic:0, ds_trend:0
@@ -1147,6 +1149,7 @@ async function main(){
       const nf = NEWS_FEATURES[sym] || NEWS_FEATURES[n];
       if (nf) {
         byName[n].newsCount       = nf.count ?? byName[n].newsCount;
+        byName[n].newsScore       = newsScoreFromFeatures(nf) ?? byName[n].newsScore;
         byName[n].sentiment       = (typeof nf.sentiment === 'number' ? nf.sentiment : byName[n].sentiment);
         byName[n].naverPopularity = nf.naverPopularity ?? byName[n].naverPopularity;
         byName[n].naverAsvi       = nf.naverAsvi ?? byName[n].naverAsvi;
@@ -1168,6 +1171,7 @@ async function main(){
       const m = med[s] || {};
       if (!Number.isFinite(byName[n].sentiment))       byName[n].sentiment       = (m.sentiment ?? 0) * IMPUTE;
       if (!Number.isFinite(byName[n].newsCount))       byName[n].newsCount       = (m.newsCount ?? 0) * IMPUTE;
+      if (!Number.isFinite(byName[n].newsScore))       byName[n].newsScore       = (m.newsScore ?? 0) * IMPUTE;
       if (!Number.isFinite(byName[n].naverPopularity)) byName[n].naverPopularity = (m.naverPopularity ?? 0) * (IMPUTE*0.7);
       if (!Number.isFinite(byName[n].ret5))            byName[n].ret5            = (m.ret5 ?? 0) * (IMPUTE*0.8);
       if (!Number.isFinite(byName[n].ret20))           byName[n].ret20           = (m.ret20 ?? 0) * (IMPUTE*0.8);
@@ -1177,7 +1181,7 @@ async function main(){
 
     const withSignals = [...processed].filter(n => {
       const m = byName[n];
-      return [m.ret5, m.ret20, m.vol20, m.turnover].some(Number.isFinite) || m.newsCount > 0 || m.earn;
+      return [m.ret5, m.ret20, m.vol20, m.turnover].some(Number.isFinite) || m.newsScore > 0 || m.earn;
     }).length;
     console.log(`[metrics] ${market} processed=${processed.size}/${names.length} withSignals=${withSignals}`);
 
@@ -1198,14 +1202,14 @@ async function main(){
     const scoreSafeRaw = {};
     const scoreAggrRaw = {};
     names.forEach((n) => {
-      const prev = PREV_METRICS?.[market]?.[n]?.newsCount || 0;
+      const prev = PREV_METRICS?.[market]?.[n]?.newsScore || 0;
 
       // trend momentum: prefer growth metric if available
       const prevTrendRow = PREV_METRICS?.[market]?.[n];
       const trendMomentum = computeTrendMomentum(byName[n], prevTrendRow);
 
       const sentScore  = scoreSentiment(byName[n].sentiment);
-      const momScore   = scoreNewsMomentum(byName[n].newsCount || 0, prev);
+      const momScore   = scoreNewsMomentum(byName[n].newsScore || 0, prev);
       const trendScore = scoreTrend(trendMomentum);
       const credScore  = scoreCredibility(byName[n].reputationScore); // normalized inside
       const catScore   = scoreCatalysts(byName[n].topKeywords);
@@ -1221,7 +1225,7 @@ async function main(){
       ]);
 
       const totalRounded = Math.round(total);
-      byName[n].prevNewsCount   = prev;
+      byName[n].prevNewsScore   = prev;
       byName[n].componentScores = { sentiment: sentScore, momentum: momScore, trends: trendScore, credibility: credScore, catalysts: catScore, risk: riskScore };
       byName[n].totalScore      = totalRounded;
 
@@ -1283,7 +1287,7 @@ async function main(){
     const EARN_BOOST = +process.env.EARNINGS_BOOST || 0.04; // +4% of 0..1 scale
     if (HOT > 0 || LIQ_W > 0) {
       const asArr = fn => names.map(fn);
-      const newsRaw  = asArr(n => (byName[n].ds_news7 ?? byName[n].newsCount ?? 0));
+      const newsRaw  = asArr(n => (byName[n].ds_news7 ?? byName[n].newsScore ?? 0));
       const trendRaw = asArr(n => (byName[n].ds_trend  ?? computeTrendMomentum(byName[n], PREV_METRICS?.[market]?.[n]) ?? 0));
 
       const newsP  = safeRank01(newsRaw);
@@ -1424,7 +1428,8 @@ async function main(){
         adv20: byName[n].adv20,
         close: byName[n].close,
         newsCount: byName[n].newsCount,
-        prevNewsCount: byName[n].prevNewsCount,
+        newsScore: byName[n].newsScore,
+        prevNewsScore: byName[n].prevNewsScore,
         sentiment: byName[n].sentiment,
         naverPopularity: byName[n].naverPopularity,
         naverAsvi: byName[n].naverAsvi,


### PR DESCRIPTION
## Summary
- bias stock-recs workflow toward Naver and expose weighting knobs
- compute weighted newsScore with Naver bias and adjust reputation
- rank pools using weighted newsScore and export metrics

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b26ae8ad78832ab229239fdce29f06