### PR TITLE
Initialize keywords before fetching news features

### DIFF
--- a/tools/buildPoolsTrendy.js
+++ b/tools/buildPoolsTrendy.js
@@ -1013,6 +1013,7 @@ async function main(){
     }
   }
 
+  let KEYWORDS = { ...NAVER_SEED_KEYWORDS };
   if (!OFFLINE) {
     const NEWS_MAX = Number(process.env.NEWS_MAX_SYMBOLS || 80);
     const kr = symbols.filter(isKR);
@@ -1024,7 +1025,7 @@ async function main(){
   }
 
   // now build keywords using up-to-date features
-  const KEYWORDS = await buildKeywordDict({
+  KEYWORDS = await buildKeywordDict({
     symbols,
     seeds: NAVER_SEED_KEYWORDS,
     symbolToName: SYMBOL_TO_NAME,


### PR DESCRIPTION
## Summary
- Prevent runtime error in `buildPoolsTrendy.js` by seeding `KEYWORDS` before fetching news features
- Rebuild keyword map after news enrichment to maintain up-to-date terms

## Testing
- `node tests/apple_association.test.js`
- `node tools/buildPoolsTrendy.js --offline`

------
https://chatgpt.com/codex/tasks/task_b_68b2cc9f22fc832a967a4887841c412b