### PR TITLE
Add market cap to index maps

### DIFF
--- a/src/maps.indexes.json
+++ b/src/maps.indexes.json
@@ -3,4469 +3,5361 @@
     {
       "symbol": "A",
       "name": "Agilent Technologies",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 33900000000
     },
     {
       "symbol": "AAPL",
       "name": "Apple Inc.",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 3410000000000
     },
     {
       "symbol": "ABBV",
       "name": "AbbVie",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 371930000000
     },
     {
       "symbol": "ABNB",
       "name": "Airbnb",
-      "sector": "Consumer Discretionary"
+      "sector": "Consumer Discretionary",
+      "marketCap": 80740000000
     },
     {
       "symbol": "ABT",
       "name": "Abbott Laboratories",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 231050000000
     },
     {
       "symbol": "ACGL",
       "name": "Arch Capital Group",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 34350000000
     },
     {
       "symbol": "ACN",
       "name": "Accenture",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 162520000000
     },
     {
       "symbol": "ADBE",
       "name": "Adobe Inc.",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 152330000000
     },
     {
       "symbol": "ADI",
       "name": "Analog Devices",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 124240000000
     },
     {
       "symbol": "ADM",
       "name": "Archer Daniels Midland",
-      "sector": "Consumer Staples"
+      "sector": "Consumer Staples",
+      "marketCap": 30120000000
     },
     {
       "symbol": "ADP",
       "name": "Automatic Data Processing",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 122740000000
     },
     {
       "symbol": "ADSK",
       "name": "Autodesk",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 66750000000
     },
     {
       "symbol": "AEE",
       "name": "Ameren",
-      "sector": "Utilities"
+      "sector": "Utilities",
+      "marketCap": 27300000000
     },
     {
       "symbol": "AEP",
       "name": "American Electric Power",
-      "sector": "Utilities"
+      "sector": "Utilities",
+      "marketCap": 59960000000
     },
     {
       "symbol": "AES",
       "name": "AES Corporation",
-      "sector": "Utilities"
+      "sector": "Utilities",
+      "marketCap": 9560000000
     },
     {
       "symbol": "AFL",
       "name": "Aflac",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 57860000000
     },
     {
       "symbol": "AIG",
       "name": "American International Group",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 45390000000
     },
     {
       "symbol": "AIZ",
       "name": "Assurant",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 10750000000
     },
     {
       "symbol": "AJG",
       "name": "Arthur J. Gallagher & Co.",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 77380000000
     },
     {
       "symbol": "AKAM",
       "name": "Akamai Technologies",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 11330000000
     },
     {
       "symbol": "ALB",
       "name": "Albemarle Corporation",
-      "sector": "Materials"
+      "sector": "Materials",
+      "marketCap": 10320000000
     },
     {
       "symbol": "ALGN",
       "name": "Align Technology",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 10350000000
     },
     {
       "symbol": "ALL",
       "name": "Allstate",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 53620000000
     },
     {
       "symbol": "ALLE",
       "name": "Allegion",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 14660000000
     },
     {
       "symbol": "AMAT",
       "name": "Applied Materials",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 127390000000
     },
     {
       "symbol": "AMCR",
       "name": "Amcor",
-      "sector": "Materials"
+      "sector": "Materials",
+      "marketCap": 19800000000
     },
     {
       "symbol": "AMD",
       "name": "Advanced Micro Devices",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 261650000000
     },
     {
       "symbol": "AME",
       "name": "Ametek",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 42640000000
     },
     {
       "symbol": "AMGN",
       "name": "Amgen",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 156170000000
     },
     {
       "symbol": "AMP",
       "name": "Ameriprise Financial",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 48690000000
     },
     {
       "symbol": "AMT",
       "name": "American Tower",
-      "sector": "Real Estate"
+      "sector": "Real Estate",
+      "marketCap": 95790000000
     },
     {
       "symbol": "AMZN",
       "name": "Amazon",
-      "sector": "Consumer Discretionary"
+      "sector": "Consumer Discretionary",
+      "marketCap": 2420000000000
     },
     {
       "symbol": "ANET",
       "name": "Arista Networks",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 167900000000
     },
     {
       "symbol": "AON",
       "name": "Aon plc",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 79530000000
     },
     {
       "symbol": "AOS",
       "name": "A. O. Smith",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 10100000000
     },
     {
       "symbol": "APA",
       "name": "APA Corporation",
-      "sector": "Energy"
+      "sector": "Energy",
+      "marketCap": 8170000000
     },
     {
       "symbol": "APD",
       "name": "Air Products",
-      "sector": "Materials"
+      "sector": "Materials",
+      "marketCap": 65360000000
     },
     {
       "symbol": "APH",
       "name": "Amphenol",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 130760000000
     },
     {
       "symbol": "APO",
       "name": "Apollo Global Management",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 81740000000
     },
     {
       "symbol": "APTV",
       "name": "Aptiv",
-      "sector": "Consumer Discretionary"
+      "sector": "Consumer Discretionary",
+      "marketCap": 17240000000
     },
     {
       "symbol": "ARE",
       "name": "Alexandria Real Estate Equities",
-      "sector": "Real Estate"
+      "sector": "Real Estate",
+      "marketCap": 14240000000
     },
     {
       "symbol": "ATO",
       "name": "Atmos Energy",
-      "sector": "Utilities"
+      "sector": "Utilities",
+      "marketCap": 26800000000
     },
     {
       "symbol": "AVB",
       "name": "AvalonBay Communities",
-      "sector": "Real Estate"
+      "sector": "Real Estate",
+      "marketCap": 27820000000
     },
     {
       "symbol": "AVGO",
       "name": "Broadcom",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 1360000000000
     },
     {
       "symbol": "AVY",
       "name": "Avery Dennison",
-      "sector": "Materials"
+      "sector": "Materials",
+      "marketCap": 13560000000
     },
     {
       "symbol": "AWK",
       "name": "American Water Works",
-      "sector": "Utilities"
+      "sector": "Utilities",
+      "marketCap": 28360000000
     },
     {
       "symbol": "AXON",
       "name": "Axon Enterprise",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 60420000000
     },
     {
       "symbol": "AXP",
       "name": "American Express",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 227340000000
     },
     {
       "symbol": "AZO",
       "name": "AutoZone",
-      "sector": "Consumer Discretionary"
+      "sector": "Consumer Discretionary",
+      "marketCap": 70380000000
     },
     {
       "symbol": "BA",
       "name": "Boeing",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 177050000000
     },
     {
       "symbol": "BAC",
       "name": "Bank of America",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 375010000000
     },
     {
       "symbol": "BALL",
       "name": "Ball Corporation",
-      "sector": "Materials"
+      "sector": "Materials",
+      "marketCap": 14390000000
     },
     {
       "symbol": "BAX",
       "name": "Baxter International",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 12750000000
     },
     {
       "symbol": "BBY",
       "name": "Best Buy",
-      "sector": "Consumer Discretionary"
+      "sector": "Consumer Discretionary",
+      "marketCap": 16160000000
     },
     {
       "symbol": "BDX",
       "name": "Becton Dickinson",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 56510000000
     },
     {
       "symbol": "BEN",
       "name": "Franklin Resources",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 13370000000
     },
     {
       "symbol": "BF.B",
       "name": "Brown–Forman",
-      "sector": "Consumer Staples"
+      "sector": "Consumer Staples",
+      "marketCap": 14940000000
     },
     {
       "symbol": "BG",
       "name": "Bunge Global",
-      "sector": "Consumer Staples"
+      "sector": "Consumer Staples",
+      "marketCap": 16860000000
     },
     {
       "symbol": "BIIB",
       "name": "Biogen",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 19930000000
     },
     {
       "symbol": "BK",
       "name": "BNY Mellon",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 73720000000
     },
     {
       "symbol": "BKNG",
       "name": "Booking Holdings",
-      "sector": "Consumer Discretionary"
+      "sector": "Consumer Discretionary",
+      "marketCap": 180300000000
     },
     {
       "symbol": "BKR",
       "name": "Baker Hughes",
-      "sector": "Energy"
+      "sector": "Energy",
+      "marketCap": 43980000000
     },
     {
       "symbol": "BLDR",
       "name": "Builders FirstSource",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 15510000000
     },
     {
       "symbol": "BLK",
       "name": "BlackRock",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 174720000000
     },
     {
       "symbol": "BMY",
       "name": "Bristol Myers Squibb",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 97570000000
     },
     {
       "symbol": "BR",
       "name": "Broadridge Financial Solutions",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 30070000000
     },
     {
       "symbol": "BRK.B",
       "name": "Berkshire Hathaway",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 1080000000000
     },
     {
       "symbol": "BRO",
       "name": "Brown & Brown",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 31940000000
     },
     {
       "symbol": "BSX",
       "name": "Boston Scientific",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 156500000000
     },
     {
       "symbol": "BX",
       "name": "Blackstone Inc.",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 202600000000
     },
     {
       "symbol": "BXP",
       "name": "BXP, Inc.",
-      "sector": "Real Estate"
+      "sector": "Real Estate",
+      "marketCap": 11380000000
     },
     {
       "symbol": "C",
       "name": "Citigroup",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 177870000000
     },
     {
       "symbol": "CAG",
       "name": "Conagra Brands",
-      "sector": "Consumer Staples"
+      "sector": "Consumer Staples",
+      "marketCap": 9340000000
     },
     {
       "symbol": "CAH",
       "name": "Cardinal Health",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 35460000000
     },
     {
       "symbol": "CARR",
       "name": "Carrier Global",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 56680000000
     },
     {
       "symbol": "CAT",
       "name": "Caterpillar Inc.",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 195300000000
     },
     {
       "symbol": "CB",
       "name": "Chubb Limited",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 109590000000
     },
     {
       "symbol": "CBOE",
       "name": "Cboe Global Markets",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": null
     },
     {
       "symbol": "CBRE",
       "name": "CBRE Group",
-      "sector": "Real Estate"
+      "sector": "Real Estate",
+      "marketCap": 48550000000
     },
     {
       "symbol": "CCI",
       "name": "Crown Castle",
-      "sector": "Real Estate"
+      "sector": "Real Estate",
+      "marketCap": 44240000000
     },
     {
       "symbol": "CCL",
       "name": "Carnival",
-      "sector": "Consumer Discretionary"
+      "sector": "Consumer Discretionary",
+      "marketCap": 41250000000
     },
     {
       "symbol": "CDNS",
       "name": "Cadence Design Systems",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 93490000000
     },
     {
       "symbol": "CDW",
       "name": "CDW Corporation",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 21510000000
     },
     {
       "symbol": "CEG",
       "name": "Constellation Energy",
-      "sector": "Utilities"
+      "sector": "Utilities",
+      "marketCap": 95130000000
     },
     {
       "symbol": "CF",
       "name": "CF Industries",
-      "sector": "Materials"
+      "sector": "Materials",
+      "marketCap": 13880000000
     },
     {
       "symbol": "CFG",
       "name": "Citizens Financial Group",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 22440000000
     },
     {
       "symbol": "CHD",
       "name": "Church & Dwight",
-      "sector": "Consumer Staples"
+      "sector": "Consumer Staples",
+      "marketCap": 22930000000
     },
     {
       "symbol": "CHRW",
       "name": "C.H. Robinson",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 15120000000
     },
     {
       "symbol": "CHTR",
       "name": "Charter Communications",
-      "sector": "Communication Services"
+      "sector": "Communication Services",
+      "marketCap": 37040000000
     },
     {
       "symbol": "CI",
       "name": "Cigna",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 80570000000
     },
     {
       "symbol": "CINF",
       "name": "Cincinnati Financial",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 24110000000
     },
     {
       "symbol": "CL",
       "name": "Colgate-Palmolive",
-      "sector": "Consumer Staples"
+      "sector": "Consumer Staples",
+      "marketCap": 68790000000
     },
     {
       "symbol": "CLX",
       "name": "Clorox",
-      "sector": "Consumer Staples"
+      "sector": "Consumer Staples",
+      "marketCap": 14580000000
     },
     {
       "symbol": "CMCSA",
       "name": "Comcast",
-      "sector": "Communication Services"
+      "sector": "Communication Services",
+      "marketCap": 126320000000
     },
     {
       "symbol": "CME",
       "name": "CME Group",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 97250000000
     },
     {
       "symbol": "CMG",
       "name": "Chipotle Mexican Grill",
-      "sector": "Consumer Discretionary"
+      "sector": "Consumer Discretionary",
+      "marketCap": 56820000000
     },
     {
       "symbol": "CMI",
       "name": "Cummins",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 54830000000
     },
     {
       "symbol": "CMS",
       "name": "CMS Energy",
-      "sector": "Utilities"
+      "sector": "Utilities",
+      "marketCap": 21720000000
     },
     {
       "symbol": "CNC",
       "name": "Centene Corporation",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 14490000000
     },
     {
       "symbol": "CNP",
       "name": "CenterPoint Energy",
-      "sector": "Utilities"
+      "sector": "Utilities",
+      "marketCap": 24780000000
     },
     {
       "symbol": "COF",
       "name": "Capital One",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 143650000000
     },
     {
       "symbol": "COIN",
       "name": "Coinbase",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 78370000000
     },
     {
       "symbol": "COO",
       "name": "Cooper Companies (The)",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 15430000000
     },
     {
       "symbol": "COP",
       "name": "ConocoPhillips",
-      "sector": "Energy"
+      "sector": "Energy",
+      "marketCap": 122920000000
     },
     {
       "symbol": "COR",
       "name": "Cencora",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 12890000000
     },
     {
       "symbol": "COST",
       "name": "Costco",
-      "sector": "Consumer Staples"
+      "sector": "Consumer Staples",
+      "marketCap": 420360000000
     },
     {
       "symbol": "CPAY",
       "name": "Corpay",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 23000000000
     },
     {
       "symbol": "CPB",
       "name": "Campbell's Company (The)",
-      "sector": "Consumer Staples"
+      "sector": "Consumer Staples",
+      "marketCap": 9650000000
     },
     {
       "symbol": "CPRT",
       "name": "Copart",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 47060000000
     },
     {
       "symbol": "CPT",
       "name": "Camden Property Trust",
-      "sector": "Real Estate"
+      "sector": "Real Estate",
+      "marketCap": 11950000000
     },
     {
       "symbol": "CRL",
       "name": "Charles River Laboratories",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 8020000000
     },
     {
       "symbol": "CRM",
       "name": "Salesforce",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 240770000000
     },
     {
       "symbol": "CRWD",
       "name": "CrowdStrike",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 100970000000
     },
     {
       "symbol": "CSCO",
       "name": "Cisco",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 269700000000
     },
     {
       "symbol": "CSGP",
       "name": "CoStar Group",
-      "sector": "Real Estate"
+      "sector": "Real Estate",
+      "marketCap": 37540000000
     },
     {
       "symbol": "CSX",
       "name": "CSX Corporation",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 60380000000
     },
     {
       "symbol": "CTAS",
       "name": "Cintas",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 86620000000
     },
     {
       "symbol": "CTRA",
       "name": "Coterra",
-      "sector": "Energy"
+      "sector": "Energy",
+      "marketCap": 445150000
     },
     {
       "symbol": "CTSH",
       "name": "Cognizant",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 35580000000
     },
     {
       "symbol": "CTVA",
       "name": "Corteva",
-      "sector": "Materials"
+      "sector": "Materials",
+      "marketCap": 50860000000
     },
     {
       "symbol": "CVS",
       "name": "CVS Health",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 92510000000
     },
     {
       "symbol": "CVX",
       "name": "Chevron Corporation",
-      "sector": "Energy"
+      "sector": "Energy",
+      "marketCap": 328650000000
     },
     {
       "symbol": "CZR",
       "name": "Caesars Entertainment",
-      "sector": "Consumer Discretionary"
+      "sector": "Consumer Discretionary",
+      "marketCap": 5510000000
     },
     {
       "symbol": "D",
       "name": "Dominion Energy",
-      "sector": "Utilities"
+      "sector": "Utilities",
+      "marketCap": 51570000000
     },
     {
       "symbol": "DAL",
       "name": "Delta Air Lines",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 39880000000
     },
     {
       "symbol": "DASH",
       "name": "DoorDash",
-      "sector": "Consumer Discretionary"
+      "sector": "Consumer Discretionary",
+      "marketCap": 104060000000
     },
     {
       "symbol": "DAY",
       "name": "Dayforce",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 11000000000
     },
     {
       "symbol": "DD",
       "name": "DuPont",
-      "sector": "Materials"
+      "sector": "Materials",
+      "marketCap": 32290000000
     },
     {
       "symbol": "DDOG",
       "name": "Datadog",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 45940000000
     },
     {
       "symbol": "DE",
       "name": "Deere & Company",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 130060000000
     },
     {
       "symbol": "DECK",
       "name": "Deckers Brands",
-      "sector": "Consumer Discretionary"
+      "sector": "Consumer Discretionary",
+      "marketCap": 17530000000
     },
     {
       "symbol": "DELL",
       "name": "Dell Technologies",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 81660000000
     },
     {
       "symbol": "DG",
       "name": "Dollar General",
-      "sector": "Consumer Staples"
+      "sector": "Consumer Staples",
+      "marketCap": 23830000000
     },
     {
       "symbol": "DGX",
       "name": "Quest Diagnostics",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 20380000000
     },
     {
       "symbol": "DHI",
       "name": "D. R. Horton",
-      "sector": "Consumer Discretionary"
+      "sector": "Consumer Discretionary",
+      "marketCap": 50100000000
     },
     {
       "symbol": "DHR",
       "name": "Danaher Corporation",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 147170000000
     },
     {
       "symbol": "DIS",
       "name": "Walt Disney Company (The)",
-      "sector": "Communication Services"
+      "sector": "Communication Services",
+      "marketCap": 213650000000
     },
     {
       "symbol": "DLR",
       "name": "Digital Realty",
-      "sector": "Real Estate"
+      "sector": "Real Estate",
+      "marketCap": 57570000000
     },
     {
       "symbol": "DLTR",
       "name": "Dollar Tree",
-      "sector": "Consumer Staples"
+      "sector": "Consumer Staples",
+      "marketCap": 22860000000
     },
     {
       "symbol": "DOC",
       "name": "Healthpeak Properties",
-      "sector": "Real Estate"
+      "sector": "Real Estate",
+      "marketCap": 12490000000
     },
     {
       "symbol": "DOV",
       "name": "Dover Corporation",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 24680000000
     },
     {
       "symbol": "DOW",
       "name": "Dow Inc.",
-      "sector": "Materials"
+      "sector": "Materials",
+      "marketCap": 17580000000
     },
     {
       "symbol": "DPZ",
       "name": "Domino's",
-      "sector": "Consumer Discretionary"
+      "sector": "Consumer Discretionary",
+      "marketCap": 15680000000
     },
     {
       "symbol": "DRI",
       "name": "Darden Restaurants",
-      "sector": "Consumer Discretionary"
+      "sector": "Consumer Discretionary",
+      "marketCap": 24080000000
     },
     {
       "symbol": "DTE",
       "name": "DTE Energy",
-      "sector": "Utilities"
+      "sector": "Utilities",
+      "marketCap": 28760000000
     },
     {
       "symbol": "DUK",
       "name": "Duke Energy",
-      "sector": "Utilities"
+      "sector": "Utilities",
+      "marketCap": 96270000000
     },
     {
       "symbol": "DVA",
       "name": "DaVita",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 9960000000
     },
     {
       "symbol": "DVN",
       "name": "Devon Energy",
-      "sector": "Energy"
+      "sector": "Energy",
+      "marketCap": 22710000000
     },
     {
       "symbol": "DXCM",
       "name": "Dexcom",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 30060000000
     },
     {
       "symbol": "EA",
       "name": "Electronic Arts",
-      "sector": "Communication Services"
+      "sector": "Communication Services",
+      "marketCap": 43430000000
     },
     {
       "symbol": "EBAY",
       "name": "eBay Inc.",
-      "sector": "Consumer Discretionary"
+      "sector": "Consumer Discretionary",
+      "marketCap": 41800000000
     },
     {
       "symbol": "ECL",
       "name": "Ecolab",
-      "sector": "Materials"
+      "sector": "Materials",
+      "marketCap": 78960000000
     },
     {
       "symbol": "ED",
       "name": "Consolidated Edison",
-      "sector": "Utilities"
+      "sector": "Utilities",
+      "marketCap": 36110000000
     },
     {
       "symbol": "EFX",
       "name": "Equifax",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 30760000000
     },
     {
       "symbol": "EG",
       "name": "Everest Group",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 14490000000
     },
     {
       "symbol": "EIX",
       "name": "Edison International",
-      "sector": "Utilities"
+      "sector": "Utilities",
+      "marketCap": 21860000000
     },
     {
       "symbol": "EL",
       "name": "Estée Lauder Companies (The)",
-      "sector": "Consumer Staples"
+      "sector": "Consumer Staples",
+      "marketCap": 33310000000
     },
     {
       "symbol": "ELV",
       "name": "Elevance Health",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 69900000000
     },
     {
       "symbol": "EMN",
       "name": "Eastman Chemical Company",
-      "sector": "Materials"
+      "sector": "Materials",
+      "marketCap": 8150000000
     },
     {
       "symbol": "EMR",
       "name": "Emerson Electric",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 73680000000
     },
     {
       "symbol": "ENPH",
       "name": "Enphase Energy",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 4930000000
     },
     {
       "symbol": "EOG",
       "name": "EOG Resources",
-      "sector": "Energy"
+      "sector": "Energy",
+      "marketCap": 67350000000
     },
     {
       "symbol": "EPAM",
       "name": "EPAM Systems",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 9790000000
     },
     {
       "symbol": "EQIX",
       "name": "Equinix",
-      "sector": "Real Estate"
+      "sector": "Real Estate",
+      "marketCap": 77350000000
     },
     {
       "symbol": "EQR",
       "name": "Equity Residential",
-      "sector": "Real Estate"
+      "sector": "Real Estate",
+      "marketCap": 25190000000
     },
     {
       "symbol": "EQT",
       "name": "EQT Corporation",
-      "sector": "Energy"
+      "sector": "Energy",
+      "marketCap": 31730000000
     },
     {
       "symbol": "ERIE",
       "name": "Erie Indemnity",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 18500000000
     },
     {
       "symbol": "ES",
       "name": "Eversource Energy",
-      "sector": "Utilities"
+      "sector": "Utilities",
+      "marketCap": 23960000000
     },
     {
       "symbol": "ESS",
       "name": "Essex Property Trust",
-      "sector": "Real Estate"
+      "sector": "Real Estate",
+      "marketCap": 17380000000
     },
     {
       "symbol": "ETN",
       "name": "Eaton Corporation",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 134410000000
     },
     {
       "symbol": "ETR",
       "name": "Entergy",
-      "sector": "Utilities"
+      "sector": "Utilities",
+      "marketCap": 39960000000
     },
     {
       "symbol": "EVRG",
       "name": "Evergy",
-      "sector": "Utilities"
+      "sector": "Utilities",
+      "marketCap": 16600000000
     },
     {
       "symbol": "EW",
       "name": "Edwards Lifesciences",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 47560000000
     },
     {
       "symbol": "EXC",
       "name": "Exelon",
-      "sector": "Utilities"
+      "sector": "Utilities",
+      "marketCap": 44750000000
     },
     {
       "symbol": "EXE",
       "name": "Expand Energy",
-      "sector": "Energy"
+      "sector": "Energy",
+      "marketCap": 22590000000
     },
     {
       "symbol": "EXPD",
       "name": "Expeditors International",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 16430000000
     },
     {
       "symbol": "EXPE",
       "name": "Expedia Group",
-      "sector": "Consumer Discretionary"
+      "sector": "Consumer Discretionary",
+      "marketCap": 26260000000
     },
     {
       "symbol": "EXR",
       "name": "Extra Space Storage",
-      "sector": "Real Estate"
+      "sector": "Real Estate",
+      "marketCap": 30310000000
     },
     {
       "symbol": "F",
       "name": "Ford Motor Company",
-      "sector": "Consumer Discretionary"
+      "sector": "Consumer Discretionary",
+      "marketCap": 47640000000
     },
     {
       "symbol": "FANG",
       "name": "Diamondback Energy",
-      "sector": "Energy"
+      "sector": "Energy",
+      "marketCap": 42450000000
     },
     {
       "symbol": "FAST",
       "name": "Fastenal",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 57010000000
     },
     {
       "symbol": "FCX",
       "name": "Freeport-McMoRan",
-      "sector": "Materials"
+      "sector": "Materials",
+      "marketCap": 63030000000
     },
     {
       "symbol": "FDS",
       "name": "FactSet",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 14280000000
     },
     {
       "symbol": "FDX",
       "name": "FedEx",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 54740000000
     },
     {
       "symbol": "FE",
       "name": "FirstEnergy",
-      "sector": "Utilities"
+      "sector": "Utilities",
+      "marketCap": 25310000000
     },
     {
       "symbol": "FFIV",
       "name": "F5, Inc.",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 17950000000
     },
     {
       "symbol": "FI",
       "name": "Fiserv",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 75290000000
     },
     {
       "symbol": "FICO",
       "name": "Fair Isaac",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 34420000000
     },
     {
       "symbol": "FIS",
       "name": "Fidelity National Information Services",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 36470000000
     },
     {
       "symbol": "FITB",
       "name": "Fifth Third Bancorp",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 30230000000
     },
     {
       "symbol": "FOX",
       "name": "Fox Corporation",
-      "sector": "Communication Services"
+      "sector": "Communication Services",
+      "marketCap": 25410000000
     },
     {
       "symbol": "FOXA",
       "name": "Fox Corporation",
-      "sector": "Communication Services"
+      "sector": "Communication Services",
+      "marketCap": 25410000000
     },
     {
       "symbol": "FRT",
       "name": "Federal Realty Investment Trust",
-      "sector": "Real Estate"
+      "sector": "Real Estate",
+      "marketCap": 8710000000
     },
     {
       "symbol": "FSLR",
       "name": "First Solar",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 20320000000
     },
     {
       "symbol": "FTNT",
       "name": "Fortinet",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 59480000000
     },
     {
       "symbol": "FTV",
       "name": "Fortive",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 16380000000
     },
     {
       "symbol": "GD",
       "name": "General Dynamics",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 87450000000
     },
     {
       "symbol": "GDDY",
       "name": "GoDaddy",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 20530000000
     },
     {
       "symbol": "GE",
       "name": "GE Aerospace",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 289030000000
     },
     {
       "symbol": "GEHC",
       "name": "GE HealthCare",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 33910000000
     },
     {
       "symbol": "GEN",
       "name": "Gen Digital",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 18930000000
     },
     {
       "symbol": "GEV",
       "name": "GE Vernova",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 163890000000
     },
     {
       "symbol": "GILD",
       "name": "Gilead Sciences",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 141870000000
     },
     {
       "symbol": "GIS",
       "name": "General Mills",
-      "sector": "Consumer Staples"
+      "sector": "Consumer Staples",
+      "marketCap": 26820000000
     },
     {
       "symbol": "GL",
       "name": "Globe Life",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 11340000000
     },
     {
       "symbol": "GLW",
       "name": "Corning Inc.",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 56020000000
     },
     {
       "symbol": "GM",
       "name": "General Motors",
-      "sector": "Consumer Discretionary"
+      "sector": "Consumer Discretionary",
+      "marketCap": 56030000000
     },
     {
       "symbol": "GNRC",
       "name": "Generac",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 10870000000
     },
     {
       "symbol": "GOOG",
       "name": "Alphabet Inc.",
-      "sector": "Communication Services"
+      "sector": "Communication Services",
+      "marketCap": 2530000000000
     },
     {
       "symbol": "GOOGL",
       "name": "Alphabet Inc.",
-      "sector": "Communication Services"
+      "sector": "Communication Services",
+      "marketCap": 2530000000000
     },
     {
       "symbol": "GPC",
       "name": "Genuine Parts Company",
-      "sector": "Consumer Discretionary"
+      "sector": "Consumer Discretionary",
+      "marketCap": 19450000000
     },
     {
       "symbol": "GPN",
       "name": "Global Payments",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 21460000000
     },
     {
       "symbol": "GRMN",
       "name": "Garmin",
-      "sector": "Consumer Discretionary"
+      "sector": "Consumer Discretionary",
+      "marketCap": 45480000000
     },
     {
       "symbol": "GS",
       "name": "Goldman Sachs",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 225140000000
     },
     {
       "symbol": "GWW",
       "name": "W. W. Grainger",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 48600000000
     },
     {
       "symbol": "HAL",
       "name": "Halliburton",
-      "sector": "Energy"
+      "sector": "Energy",
+      "marketCap": 19100000000
     },
     {
       "symbol": "HAS",
       "name": "Hasbro",
-      "sector": "Consumer Discretionary"
+      "sector": "Consumer Discretionary",
+      "marketCap": 11380000000
     },
     {
       "symbol": "HBAN",
       "name": "Huntington Bancshares",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 26110000000
     },
     {
       "symbol": "HCA",
       "name": "HCA Healthcare",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": null
     },
     {
       "symbol": "HD",
       "name": "Home Depot (The)",
-      "sector": "Consumer Discretionary"
+      "sector": "Consumer Discretionary",
+      "marketCap": 405680000000
     },
     {
       "symbol": "HIG",
       "name": "Hartford (The)",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 37440000000
     },
     {
       "symbol": "HII",
       "name": "Huntington Ingalls Industries",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 10670000000
     },
     {
       "symbol": "HLT",
       "name": "Hilton Worldwide",
-      "sector": "Consumer Discretionary"
+      "sector": "Consumer Discretionary",
+      "marketCap": 64950000000
     },
     {
       "symbol": "HOLX",
       "name": "Hologic",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 14950000000
     },
     {
       "symbol": "HON",
       "name": "Honeywell",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 139300000000
     },
     {
       "symbol": "HPE",
       "name": "Hewlett Packard Enterprise",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 29070000000
     },
     {
       "symbol": "HPQ",
       "name": "HP Inc.",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 25630000000
     },
     {
       "symbol": "HRL",
       "name": "Hormel Foods",
-      "sector": "Consumer Staples"
+      "sector": "Consumer Staples",
+      "marketCap": 16100000000
     },
     {
       "symbol": "HSIC",
       "name": "Henry Schein",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 8430000000
     },
     {
       "symbol": "HST",
       "name": "Host Hotels & Resorts",
-      "sector": "Real Estate"
+      "sector": "Real Estate",
+      "marketCap": 11890000000
     },
     {
       "symbol": "HSY",
       "name": "Hershey Company (The)",
-      "sector": "Consumer Staples"
+      "sector": "Consumer Staples",
+      "marketCap": 37600000000
     },
     {
       "symbol": "HUBB",
       "name": "Hubbell Incorporated",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 22920000000
     },
     {
       "symbol": "HUM",
       "name": "Humana",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 36440000000
     },
     {
       "symbol": "HWM",
       "name": "Howmet Aerospace",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 69980000000
     },
     {
       "symbol": "IBKR",
       "name": "Interactive Brokers",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 104130000000
     },
     {
       "symbol": "IBM",
       "name": "IBM",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 225990000000
     },
     {
       "symbol": "ICE",
       "name": "Intercontinental Exchange",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 101180000000
     },
     {
       "symbol": "IDXX",
       "name": "Idexx Laboratories",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 51280000000
     },
     {
       "symbol": "IEX",
       "name": "IDEX Corporation",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 12450000000
     },
     {
       "symbol": "IFF",
       "name": "International Flavors & Fragrances",
-      "sector": "Materials"
+      "sector": "Materials",
+      "marketCap": 17220000000
     },
     {
       "symbol": "INCY",
       "name": "Incyte",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 16750000000
     },
     {
       "symbol": "INTC",
       "name": "Intel",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 106240000000
     },
     {
       "symbol": "INTU",
       "name": "Intuit",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 184660000000
     },
     {
       "symbol": "INVH",
       "name": "Invitation Homes",
-      "sector": "Real Estate"
+      "sector": "Real Estate",
+      "marketCap": 19300000000
     },
     {
       "symbol": "IP",
       "name": "International Paper",
-      "sector": "Materials"
+      "sector": "Materials",
+      "marketCap": 25910000000
     },
     {
       "symbol": "IPG",
       "name": "Interpublic Group of Companies (The)",
-      "sector": "Communication Services"
+      "sector": "Communication Services",
+      "marketCap": 9900000000
     },
     {
       "symbol": "IQV",
       "name": "IQVIA",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 32450000000
     },
     {
       "symbol": "IR",
       "name": "Ingersoll Rand",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 31720000000
     },
     {
       "symbol": "IRM",
       "name": "Iron Mountain",
-      "sector": "Real Estate"
+      "sector": "Real Estate",
+      "marketCap": 27240000000
     },
     {
       "symbol": "ISRG",
       "name": "Intuitive Surgical",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 168700000000
     },
     {
       "symbol": "IT",
       "name": "Gartner",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 18920000000
     },
     {
       "symbol": "ITW",
       "name": "Illinois Tool Works",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 77460000000
     },
     {
       "symbol": "IVZ",
       "name": "Invesco",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 9760000000
     },
     {
       "symbol": "J",
       "name": "Jacobs Solutions",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 17650000000
     },
     {
       "symbol": "JBHT",
       "name": "J.B. Hunt",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 14210000000
     },
     {
       "symbol": "JBL",
       "name": "Jabil",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 21780000000
     },
     {
       "symbol": "JCI",
       "name": "Johnson Controls",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 70350000000
     },
     {
       "symbol": "JKHY",
       "name": "Jack Henry & Associates",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 11890000000
     },
     {
       "symbol": "JNJ",
       "name": "Johnson & Johnson",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 429940000000
     },
     {
       "symbol": "JPM",
       "name": "JPMorgan Chase",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 823900000000
     },
     {
       "symbol": "K",
       "name": "Kellanova",
-      "sector": "Consumer Staples"
+      "sector": "Consumer Staples",
+      "marketCap": 27770000000
     },
     {
       "symbol": "KDP",
       "name": "Keurig Dr Pepper",
-      "sector": "Consumer Staples"
+      "sector": "Consumer Staples",
+      "marketCap": 40100000000
     },
     {
       "symbol": "KEY",
       "name": "KeyCorp",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 21270000000
     },
     {
       "symbol": "KEYS",
       "name": "Keysight Technologies",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 27820000000
     },
     {
       "symbol": "KHC",
       "name": "Kraft Heinz",
-      "sector": "Consumer Staples"
+      "sector": "Consumer Staples",
+      "marketCap": 33010000000
     },
     {
       "symbol": "KIM",
       "name": "Kimco Realty",
-      "sector": "Real Estate"
+      "sector": "Real Estate",
+      "marketCap": 15220000000
     },
     {
       "symbol": "KKR",
       "name": "KKR & Co.",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 124620000000
     },
     {
       "symbol": "KLAC",
       "name": "KLA Corporation",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 114410000000
     },
     {
       "symbol": "KMB",
       "name": "Kimberly-Clark",
-      "sector": "Consumer Staples"
+      "sector": "Consumer Staples",
+      "marketCap": 43340000000
     },
     {
       "symbol": "KMI",
       "name": "Kinder Morgan",
-      "sector": "Energy"
+      "sector": "Energy",
+      "marketCap": 59550000000
     },
     {
       "symbol": "KMX",
       "name": "CarMax",
-      "sector": "Consumer Discretionary"
+      "sector": "Consumer Discretionary",
+      "marketCap": 9190000000
     },
     {
       "symbol": "KO",
       "name": "Coca-Cola Company (The)",
-      "sector": "Consumer Staples"
+      "sector": "Consumer Staples",
+      "marketCap": 298950000000
     },
     {
       "symbol": "KR",
       "name": "Kroger",
-      "sector": "Consumer Staples"
+      "sector": "Consumer Staples",
+      "marketCap": 45200000000
     },
     {
       "symbol": "KVUE",
       "name": "Kenvue",
-      "sector": "Consumer Staples"
+      "sector": "Consumer Staples",
+      "marketCap": 40150000000
     },
     {
       "symbol": "L",
       "name": "Loews Corporation",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 20050000000
     },
     {
       "symbol": "LDOS",
       "name": "Leidos",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 23470000000
     },
     {
       "symbol": "LEN",
       "name": "Lennar",
-      "sector": "Consumer Discretionary"
+      "sector": "Consumer Discretionary",
+      "marketCap": 34360000000
     },
     {
       "symbol": "LH",
       "name": "Labcorp",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 23440000000
     },
     {
       "symbol": "LHX",
       "name": "L3Harris",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 51890000000
     },
     {
       "symbol": "LII",
       "name": "Lennox International",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 19860000000
     },
     {
       "symbol": "LIN",
       "name": "Linde plc",
-      "sector": "Materials"
+      "sector": "Materials",
+      "marketCap": 224540000000
     },
     {
       "symbol": "LKQ",
       "name": "LKQ Corporation",
-      "sector": "Consumer Discretionary"
+      "sector": "Consumer Discretionary",
+      "marketCap": 8350000000
     },
     {
       "symbol": "LLY",
       "name": "Lilly (Eli)",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 695450000000
     },
     {
       "symbol": "LMT",
       "name": "Lockheed Martin",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 105970000000
     },
     {
       "symbol": "LNT",
       "name": "Alliant Energy",
-      "sector": "Utilities"
+      "sector": "Utilities",
+      "marketCap": 16920000000
     },
     {
       "symbol": "LOW",
       "name": "Lowe's",
-      "sector": "Consumer Discretionary"
+      "sector": "Consumer Discretionary",
+      "marketCap": 145410000000
     },
     {
       "symbol": "LRCX",
       "name": "Lam Research",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 126240000000
     },
     {
       "symbol": "LULU",
       "name": "Lululemon Athletica",
-      "sector": "Consumer Discretionary"
+      "sector": "Consumer Discretionary",
+      "marketCap": 24290000000
     },
     {
       "symbol": "LUV",
       "name": "Southwest Airlines",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 17390000000
     },
     {
       "symbol": "LVS",
       "name": "Las Vegas Sands",
-      "sector": "Consumer Discretionary"
+      "sector": "Consumer Discretionary",
+      "marketCap": 38870000000
     },
     {
       "symbol": "LW",
       "name": "Lamb Weston",
-      "sector": "Consumer Staples"
+      "sector": "Consumer Staples",
+      "marketCap": 8080000000
     },
     {
       "symbol": "LYB",
       "name": "LyondellBasell",
-      "sector": "Materials"
+      "sector": "Materials",
+      "marketCap": 18260000000
     },
     {
       "symbol": "LYV",
       "name": "Live Nation Entertainment",
-      "sector": "Communication Services"
+      "sector": "Communication Services",
+      "marketCap": 38790000000
     },
     {
       "symbol": "MA",
       "name": "Mastercard",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 538310000000
     },
     {
       "symbol": "MAA",
       "name": "Mid-America Apartment Communities",
-      "sector": "Real Estate"
+      "sector": "Real Estate",
+      "marketCap": 17110000000
     },
     {
       "symbol": "MAR",
       "name": "Marriott International",
-      "sector": "Consumer Discretionary"
+      "sector": "Consumer Discretionary",
+      "marketCap": 72560000000
     },
     {
       "symbol": "MAS",
       "name": "Masco",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 15570000000
     },
     {
       "symbol": "MCD",
       "name": "McDonald's",
-      "sector": "Consumer Discretionary"
+      "sector": "Consumer Discretionary",
+      "marketCap": 223180000000
     },
     {
       "symbol": "MCHP",
       "name": "Microchip Technology",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 35830000000
     },
     {
       "symbol": "MCK",
       "name": "McKesson Corporation",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 85720000000
     },
     {
       "symbol": "MCO",
       "name": "Moody's Corporation",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 91570000000
     },
     {
       "symbol": "MDLZ",
       "name": "Mondelez International",
-      "sector": "Consumer Staples"
+      "sector": "Consumer Staples",
+      "marketCap": 80120000000
     },
     {
       "symbol": "MDT",
       "name": "Medtronic",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 119160000000
     },
     {
       "symbol": "MET",
       "name": "MetLife",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 54310000000
     },
     {
       "symbol": "META",
       "name": "Meta Platforms",
-      "sector": "Communication Services"
+      "sector": "Communication Services",
+      "marketCap": 1850000000000
     },
     {
       "symbol": "MGM",
       "name": "MGM Resorts",
-      "sector": "Consumer Discretionary"
+      "sector": "Consumer Discretionary",
+      "marketCap": 10850000000
     },
     {
       "symbol": "MHK",
       "name": "Mohawk Industries",
-      "sector": "Consumer Discretionary"
+      "sector": "Consumer Discretionary",
+      "marketCap": 8230000000
     },
     {
       "symbol": "MKC",
       "name": "McCormick & Company",
-      "sector": "Consumer Staples"
+      "sector": "Consumer Staples",
+      "marketCap": 19100000000
     },
     {
       "symbol": "MKTX",
       "name": "MarketAxess",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 7060000000
     },
     {
       "symbol": "MLM",
       "name": "Martin Marietta Materials",
-      "sector": "Materials"
+      "sector": "Materials",
+      "marketCap": 37440000000
     },
     {
       "symbol": "MMC",
       "name": "Marsh McLennan",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 101150000000
     },
     {
       "symbol": "MMM",
       "name": "3M",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 82300000000
     },
     {
       "symbol": "MNST",
       "name": "Monster Beverage",
-      "sector": "Consumer Staples"
+      "sector": "Consumer Staples",
+      "marketCap": 60650000000
     },
     {
       "symbol": "MO",
       "name": "Altria",
-      "sector": "Consumer Staples"
+      "sector": "Consumer Staples",
+      "marketCap": 112890000000
     },
     {
       "symbol": "MOH",
       "name": "Molina Healthcare",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 9880000000
     },
     {
       "symbol": "MOS",
       "name": "Mosaic Company (The)",
-      "sector": "Materials"
+      "sector": "Materials",
+      "marketCap": 10460000000
     },
     {
       "symbol": "MPC",
       "name": "Marathon Petroleum",
-      "sector": "Energy"
+      "sector": "Energy",
+      "marketCap": 54210000000
     },
     {
       "symbol": "MPWR",
       "name": "Monolithic Power Systems",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 40390000000
     },
     {
       "symbol": "MRK",
       "name": "Merck & Co.",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 212290000000
     },
     {
       "symbol": "MRNA",
       "name": "Moderna",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 9610000000
     },
     {
       "symbol": "MS",
       "name": "Morgan Stanley",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 238940000000
     },
     {
       "symbol": "MSCI",
       "name": "MSCI Inc.",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 44050000000
     },
     {
       "symbol": "MSFT",
       "name": "Microsoft",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 3740000000000
     },
     {
       "symbol": "MSI",
       "name": "Motorola Solutions",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 77760000000
     },
     {
       "symbol": "MTB",
       "name": "M&T Bank",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 31700000000
     },
     {
       "symbol": "MTCH",
       "name": "Match Group",
-      "sector": "Communication Services"
+      "sector": "Communication Services",
+      "marketCap": 9080000000
     },
     {
       "symbol": "MTD",
       "name": "Mettler Toledo",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 26840000000
     },
     {
       "symbol": "MU",
       "name": "Micron Technology",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 128550000000
     },
     {
       "symbol": "NCLH",
       "name": "Norwegian Cruise Line Holdings",
-      "sector": "Consumer Discretionary"
+      "sector": "Consumer Discretionary",
+      "marketCap": 11000000000
     },
     {
       "symbol": "NDAQ",
       "name": "Nasdaq, Inc.",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 54130000000
     },
     {
       "symbol": "NDSN",
       "name": "Nordson Corporation",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 12680000000
     },
     {
       "symbol": "NEE",
       "name": "NextEra Energy",
-      "sector": "Utilities"
+      "sector": "Utilities",
+      "marketCap": 152080000000
     },
     {
       "symbol": "NEM",
       "name": "Newmont",
-      "sector": "Materials"
+      "sector": "Materials",
+      "marketCap": 81080000000
     },
     {
       "symbol": "NFLX",
       "name": "Netflix",
-      "sector": "Communication Services"
+      "sector": "Communication Services",
+      "marketCap": 510100000000
     },
     {
       "symbol": "NI",
       "name": "NiSource",
-      "sector": "Utilities"
+      "sector": "Utilities",
+      "marketCap": 20040000000
     },
     {
       "symbol": "NKE",
       "name": "Nike, Inc.",
-      "sector": "Consumer Discretionary"
+      "sector": "Consumer Discretionary",
+      "marketCap": 114470000000
     },
     {
       "symbol": "NOC",
       "name": "Northrop Grumman",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 84300000000
     },
     {
       "symbol": "NOW",
       "name": "ServiceNow",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 182480000000
     },
     {
       "symbol": "NRG",
       "name": "NRG Energy",
-      "sector": "Utilities"
+      "sector": "Utilities",
+      "marketCap": 28050000000
     },
     {
       "symbol": "NSC",
       "name": "Norfolk Southern",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 61580000000
     },
     {
       "symbol": "NTAP",
       "name": "NetApp",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 21590000000
     },
     {
       "symbol": "NTRS",
       "name": "Northern Trust",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 25220000000
     },
     {
       "symbol": "NUE",
       "name": "Nucor",
-      "sector": "Materials"
+      "sector": "Materials",
+      "marketCap": 34260000000
     },
     {
       "symbol": "NVDA",
       "name": "Nvidia",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 4280000000000
     },
     {
       "symbol": "NVR",
       "name": "NVR, Inc.",
-      "sector": "Consumer Discretionary"
+      "sector": "Consumer Discretionary",
+      "marketCap": 23180000000
     },
     {
       "symbol": "NWS",
       "name": "News Corp",
-      "sector": "Communication Services"
+      "sector": "Communication Services",
+      "marketCap": 17600000000
     },
     {
       "symbol": "NWSA",
       "name": "News Corp",
-      "sector": "Communication Services"
+      "sector": "Communication Services",
+      "marketCap": 17600000000
     },
     {
       "symbol": "NXPI",
       "name": "NXP Semiconductors",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 58860000000
     },
     {
       "symbol": "O",
       "name": "Realty Income",
-      "sector": "Real Estate"
+      "sector": "Real Estate",
+      "marketCap": 54110000000
     },
     {
       "symbol": "ODFL",
       "name": "Old Dominion",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 32600000000
     },
     {
       "symbol": "OKE",
       "name": "Oneok",
-      "sector": "Energy"
+      "sector": "Energy",
+      "marketCap": 47590000000
     },
     {
       "symbol": "OMC",
       "name": "Omnicom Group",
-      "sector": "Communication Services"
+      "sector": "Communication Services",
+      "marketCap": 15320000000
     },
     {
       "symbol": "ON",
       "name": "ON Semiconductor",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 20470000000
     },
     {
       "symbol": "ORCL",
       "name": "Oracle Corporation",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 623240000000
     },
     {
       "symbol": "ORLY",
       "name": "O’Reilly Automotive",
-      "sector": "Consumer Discretionary"
+      "sector": "Consumer Discretionary",
+      "marketCap": 88020000000
     },
     {
       "symbol": "OTIS",
       "name": "Otis Worldwide",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 34480000000
     },
     {
       "symbol": "OXY",
       "name": "Occidental Petroleum",
-      "sector": "Energy"
+      "sector": "Energy",
+      "marketCap": 46240000000
     },
     {
       "symbol": "PANW",
       "name": "Palo Alto Networks",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 124980000000
     },
     {
       "symbol": "PAYC",
       "name": "Paycom",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 12900000000
     },
     {
       "symbol": "PAYX",
       "name": "Paychex",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 49950000000
     },
     {
       "symbol": "PCAR",
       "name": "Paccar",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 53270000000
     },
     {
       "symbol": "PCG",
       "name": "PG&E Corporation",
-      "sector": "Utilities"
+      "sector": "Utilities",
+      "marketCap": 33780000000
     },
     {
       "symbol": "PEG",
       "name": "Public Service Enterprise Group",
-      "sector": "Utilities"
+      "sector": "Utilities",
+      "marketCap": 41210000000
     },
     {
       "symbol": "PEP",
       "name": "PepsiCo",
-      "sector": "Consumer Staples"
+      "sector": "Consumer Staples",
+      "marketCap": 204430000000
     },
     {
       "symbol": "PFE",
       "name": "Pfizer",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 143460000000
     },
     {
       "symbol": "PFG",
       "name": "Principal Financial Group",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 18070000000
     },
     {
       "symbol": "PG",
       "name": "Procter & Gamble",
-      "sector": "Consumer Staples"
+      "sector": "Consumer Staples",
+      "marketCap": 370940000000
     },
     {
       "symbol": "PGR",
       "name": "Progressive Corporation",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 144040000000
     },
     {
       "symbol": "PH",
       "name": "Parker Hannifin",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 96350000000
     },
     {
       "symbol": "PHM",
       "name": "PulteGroup",
-      "sector": "Consumer Discretionary"
+      "sector": "Consumer Discretionary",
+      "marketCap": 25960000000
     },
     {
       "symbol": "PKG",
       "name": "Packaging Corporation of America",
-      "sector": "Materials"
+      "sector": "Materials",
+      "marketCap": 19070000000
     },
     {
       "symbol": "PLD",
       "name": "Prologis",
-      "sector": "Real Estate"
+      "sector": "Real Estate",
+      "marketCap": 105630000000
     },
     {
       "symbol": "PLTR",
       "name": "Palantir Technologies",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 368320000000
     },
     {
       "symbol": "PM",
       "name": "Philip Morris International",
-      "sector": "Consumer Staples"
+      "sector": "Consumer Staples",
+      "marketCap": 257670000000
     },
     {
       "symbol": "PNC",
       "name": "PNC Financial Services",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 81860000000
     },
     {
       "symbol": "PNR",
       "name": "Pentair",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 17650000000
     },
     {
       "symbol": "PNW",
       "name": "Pinnacle West Capital",
-      "sector": "Utilities"
+      "sector": "Utilities",
+      "marketCap": 10800000000
     },
     {
       "symbol": "PODD",
       "name": "Insulet Corporation",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 23690000000
     },
     {
       "symbol": "POOL",
       "name": "Pool Corporation",
-      "sector": "Consumer Discretionary"
+      "sector": "Consumer Discretionary",
+      "marketCap": 11700000000
     },
     {
       "symbol": "PPG",
       "name": "PPG Industries",
-      "sector": "Materials"
+      "sector": "Materials",
+      "marketCap": 25310000000
     },
     {
       "symbol": "PPL",
       "name": "PPL Corporation",
-      "sector": "Utilities"
+      "sector": "Utilities",
+      "marketCap": 27010000000
     },
     {
       "symbol": "PRU",
       "name": "Prudential Financial",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 38860000000
     },
     {
       "symbol": "PSA",
       "name": "Public Storage",
-      "sector": "Real Estate"
+      "sector": "Real Estate",
+      "marketCap": 51600000000
     },
     {
       "symbol": "PSKY",
       "name": "Paramount Skydance Corporation",
-      "sector": "Communication Services"
+      "sector": "Communication Services",
+      "marketCap": 9380000000
     },
     {
       "symbol": "PSX",
       "name": "Phillips 66",
-      "sector": "Energy"
+      "sector": "Energy",
+      "marketCap": 53900000000
     },
     {
       "symbol": "PTC",
       "name": "PTC Inc.",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 25940000000
     },
     {
       "symbol": "PWR",
       "name": "Quanta Services",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 55680000000
     },
     {
       "symbol": "PYPL",
       "name": "PayPal",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 66540000000
     },
     {
       "symbol": "QCOM",
       "name": "Qualcomm",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 172320000000
     },
     {
       "symbol": "RCL",
       "name": "Royal Caribbean Group",
-      "sector": "Consumer Discretionary"
+      "sector": "Consumer Discretionary",
+      "marketCap": 96830000000
     },
     {
       "symbol": "REG",
       "name": "Regency Centers",
-      "sector": "Real Estate"
+      "sector": "Real Estate",
+      "marketCap": 13210000000
     },
     {
       "symbol": "REGN",
       "name": "Regeneron Pharmaceuticals",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 62210000000
     },
     {
       "symbol": "RF",
       "name": "Regions Financial Corporation",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 24510000000
     },
     {
       "symbol": "RJF",
       "name": "Raymond James Financial",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 33630000000
     },
     {
       "symbol": "RL",
       "name": "Ralph Lauren Corporation",
-      "sector": "Consumer Discretionary"
+      "sector": "Consumer Discretionary",
+      "marketCap": 17810000000
     },
     {
       "symbol": "RMD",
       "name": "ResMed",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 41150000000
     },
     {
       "symbol": "ROK",
       "name": "Rockwell Automation",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 38620000000
     },
     {
       "symbol": "ROL",
       "name": "Rollins, Inc.",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 27610000000
     },
     {
       "symbol": "ROP",
       "name": "Roper Technologies",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 56860000000
     },
     {
       "symbol": "ROST",
       "name": "Ross Stores",
-      "sector": "Consumer Discretionary"
+      "sector": "Consumer Discretionary",
+      "marketCap": 48530000000
     },
     {
       "symbol": "RSG",
       "name": "Republic Services",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 73610000000
     },
     {
       "symbol": "RTX",
       "name": "RTX Corporation",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 211210000000
     },
     {
       "symbol": "RVTY",
       "name": "Revvity",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 10360000000
     },
     {
       "symbol": "SBAC",
       "name": "SBA Communications",
-      "sector": "Real Estate"
+      "sector": "Real Estate",
+      "marketCap": 22350000000
     },
     {
       "symbol": "SBUX",
       "name": "Starbucks",
-      "sector": "Consumer Discretionary"
+      "sector": "Consumer Discretionary",
+      "marketCap": 99640000000
     },
     {
       "symbol": "SCHW",
       "name": "Charles Schwab Corporation",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 173580000000
     },
     {
       "symbol": "SHW",
       "name": "Sherwin-Williams",
-      "sector": "Materials"
+      "sector": "Materials",
+      "marketCap": 91520000000
     },
     {
       "symbol": "SJM",
       "name": "J.M. Smucker Company (The)",
-      "sector": "Consumer Staples"
+      "sector": "Consumer Staples",
+      "marketCap": 11670000000
     },
     {
       "symbol": "SLB",
       "name": "Schlumberger",
-      "sector": "Energy"
+      "sector": "Energy",
+      "marketCap": 54210000000
     },
     {
       "symbol": "SMCI",
       "name": "Supermicro",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 25240000000
     },
     {
       "symbol": "SNA",
       "name": "Snap-on",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 17120000000
     },
     {
       "symbol": "SNPS",
       "name": "Synopsys",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 110000000000
     },
     {
       "symbol": "SO",
       "name": "Southern Company",
-      "sector": "Utilities"
+      "sector": "Utilities",
+      "marketCap": 102680000000
     },
     {
       "symbol": "SOLV",
       "name": "Solventum",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 12710000000
     },
     {
       "symbol": "SPG",
       "name": "Simon Property Group",
-      "sector": "Real Estate"
+      "sector": "Real Estate",
+      "marketCap": 58590000000
     },
     {
       "symbol": "SPGI",
       "name": "S&P Global",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 167170000000
     },
     {
       "symbol": "SRE",
       "name": "Sempra",
-      "sector": "Utilities"
+      "sector": "Utilities",
+      "marketCap": 54410000000
     },
     {
       "symbol": "STE",
       "name": "Steris",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 24550000000
     },
     {
       "symbol": "STLD",
       "name": "Steel Dynamics",
-      "sector": "Materials"
+      "sector": "Materials",
+      "marketCap": 19530000000
     },
     {
       "symbol": "STT",
       "name": "State Street Corporation",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 32510000000
     },
     {
       "symbol": "STX",
       "name": "Seagate Technology",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 35570000000
     },
     {
       "symbol": "STZ",
       "name": "Constellation Brands",
-      "sector": "Consumer Staples"
+      "sector": "Consumer Staples",
+      "marketCap": 28800000000
     },
     {
       "symbol": "SW",
       "name": "Smurfit Westrock",
-      "sector": "Materials"
+      "sector": "Materials",
+      "marketCap": 24340000000
     },
     {
       "symbol": "SWK",
       "name": "Stanley Black & Decker",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 11570000000
     },
     {
       "symbol": "SWKS",
       "name": "Skyworks Solutions",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 11290000000
     },
     {
       "symbol": "SYF",
       "name": "Synchrony Financial",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 28100000000
     },
     {
       "symbol": "SYK",
       "name": "Stryker Corporation",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 150980000000
     },
     {
       "symbol": "SYY",
       "name": "Sysco",
-      "sector": "Consumer Staples"
+      "sector": "Consumer Staples",
+      "marketCap": 38830000000
     },
     {
       "symbol": "T",
       "name": "AT&T",
-      "sector": "Communication Services"
+      "sector": "Communication Services",
+      "marketCap": 210300000000
     },
     {
       "symbol": "TAP",
       "name": "Molson Coors Beverage Company",
-      "sector": "Consumer Staples"
+      "sector": "Consumer Staples",
+      "marketCap": 9670000000
     },
     {
       "symbol": "TDG",
       "name": "TransDigm Group",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 78660000000
     },
     {
       "symbol": "TDY",
       "name": "Teledyne Technologies",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 25200000000
     },
     {
       "symbol": "TECH",
       "name": "Bio-Techne",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 8790000000
     },
     {
       "symbol": "TEL",
       "name": "TE Connectivity",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 60880000000
     },
     {
       "symbol": "TER",
       "name": "Teradyne",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 18670000000
     },
     {
       "symbol": "TFC",
       "name": "Truist Financial",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 60360000000
     },
     {
       "symbol": "TGT",
       "name": "Target Corporation",
-      "sector": "Consumer Staples"
+      "sector": "Consumer Staples",
+      "marketCap": 44130000000
     },
     {
       "symbol": "TJX",
       "name": "TJX Companies",
-      "sector": "Consumer Discretionary"
+      "sector": "Consumer Discretionary",
+      "marketCap": 152530000000
     },
     {
       "symbol": "TKO",
       "name": "TKO Group Holdings",
-      "sector": "Communication Services"
+      "sector": "Communication Services",
+      "marketCap": 36700000000
     },
     {
       "symbol": "TMO",
       "name": "Thermo Fisher Scientific",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 185440000000
     },
     {
       "symbol": "TMUS",
       "name": "T-Mobile US",
-      "sector": "Communication Services"
+      "sector": "Communication Services",
+      "marketCap": 284500000000
     },
     {
       "symbol": "TPL",
       "name": "Texas Pacific Land Corporation",
-      "sector": "Energy"
+      "sector": "Energy",
+      "marketCap": 21150000000
     },
     {
       "symbol": "TPR",
       "name": "Tapestry, Inc.",
-      "sector": "Consumer Discretionary"
+      "sector": "Consumer Discretionary",
+      "marketCap": 20850000000
     },
     {
       "symbol": "TRGP",
       "name": "Targa Resources",
-      "sector": "Energy"
+      "sector": "Energy",
+      "marketCap": 35710000000
     },
     {
       "symbol": "TRMB",
       "name": "Trimble Inc.",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 19560000000
     },
     {
       "symbol": "TROW",
       "name": "T. Rowe Price",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 24030000000
     },
     {
       "symbol": "TRV",
       "name": "Travelers Companies (The)",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 61560000000
     },
     {
       "symbol": "TSCO",
       "name": "Tractor Supply",
-      "sector": "Consumer Discretionary"
+      "sector": "Consumer Discretionary",
+      "marketCap": 32590000000
     },
     {
       "symbol": "TSLA",
       "name": "Tesla, Inc.",
-      "sector": "Consumer Discretionary"
+      "sector": "Consumer Discretionary",
+      "marketCap": 1050000000000
     },
     {
       "symbol": "TSN",
       "name": "Tyson Foods",
-      "sector": "Consumer Staples"
+      "sector": "Consumer Staples",
+      "marketCap": 20670000000
     },
     {
       "symbol": "TT",
       "name": "Trane Technologies",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 92410000000
     },
     {
       "symbol": "TTD",
       "name": "Trade Desk (The)",
-      "sector": "Communication Services"
+      "sector": "Communication Services",
+      "marketCap": 25420000000
     },
     {
       "symbol": "TTWO",
       "name": "Take-Two Interactive",
-      "sector": "Communication Services"
+      "sector": "Communication Services",
+      "marketCap": 42510000000
     },
     {
       "symbol": "TXN",
       "name": "Texas Instruments",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 186800000000
     },
     {
       "symbol": "TXT",
       "name": "Textron",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 14540000000
     },
     {
       "symbol": "TYL",
       "name": "Tyler Technologies",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 24550000000
     },
     {
       "symbol": "UAL",
       "name": "United Airlines Holdings",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 33710000000
     },
     {
       "symbol": "UBER",
       "name": "Uber",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 194220000000
     },
     {
       "symbol": "UDR",
       "name": "UDR, Inc.",
-      "sector": "Real Estate"
+      "sector": "Real Estate",
+      "marketCap": 13100000000
     },
     {
       "symbol": "UHS",
       "name": "Universal Health Services",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 11630000000
     },
     {
       "symbol": "ULTA",
       "name": "Ulta Beauty",
-      "sector": "Consumer Discretionary"
+      "sector": "Consumer Discretionary",
+      "marketCap": 23990000000
     },
     {
       "symbol": "UNH",
       "name": "UnitedHealth Group",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 282120000000
     },
     {
       "symbol": "UNP",
       "name": "Union Pacific Corporation",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 131750000000
     },
     {
       "symbol": "UPS",
       "name": "United Parcel Service",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 74610000000
     },
     {
       "symbol": "URI",
       "name": "United Rentals",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 61150000000
     },
     {
       "symbol": "USB",
       "name": "U.S. Bancorp",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 76130000000
     },
     {
       "symbol": "V",
       "name": "Visa Inc.",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 678690000000
     },
     {
       "symbol": "VICI",
       "name": "Vici Properties",
-      "sector": "Real Estate"
+      "sector": "Real Estate",
+      "marketCap": 36280000000
     },
     {
       "symbol": "VLO",
       "name": "Valero Energy",
-      "sector": "Energy"
+      "sector": "Energy",
+      "marketCap": 47100000000
     },
     {
       "symbol": "VLTO",
       "name": "Veralto",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 26570000000
     },
     {
       "symbol": "VMC",
       "name": "Vulcan Materials Company",
-      "sector": "Materials"
+      "sector": "Materials",
+      "marketCap": 38470000000
     },
     {
       "symbol": "VRSK",
       "name": "Verisk Analytics",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 37400000000
     },
     {
       "symbol": "VRSN",
       "name": "Verisign",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 25570000000
     },
     {
       "symbol": "VRTX",
       "name": "Vertex Pharmaceuticals",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 99490000000
     },
     {
       "symbol": "VST",
       "name": "Vistra Corp",
-      "sector": "Utilities"
+      "sector": "Utilities",
+      "marketCap": 63390000000
     },
     {
       "symbol": "VTR",
       "name": "Ventas",
-      "sector": "Real Estate"
+      "sector": "Real Estate",
+      "marketCap": 31090000000
     },
     {
       "symbol": "VTRS",
       "name": "Viatris",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 12310000000
     },
     {
       "symbol": "VZ",
       "name": "Verizon",
-      "sector": "Communication Services"
+      "sector": "Communication Services",
+      "marketCap": 187930000000
     },
     {
       "symbol": "WAB",
       "name": "Wabtec",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 33100000000
     },
     {
       "symbol": "WAT",
       "name": "Waters Corporation",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 17780000000
     },
     {
       "symbol": "WBD",
       "name": "Warner Bros. Discovery",
-      "sector": "Communication Services"
+      "sector": "Communication Services",
+      "marketCap": 29030000000
     },
     {
       "symbol": "WDAY",
       "name": "Workday, Inc.",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 61330000000
     },
     {
       "symbol": "WDC",
       "name": "Western Digital",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 27990000000
     },
     {
       "symbol": "WEC",
       "name": "WEC Energy Group",
-      "sector": "Utilities"
+      "sector": "Utilities",
+      "marketCap": 34720000000
     },
     {
       "symbol": "WELL",
       "name": "Welltower",
-      "sector": "Real Estate"
+      "sector": "Real Estate",
+      "marketCap": 112790000000
     },
     {
       "symbol": "WFC",
       "name": "Wells Fargo",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 264930000000
     },
     {
       "symbol": "WM",
       "name": "Waste Management",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 91700000000
     },
     {
       "symbol": "WMB",
       "name": "Williams Companies",
-      "sector": "Energy"
+      "sector": "Energy",
+      "marketCap": 70060000000
     },
     {
       "symbol": "WMT",
       "name": "Walmart",
-      "sector": "Consumer Staples"
+      "sector": "Consumer Staples",
+      "marketCap": 773700000000
     },
     {
       "symbol": "WRB",
       "name": "W. R. Berkley Corporation",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 27360000000
     },
     {
       "symbol": "WSM",
       "name": "Williams-Sonoma, Inc.",
-      "sector": "Consumer Discretionary"
+      "sector": "Consumer Discretionary",
+      "marketCap": 23650000000
     },
     {
       "symbol": "WST",
       "name": "West Pharmaceutical Services",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 17800000000
     },
     {
       "symbol": "WTW",
       "name": "Willis Towers Watson",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 21990000000
     },
     {
       "symbol": "WY",
       "name": "Weyerhaeuser",
-      "sector": "Real Estate"
+      "sector": "Real Estate",
+      "marketCap": 18790000000
     },
     {
       "symbol": "WYNN",
       "name": "Wynn Resorts",
-      "sector": "Consumer Discretionary"
+      "sector": "Consumer Discretionary",
+      "marketCap": 12810000000
     },
     {
       "symbol": "XEL",
       "name": "Xcel Energy",
-      "sector": "Utilities"
+      "sector": "Utilities",
+      "marketCap": 43140000000
     },
     {
       "symbol": "XOM",
       "name": "ExxonMobil",
-      "sector": "Energy"
+      "sector": "Energy",
+      "marketCap": 484670000000
     },
     {
       "symbol": "XYL",
       "name": "Xylem Inc.",
-      "sector": "Industrials"
+      "sector": "Industrials",
+      "marketCap": 34600000000
     },
     {
       "symbol": "XYZ",
       "name": "Block, Inc.",
-      "sector": "Financials"
+      "sector": "Financials",
+      "marketCap": 49240000000
     },
     {
       "symbol": "YUM",
       "name": "Yum! Brands",
-      "sector": "Consumer Discretionary"
+      "sector": "Consumer Discretionary",
+      "marketCap": 40750000000
     },
     {
       "symbol": "ZBH",
       "name": "Zimmer Biomet",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 21360000000
     },
     {
       "symbol": "ZBRA",
       "name": "Zebra Technologies",
-      "sector": "Information Technology"
+      "sector": "Information Technology",
+      "marketCap": 16340000000
     },
     {
       "symbol": "ZTS",
       "name": "Zoetis",
-      "sector": "Health Care"
+      "sector": "Health Care",
+      "marketCap": 69570000000
     }
   ],
   "nasdaq100": [
     {
       "symbol": "AAPL",
       "name": "Apple Inc.",
-      "sector": null
+      "sector": null,
+      "marketCap": 3410000000000
     },
     {
       "symbol": "ABNB",
       "name": "Airbnb",
-      "sector": null
+      "sector": null,
+      "marketCap": 80740000000
     },
     {
       "symbol": "ADBE",
       "name": "Adobe Inc.",
-      "sector": null
+      "sector": null,
+      "marketCap": 152330000000
     },
     {
       "symbol": "ADI",
       "name": "Analog Devices",
-      "sector": null
+      "sector": null,
+      "marketCap": 124240000000
     },
     {
       "symbol": "ADP",
       "name": "Automatic Data Processing",
-      "sector": null
+      "sector": null,
+      "marketCap": 122740000000
     },
     {
       "symbol": "ADSK",
       "name": "Autodesk",
-      "sector": null
+      "sector": null,
+      "marketCap": 66750000000
     },
     {
       "symbol": "AEP",
       "name": "American Electric Power",
-      "sector": null
+      "sector": null,
+      "marketCap": 59960000000
     },
     {
       "symbol": "AMAT",
       "name": "Applied Materials",
-      "sector": null
+      "sector": null,
+      "marketCap": 127390000000
     },
     {
       "symbol": "AMD",
       "name": "Advanced Micro Devices",
-      "sector": null
+      "sector": null,
+      "marketCap": 261650000000
     },
     {
       "symbol": "AMGN",
       "name": "Amgen",
-      "sector": null
+      "sector": null,
+      "marketCap": 156170000000
     },
     {
       "symbol": "AMZN",
       "name": "Amazon",
-      "sector": null
+      "sector": null,
+      "marketCap": 2420000000000
     },
     {
       "symbol": "APP",
       "name": "AppLovin",
-      "sector": null
+      "sector": null,
+      "marketCap": 154920000000
     },
     {
       "symbol": "ARM",
       "name": "Arm Holdings",
-      "sector": null
+      "sector": null,
+      "marketCap": 144560000000
     },
     {
       "symbol": "ASML",
       "name": "ASML Holding",
-      "sector": null
+      "sector": null,
+      "marketCap": 295580000000
     },
     {
       "symbol": "AVGO",
       "name": "Broadcom",
-      "sector": null
+      "sector": null,
+      "marketCap": 1360000000000
     },
     {
       "symbol": "AXON",
       "name": "Axon Enterprise",
-      "sector": null
+      "sector": null,
+      "marketCap": 60420000000
     },
     {
       "symbol": "AZN",
       "name": "AstraZeneca",
-      "sector": null
+      "sector": null,
+      "marketCap": 248280000000
     },
     {
       "symbol": "BIIB",
       "name": "Biogen",
-      "sector": null
+      "sector": null,
+      "marketCap": 19930000000
     },
     {
       "symbol": "BKNG",
       "name": "Booking Holdings",
-      "sector": null
+      "sector": null,
+      "marketCap": 180300000000
     },
     {
       "symbol": "BKR",
       "name": "Baker Hughes",
-      "sector": null
+      "sector": null,
+      "marketCap": 43980000000
     },
     {
       "symbol": "CCEP",
       "name": "Coca-Cola Europacific Partners",
-      "sector": null
+      "sector": null,
+      "marketCap": 40550000000
     },
     {
       "symbol": "CDNS",
       "name": "Cadence Design Systems",
-      "sector": null
+      "sector": null,
+      "marketCap": 93490000000
     },
     {
       "symbol": "CDW",
       "name": "CDW Corporation",
-      "sector": null
+      "sector": null,
+      "marketCap": 21510000000
     },
     {
       "symbol": "CEG",
       "name": "Constellation Energy",
-      "sector": null
+      "sector": null,
+      "marketCap": 95130000000
     },
     {
       "symbol": "CHTR",
       "name": "Charter Communications",
-      "sector": null
+      "sector": null,
+      "marketCap": 37040000000
     },
     {
       "symbol": "CMCSA",
       "name": "Comcast",
-      "sector": null
+      "sector": null,
+      "marketCap": 126320000000
     },
     {
       "symbol": "COST",
       "name": "Costco",
-      "sector": null
+      "sector": null,
+      "marketCap": 420360000000
     },
     {
       "symbol": "CPRT",
       "name": "Copart",
-      "sector": null
+      "sector": null,
+      "marketCap": 47060000000
     },
     {
       "symbol": "CRWD",
       "name": "CrowdStrike",
-      "sector": null
+      "sector": null,
+      "marketCap": 100970000000
     },
     {
       "symbol": "CSCO",
       "name": "Cisco",
-      "sector": null
+      "sector": null,
+      "marketCap": 269700000000
     },
     {
       "symbol": "CSGP",
       "name": "CoStar Group",
-      "sector": null
+      "sector": null,
+      "marketCap": 37540000000
     },
     {
       "symbol": "CSX",
       "name": "CSX Corporation",
-      "sector": null
+      "sector": null,
+      "marketCap": 60380000000
     },
     {
       "symbol": "CTAS",
       "name": "Cintas",
-      "sector": null
+      "sector": null,
+      "marketCap": 86620000000
     },
     {
       "symbol": "CTSH",
       "name": "Cognizant",
-      "sector": null
+      "sector": null,
+      "marketCap": 35580000000
     },
     {
       "symbol": "DASH",
       "name": "DoorDash",
-      "sector": null
+      "sector": null,
+      "marketCap": 104060000000
     },
     {
       "symbol": "DDOG",
       "name": "Datadog",
-      "sector": null
+      "sector": null,
+      "marketCap": 45940000000
     },
     {
       "symbol": "DXCM",
       "name": "DexCom",
-      "sector": null
+      "sector": null,
+      "marketCap": 30060000000
     },
     {
       "symbol": "EA",
       "name": "Electronic Arts",
-      "sector": null
+      "sector": null,
+      "marketCap": 43430000000
     },
     {
       "symbol": "EXC",
       "name": "Exelon",
-      "sector": null
+      "sector": null,
+      "marketCap": 44750000000
     },
     {
       "symbol": "FANG",
       "name": "Diamondback Energy",
-      "sector": null
+      "sector": null,
+      "marketCap": 42450000000
     },
     {
       "symbol": "FAST",
       "name": "Fastenal",
-      "sector": null
+      "sector": null,
+      "marketCap": 57010000000
     },
     {
       "symbol": "FTNT",
       "name": "Fortinet",
-      "sector": null
+      "sector": null,
+      "marketCap": 59480000000
     },
     {
       "symbol": "GEHC",
       "name": "GE HealthCare",
-      "sector": null
+      "sector": null,
+      "marketCap": 33910000000
     },
     {
       "symbol": "GFS",
       "name": "GlobalFoundries",
-      "sector": null
+      "sector": null,
+      "marketCap": 18750000000
     },
     {
       "symbol": "GILD",
       "name": "Gilead Sciences",
-      "sector": null
+      "sector": null,
+      "marketCap": 141870000000
     },
     {
       "symbol": "GOOG",
       "name": "Alphabet Inc.",
-      "sector": null
+      "sector": null,
+      "marketCap": 2530000000000
     },
     {
       "symbol": "GOOGL",
       "name": "Alphabet Inc.",
-      "sector": null
+      "sector": null,
+      "marketCap": 2530000000000
     },
     {
       "symbol": "HON",
       "name": "Honeywell",
-      "sector": null
+      "sector": null,
+      "marketCap": 139300000000
     },
     {
       "symbol": "IDXX",
       "name": "Idexx Laboratories",
-      "sector": null
+      "sector": null,
+      "marketCap": 51280000000
     },
     {
       "symbol": "INTC",
       "name": "Intel",
-      "sector": null
+      "sector": null,
+      "marketCap": 106240000000
     },
     {
       "symbol": "INTU",
       "name": "Intuit",
-      "sector": null
+      "sector": null,
+      "marketCap": 184660000000
     },
     {
       "symbol": "ISRG",
       "name": "Intuitive Surgical",
-      "sector": null
+      "sector": null,
+      "marketCap": 168700000000
     },
     {
       "symbol": "KDP",
       "name": "Keurig Dr Pepper",
-      "sector": null
+      "sector": null,
+      "marketCap": 40100000000
     },
     {
       "symbol": "KHC",
       "name": "Kraft Heinz",
-      "sector": null
+      "sector": null,
+      "marketCap": 33010000000
     },
     {
       "symbol": "KLAC",
       "name": "KLA Corporation",
-      "sector": null
+      "sector": null,
+      "marketCap": 114410000000
     },
     {
       "symbol": "LIN",
       "name": "Linde plc",
-      "sector": null
+      "sector": null,
+      "marketCap": 224540000000
     },
     {
       "symbol": "LRCX",
       "name": "Lam Research",
-      "sector": null
+      "sector": null,
+      "marketCap": 126240000000
     },
     {
       "symbol": "LULU",
       "name": "Lululemon",
-      "sector": null
+      "sector": null,
+      "marketCap": 24290000000
     },
     {
       "symbol": "MAR",
       "name": "Marriott International",
-      "sector": null
+      "sector": null,
+      "marketCap": 72560000000
     },
     {
       "symbol": "MCHP",
       "name": "Microchip Technology",
-      "sector": null
+      "sector": null,
+      "marketCap": 35830000000
     },
     {
       "symbol": "MDLZ",
       "name": "Mondelez International",
-      "sector": null
+      "sector": null,
+      "marketCap": 80120000000
     },
     {
       "symbol": "MELI",
       "name": "Mercado Libre",
-      "sector": null
+      "sector": null,
+      "marketCap": 122390000000
     },
     {
       "symbol": "META",
       "name": "Meta Platforms",
-      "sector": null
+      "sector": null,
+      "marketCap": 1850000000000
     },
     {
       "symbol": "MNST",
       "name": "Monster Beverage",
-      "sector": null
+      "sector": null,
+      "marketCap": 60650000000
     },
     {
       "symbol": "MRVL",
       "name": "Marvell Technology",
-      "sector": null
+      "sector": null,
+      "marketCap": 52490000000
     },
     {
       "symbol": "MSFT",
       "name": "Microsoft",
-      "sector": null
+      "sector": null,
+      "marketCap": 3740000000000
     },
     {
       "symbol": "MSTR",
       "name": "MicroStrategy",
-      "sector": null
+      "sector": null,
+      "marketCap": 96020000000
     },
     {
       "symbol": "MU",
       "name": "Micron Technology",
-      "sector": null
+      "sector": null,
+      "marketCap": 128550000000
     },
     {
       "symbol": "NFLX",
       "name": "Netflix, Inc.",
-      "sector": null
+      "sector": null,
+      "marketCap": 510100000000
     },
     {
       "symbol": "NVDA",
       "name": "Nvidia",
-      "sector": null
+      "sector": null,
+      "marketCap": 4280000000000
     },
     {
       "symbol": "NXPI",
       "name": "NXP Semiconductors",
-      "sector": null
+      "sector": null,
+      "marketCap": 58860000000
     },
     {
       "symbol": "ODFL",
       "name": "Old Dominion Freight Line",
-      "sector": null
+      "sector": null,
+      "marketCap": 32600000000
     },
     {
       "symbol": "ON",
       "name": "Onsemi",
-      "sector": null
+      "sector": null,
+      "marketCap": 20470000000
     },
     {
       "symbol": "ORLY",
       "name": "O'Reilly Automotive",
-      "sector": null
+      "sector": null,
+      "marketCap": 88020000000
     },
     {
       "symbol": "PANW",
       "name": "Palo Alto Networks",
-      "sector": null
+      "sector": null,
+      "marketCap": 124980000000
     },
     {
       "symbol": "PAYX",
       "name": "Paychex",
-      "sector": null
+      "sector": null,
+      "marketCap": 49950000000
     },
     {
       "symbol": "PCAR",
       "name": "Paccar",
-      "sector": null
+      "sector": null,
+      "marketCap": 53270000000
     },
     {
       "symbol": "PDD",
       "name": "PDD Holdings",
-      "sector": null
+      "sector": null,
+      "marketCap": 171220000000
     },
     {
       "symbol": "PEP",
       "name": "PepsiCo",
-      "sector": null
+      "sector": null,
+      "marketCap": 204430000000
     },
     {
       "symbol": "PLTR",
       "name": "Palantir Technologies",
-      "sector": null
+      "sector": null,
+      "marketCap": 368320000000
     },
     {
       "symbol": "PYPL",
       "name": "PayPal",
-      "sector": null
+      "sector": null,
+      "marketCap": 66540000000
     },
     {
       "symbol": "QCOM",
       "name": "Qualcomm",
-      "sector": null
+      "sector": null,
+      "marketCap": 172320000000
     },
     {
       "symbol": "REGN",
       "name": "Regeneron Pharmaceuticals",
-      "sector": null
+      "sector": null,
+      "marketCap": 62210000000
     },
     {
       "symbol": "ROP",
       "name": "Roper Technologies",
-      "sector": null
+      "sector": null,
+      "marketCap": 56860000000
     },
     {
       "symbol": "ROST",
       "name": "Ross Stores",
-      "sector": null
+      "sector": null,
+      "marketCap": 48530000000
     },
     {
       "symbol": "SBUX",
       "name": "Starbucks",
-      "sector": null
+      "sector": null,
+      "marketCap": 99640000000
     },
     {
       "symbol": "SHOP",
       "name": "Shopify",
-      "sector": null
+      "sector": null,
+      "marketCap": 181480000000
     },
     {
       "symbol": "SNPS",
       "name": "Synopsys",
-      "sector": null
+      "sector": null,
+      "marketCap": 110000000000
     },
     {
       "symbol": "TEAM",
       "name": "Atlassian",
-      "sector": null
+      "sector": null,
+      "marketCap": 45090000000
     },
     {
       "symbol": "TMUS",
       "name": "T-Mobile US",
-      "sector": null
+      "sector": null,
+      "marketCap": 284500000000
     },
     {
       "symbol": "TRI",
       "name": "Thomson Reuters",
-      "sector": null
+      "sector": null,
+      "marketCap": 78270000000
     },
     {
       "symbol": "TSLA",
       "name": "Tesla, Inc.",
-      "sector": null
+      "sector": null,
+      "marketCap": 1050000000000
     },
     {
       "symbol": "TTD",
       "name": "Trade Desk (The)",
-      "sector": null
+      "sector": null,
+      "marketCap": 25420000000
     },
     {
       "symbol": "TTWO",
       "name": "Take-Two Interactive",
-      "sector": null
+      "sector": null,
+      "marketCap": 42510000000
     },
     {
       "symbol": "TXN",
       "name": "Texas Instruments",
-      "sector": null
+      "sector": null,
+      "marketCap": 186800000000
     },
     {
       "symbol": "VRSK",
       "name": "Verisk Analytics",
-      "sector": null
+      "sector": null,
+      "marketCap": 37400000000
     },
     {
       "symbol": "VRTX",
       "name": "Vertex Pharmaceuticals",
-      "sector": null
+      "sector": null,
+      "marketCap": 99490000000
     },
     {
       "symbol": "WBD",
       "name": "Warner Bros. Discovery",
-      "sector": null
+      "sector": null,
+      "marketCap": 29030000000
     },
     {
       "symbol": "WDAY",
       "name": "Workday, Inc.",
-      "sector": null
+      "sector": null,
+      "marketCap": 61330000000
     },
     {
       "symbol": "XEL",
       "name": "Xcel Energy",
-      "sector": null
+      "sector": null,
+      "marketCap": 43140000000
     },
     {
       "symbol": "ZS",
       "name": "Zscaler",
-      "sector": null
+      "sector": null,
+      "marketCap": 42000000000
     }
   ],
   "kospi200": [
     {
       "symbol": "000080.KS",
       "name": "하이트진로",
-      "sector": "필수소비재"
+      "sector": "필수소비재",
+      "marketCap": 1370000000000
     },
     {
       "symbol": "000100.KS",
       "name": "유한양행",
-      "sector": "헬스케어"
+      "sector": "헬스케어",
+      "marketCap": 9380000000000
     },
     {
       "symbol": "000120.KS",
       "name": "CJ대한통운",
-      "sector": "산업재"
+      "sector": "산업재",
+      "marketCap": 1900000000000
     },
     {
       "symbol": "000150.KS",
       "name": "두산",
-      "sector": "산업재"
+      "sector": "산업재",
+      "marketCap": 10660000000000
     },
     {
       "symbol": "000210.KS",
       "name": "DL",
-      "sector": "산업재"
+      "sector": "산업재",
+      "marketCap": 841580000000
     },
     {
       "symbol": "000270.KS",
       "name": "기아",
-      "sector": "경기소비재"
+      "sector": "경기소비재",
+      "marketCap": 42250000000000
     },
     {
       "symbol": "000660.KS",
       "name": "SK하이닉스",
-      "sector": "정보기술"
+      "sector": "정보기술",
+      "marketCap": 188020000000000
     },
     {
       "symbol": "000720.KS",
       "name": "현대건설",
-      "sector": "산업재"
+      "sector": "산업재",
+      "marketCap": 6840000000000
     },
     {
       "symbol": "000810.KS",
       "name": "삼성화재",
-      "sector": "금융"
+      "sector": "금융",
+      "marketCap": 22320000000000
     },
     {
       "symbol": "000880.KS",
       "name": "한화",
-      "sector": "산업재"
+      "sector": "산업재",
+      "marketCap": 7140000000000
     },
     {
       "symbol": "000990.KS",
       "name": "DB하이텍",
-      "sector": "정보기술"
+      "sector": "정보기술",
+      "marketCap": 1970000000000
     },
     {
       "symbol": "001040.KS",
       "name": "CJ",
-      "sector": "산업재"
+      "sector": "산업재",
+      "marketCap": 5500000000000
     },
     {
       "symbol": "001120.KS",
       "name": "LX인터내셔널",
-      "sector": "산업재"
+      "sector": "산업재",
+      "marketCap": 1160000000000
     },
     {
       "symbol": "001230.KS",
       "name": "동국홀딩스",
-      "sector": "산업재"
+      "sector": "산업재",
+      "marketCap": 237830000000
     },
     {
       "symbol": "001430.KS",
       "name": "세아베스틸지주",
-      "sector": "소재"
+      "sector": "소재",
+      "marketCap": 977380000000
     },
     {
       "symbol": "001450.KS",
       "name": "현대해상",
-      "sector": "금융"
+      "sector": "금융",
+      "marketCap": 2520000000000
     },
     {
       "symbol": "001570.KS",
       "name": "금양",
-      "sector": "소재"
+      "sector": "소재",
+      "marketCap": 633280000000
     },
     {
       "symbol": "001680.KS",
       "name": "대상",
-      "sector": "필수소비재"
+      "sector": "필수소비재",
+      "marketCap": 809520000000
     },
     {
       "symbol": "001740.KS",
       "name": "SK네트웍스",
-      "sector": "산업재"
+      "sector": "산업재",
+      "marketCap": 974670000000
     },
     {
       "symbol": "001800.KS",
       "name": "오리온홀딩스",
-      "sector": "산업재"
+      "sector": "산업재",
+      "marketCap": 1280000000000
     },
     {
       "symbol": "002350.KS",
       "name": "넥센타이어",
-      "sector": "경기소비재"
+      "sector": "경기소비재",
+      "marketCap": 586730000000
     },
     {
       "symbol": "002380.KS",
       "name": "KCC",
-      "sector": "소재"
+      "sector": "소재",
+      "marketCap": 3480000000000
     },
     {
       "symbol": "002710.KS",
       "name": "TCC스틸",
-      "sector": "소재"
+      "sector": "소재",
+      "marketCap": 452530000000
     },
     {
       "symbol": "002790.KS",
       "name": "아모레G",
-      "sector": "필수소비재"
+      "sector": "필수소비재",
+      "marketCap": 2400000000000
     },
     {
       "symbol": "003000.KS",
       "name": "부광약품",
-      "sector": "헬스케어"
+      "sector": "헬스케어",
+      "marketCap": 329000000000
     },
     {
       "symbol": "003030.KS",
       "name": "세아제강지주",
-      "sector": "소재"
+      "sector": "소재",
+      "marketCap": 745460000000
     },
     {
       "symbol": "003090.KS",
       "name": "대웅",
-      "sector": "헬스케어"
+      "sector": "헬스케어",
+      "marketCap": 1370000000000
     },
     {
       "symbol": "003410.KS",
       "name": "쌍용C&E",
-      "sector": "소재"
+      "sector": "소재",
+      "marketCap": null
     },
     {
       "symbol": "003490.KS",
       "name": "대한항공",
-      "sector": "산업재"
+      "sector": "산업재",
+      "marketCap": 8770000000000
     },
     {
       "symbol": "003550.KS",
       "name": "LG",
-      "sector": "산업재"
+      "sector": "산업재",
+      "marketCap": 12170000000000
     },
     {
       "symbol": "003620.KS",
       "name": "KG모빌리티",
-      "sector": "경기소비재"
+      "sector": "경기소비재",
+      "marketCap": 670710000000
     },
     {
       "symbol": "003670.KS",
       "name": "포스코퓨처엠",
-      "sector": "소재"
+      "sector": "소재",
+      "marketCap": 12870000000000
     },
     {
       "symbol": "003850.KS",
       "name": "보령",
-      "sector": "헬스케어"
+      "sector": "헬스케어",
+      "marketCap": 707740000000
     },
     {
       "symbol": "004000.KS",
       "name": "롯데정밀화학",
-      "sector": "소재"
+      "sector": "소재",
+      "marketCap": 1080000000000
     },
     {
       "symbol": "004020.KS",
       "name": "현대제철",
-      "sector": "소재"
+      "sector": "소재",
+      "marketCap": 4230000000000
     },
     {
       "symbol": "004170.KS",
       "name": "신세계",
-      "sector": "경기소비재"
+      "sector": "경기소비재",
+      "marketCap": 1590000000000
     },
     {
       "symbol": "004800.KS",
       "name": "효성",
-      "sector": "산업재"
+      "sector": "산업재",
+      "marketCap": 1430000000000
     },
     {
       "symbol": "004990.KS",
       "name": "롯데지주",
-      "sector": "산업재"
+      "sector": "산업재",
+      "marketCap": 3110000000000
     },
     {
       "symbol": "005070.KS",
       "name": "코스모신소재",
-      "sector": "소재"
+      "sector": "소재",
+      "marketCap": 1440000000000
     },
     {
       "symbol": "005180.KS",
       "name": "빙그레",
-      "sector": "필수소비재"
+      "sector": "필수소비재",
+      "marketCap": 684190000000
     },
     {
       "symbol": "005250.KS",
       "name": "녹십자홀딩스",
-      "sector": "헬스케어"
+      "sector": "헬스케어",
+      "marketCap": 726470000000
     },
     {
       "symbol": "005300.KS",
       "name": "롯데칠성",
-      "sector": "필수소비재"
+      "sector": "필수소비재",
+      "marketCap": 1170000000000
     },
     {
       "symbol": "005380.KS",
       "name": "현대차",
-      "sector": "경기소비재"
+      "sector": "경기소비재",
+      "marketCap": 56180000000000
     },
     {
       "symbol": "005385.KS",
       "name": "현대차우",
-      "sector": "경기소비재"
+      "sector": "경기소비재",
+      "marketCap": 56180000000000
     },
     {
       "symbol": "005387.KS",
       "name": "현대차2우B",
-      "sector": "경기소비재"
+      "sector": "경기소비재",
+      "marketCap": 56180000000000
     },
     {
       "symbol": "005420.KS",
       "name": "코스모화학",
-      "sector": "소재"
+      "sector": "소재",
+      "marketCap": 634840000000
     },
     {
       "symbol": "005490.KS",
       "name": "POSCO홀딩스",
-      "sector": "소재"
+      "sector": "소재",
+      "marketCap": 22940000000000
     },
     {
       "symbol": "005830.KS",
       "name": "DB손해보험",
-      "sector": "금융"
+      "sector": "금융",
+      "marketCap": 9810000000000
     },
     {
       "symbol": "005850.KS",
       "name": "에스엘",
-      "sector": "경기소비재"
+      "sector": "경기소비재",
+      "marketCap": 1590000000000
     },
     {
       "symbol": "005930.KS",
       "name": "삼성전자",
-      "sector": "정보기술"
+      "sector": "정보기술",
+      "marketCap": 449070000000000
     },
     {
       "symbol": "005935.KS",
       "name": "삼성전자우",
-      "sector": "정보기술"
+      "sector": "정보기술",
+      "marketCap": 448740000000000
     },
     {
       "symbol": "005940.KS",
       "name": "NH투자증권",
-      "sector": "금융"
+      "sector": "금융",
+      "marketCap": 7300000000000
     },
     {
       "symbol": "006110.KS",
       "name": "삼아알미늄",
-      "sector": "소재"
+      "sector": "소재",
+      "marketCap": 330240000000
     },
     {
       "symbol": "006120.KS",
       "name": "SK디스커버리",
-      "sector": "산업재"
+      "sector": "산업재",
+      "marketCap": 1000000000000
     },
     {
       "symbol": "006260.KS",
       "name": "LS",
-      "sector": "산업재"
+      "sector": "산업재",
+      "marketCap": 5570000000000
     },
     {
       "symbol": "006280.KS",
       "name": "녹십자",
-      "sector": "헬스케어"
+      "sector": "헬스케어",
+      "marketCap": 1540000000000
     },
     {
       "symbol": "006360.KS",
       "name": "GS건설",
-      "sector": "산업재"
+      "sector": "산업재",
+      "marketCap": 1610000000000
     },
     {
       "symbol": "006400.KS",
       "name": "삼성SDI",
-      "sector": "정보기술"
+      "sector": "정보기술",
+      "marketCap": 17410000000000
     },
     {
       "symbol": "006650.KS",
       "name": "대한유화",
-      "sector": "소재"
+      "sector": "소재",
+      "marketCap": 779720000000
     },
     {
       "symbol": "006800.KS",
       "name": "미래에셋증권",
-      "sector": "금융"
+      "sector": "금융",
+      "marketCap": 12080000000000
     },
     {
       "symbol": "007070.KS",
       "name": "GS리테일",
-      "sector": "필수소비재"
+      "sector": "필수소비재",
+      "marketCap": 1380000000000
     },
     {
       "symbol": "008560.KS",
       "name": "메리츠증권",
-      "sector": "금융"
+      "sector": "금융",
+      "marketCap": null
     },
     {
       "symbol": "008770.KS",
       "name": "호텔신라",
-      "sector": "경기소비재"
+      "sector": "경기소비재",
+      "marketCap": 1870000000000
     },
     {
       "symbol": "008930.KS",
       "name": "한미사이언스",
-      "sector": "헬스케어"
+      "sector": "헬스케어",
+      "marketCap": 2900000000000
     },
     {
       "symbol": "009150.KS",
       "name": "삼성전기",
-      "sector": "정보기술"
+      "sector": "정보기술",
+      "marketCap": 12540000000000
     },
     {
       "symbol": "009240.KS",
       "name": "한샘",
-      "sector": "경기소비재"
+      "sector": "경기소비재",
+      "marketCap": 987250000000
     },
     {
       "symbol": "009420.KS",
       "name": "한올바이오파마",
-      "sector": "헬스케어"
+      "sector": "헬스케어",
+      "marketCap": 1550000000000
     },
     {
       "symbol": "009540.KS",
       "name": "HD한국조선해양",
-      "sector": "산업재"
+      "sector": "산업재",
+      "marketCap": 29730000000000
     },
     {
       "symbol": "009830.KS",
       "name": "한화솔루션",
-      "sector": "소재"
+      "sector": "소재",
+      "marketCap": 4840000000000
     },
     {
       "symbol": "009900.KS",
       "name": "명신산업",
-      "sector": "경기소비재"
+      "sector": "경기소비재",
+      "marketCap": 464720000000
     },
     {
       "symbol": "009970.KS",
       "name": "영풍",
-      "sector": "소재"
+      "sector": "소재",
+      "marketCap": 1710000000000
     },
     {
       "symbol": "010060.KS",
       "name": "OCI홀딩스",
-      "sector": "산업재"
+      "sector": "산업재",
+      "marketCap": 1680000000000
     },
     {
       "symbol": "010120.KS",
       "name": "LS ELECTRIC",
-      "sector": "산업재"
+      "sector": "산업재",
+      "marketCap": 8300000000000
     },
     {
       "symbol": "010130.KS",
       "name": "고려아연",
-      "sector": "소재"
+      "sector": "소재",
+      "marketCap": 16000000000000
     },
     {
       "symbol": "010140.KS",
       "name": "삼성중공업",
-      "sector": "산업재"
+      "sector": "산업재",
+      "marketCap": 18610000000000
     },
     {
       "symbol": "010620.KS",
       "name": "현대미포조선",
-      "sector": "산업재"
+      "sector": "산업재",
+      "marketCap": 7950000000000
     },
     {
       "symbol": "010780.KS",
       "name": "아이에스동서",
-      "sector": "소재"
+      "sector": "소재",
+      "marketCap": 599430000000
     },
     {
       "symbol": "010950.KS",
       "name": "S-Oil",
-      "sector": "에너지"
+      "sector": "에너지",
+      "marketCap": 6850000000000
     },
     {
       "symbol": "011070.KS",
       "name": "LG이노텍",
-      "sector": "정보기술"
+      "sector": "정보기술",
+      "marketCap": 3810000000000
     },
     {
       "symbol": "011170.KS",
       "name": "롯데케미칼",
-      "sector": "소재"
+      "sector": "소재",
+      "marketCap": 2680000000000
     },
     {
       "symbol": "011200.KS",
       "name": "HMM",
-      "sector": "산업재"
+      "sector": "산업재",
+      "marketCap": 22650000000000
     },
     {
       "symbol": "011780.KS",
       "name": "금호석유",
-      "sector": "소재"
+      "sector": "소재",
+      "marketCap": 3020000000000
     },
     {
       "symbol": "011790.KS",
       "name": "SKC",
-      "sector": "소재"
+      "sector": "소재",
+      "marketCap": 3500000000000
     },
     {
       "symbol": "012330.KS",
       "name": "현대모비스",
-      "sector": "경기소비재"
+      "sector": "경기소비재",
+      "marketCap": 28250000000000
     },
     {
       "symbol": "012450.KS",
       "name": "한화에어로스페이스",
-      "sector": "산업재"
+      "sector": "산업재",
+      "marketCap": 48990000000000
     },
     {
       "symbol": "012750.KS",
       "name": "에스원",
-      "sector": "산업재"
+      "sector": "산업재",
+      "marketCap": 3040000000000
     },
     {
       "symbol": "014680.KS",
       "name": "한솔케미칼",
-      "sector": "소재"
+      "sector": "소재",
+      "marketCap": 1810000000000
     },
     {
       "symbol": "014820.KS",
       "name": "동원시스템즈",
-      "sector": "산업재"
+      "sector": "산업재",
+      "marketCap": 851250000000
     },
     {
       "symbol": "014830.KS",
       "name": "유니드",
-      "sector": "소재"
+      "sector": "소재",
+      "marketCap": 511560000000
     },
     {
       "symbol": "015760.KS",
       "name": "한국전력",
-      "sector": "유틸리티"
+      "sector": "유틸리티",
+      "marketCap": 23950000000000
     },
     {
       "symbol": "016360.KS",
       "name": "삼성증권",
-      "sector": "금융"
+      "sector": "금융",
+      "marketCap": 6180000000000
     },
     {
       "symbol": "016380.KS",
       "name": "KG스틸",
-      "sector": "소재"
+      "sector": "소재",
+      "marketCap": 528050000000
     },
     {
       "symbol": "017670.KS",
       "name": "SK텔레콤",
-      "sector": "커뮤니케이션서비스"
+      "sector": "커뮤니케이션서비스",
+      "marketCap": 11880000000000
     },
     {
       "symbol": "017800.KS",
       "name": "현대엘리베이터",
-      "sector": "산업재"
+      "sector": "산업재",
+      "marketCap": 3130000000000
     },
     {
       "symbol": "018260.KS",
       "name": "삼성에스디에스",
-      "sector": "정보기술"
+      "sector": "정보기술",
+      "marketCap": 11390000000000
     },
     {
       "symbol": "018670.KS",
       "name": "SK가스",
-      "sector": "유틸리티"
+      "sector": "유틸리티",
+      "marketCap": 2200000000000
     },
     {
       "symbol": "018880.KS",
       "name": "한온시스템",
-      "sector": "경기소비재"
+      "sector": "경기소비재",
+      "marketCap": 2470000000000
     },
     {
       "symbol": "019170.KS",
       "name": "신풍제약",
-      "sector": "헬스케어"
+      "sector": "헬스케어",
+      "marketCap": 721510000000
     },
     {
       "symbol": "020000.KS",
       "name": "한섬",
-      "sector": "경기소비재"
+      "sector": "경기소비재",
+      "marketCap": 336780000000
     },
     {
       "symbol": "020150.KS",
       "name": "롯데에너지머티리얼즈",
-      "sector": "소재"
+      "sector": "소재",
+      "marketCap": 1340000000000
     },
     {
       "symbol": "021240.KS",
       "name": "코웨이",
-      "sector": "경기소비재"
+      "sector": "경기소비재",
+      "marketCap": 7630000000000
     },
     {
       "symbol": "022100.KS",
       "name": "포스코DX",
-      "sector": "정보기술"
+      "sector": "정보기술",
+      "marketCap": 3420000000000
     },
     {
       "symbol": "023530.KS",
       "name": "롯데쇼핑",
-      "sector": "경기소비재"
+      "sector": "경기소비재",
+      "marketCap": null
     },
     {
       "symbol": "024110.KS",
       "name": "기업은행",
-      "sector": "금융"
+      "sector": "금융",
+      "marketCap": 15280000000000
     },
     {
       "symbol": "026960.KS",
       "name": "동서",
-      "sector": "필수소비재"
+      "sector": "필수소비재",
+      "marketCap": 2790000000000
     },
     {
       "symbol": "028050.KS",
       "name": "삼성엔지니어링",
-      "sector": "산업재"
+      "sector": "산업재",
+      "marketCap": 5680000000000
     },
     {
       "symbol": "028260.KS",
       "name": "삼성물산",
-      "sector": "산업재"
+      "sector": "산업재",
+      "marketCap": 28810000000000
     },
     {
       "symbol": "030000.KS",
       "name": "제일기획",
-      "sector": "커뮤니케이션서비스"
+      "sector": "커뮤니케이션서비스",
+      "marketCap": 2260000000000
     },
     {
       "symbol": "030200.KS",
       "name": "KT",
-      "sector": "커뮤니케이션서비스"
+      "sector": "커뮤니케이션서비스",
+      "marketCap": 13410000000000
     },
     {
       "symbol": "031430.KS",
       "name": "신세계인터내셔날",
-      "sector": "경기소비재"
+      "sector": "경기소비재",
+      "marketCap": 364680000000
     },
     {
       "symbol": "032640.KS",
       "name": "LG유플러스",
-      "sector": "커뮤니케이션서비스"
+      "sector": "커뮤니케이션서비스",
+      "marketCap": 6190000000000
     },
     {
       "symbol": "032830.KS",
       "name": "삼성생명",
-      "sector": "금융"
+      "sector": "금융",
+      "marketCap": 29200000000000
     },
     {
       "symbol": "033780.KS",
       "name": "KT&G",
-      "sector": "필수소비재"
+      "sector": "필수소비재",
+      "marketCap": 17090000000000
     },
     {
       "symbol": "034020.KS",
       "name": "두산에너빌리티",
-      "sector": "산업재"
+      "sector": "산업재",
+      "marketCap": 39770000000000
     },
     {
       "symbol": "034220.KS",
       "name": "LG디스플레이",
-      "sector": "정보기술"
+      "sector": "정보기술",
+      "marketCap": 5870000000000
     },
     {
       "symbol": "034730.KS",
       "name": "SK",
-      "sector": "산업재"
+      "sector": "산업재",
+      "marketCap": 15210000000000
     },
     {
       "symbol": "035250.KS",
       "name": "강원랜드",
-      "sector": "경기소비재"
+      "sector": "경기소비재",
+      "marketCap": 3840000000000
     },
     {
       "symbol": "035420.KS",
       "name": "NAVER",
-      "sector": "커뮤니케이션서비스"
+      "sector": "커뮤니케이션서비스",
+      "marketCap": 34620000000000
     },
     {
       "symbol": "035720.KS",
       "name": "카카오",
-      "sector": "커뮤니케이션서비스"
+      "sector": "커뮤니케이션서비스",
+      "marketCap": 27630000000000
     },
     {
       "symbol": "035900.KS",
       "name": "JYP Ent.",
-      "sector": "커뮤니케이션서비스"
+      "sector": "커뮤니케이션서비스",
+      "marketCap": null
     },
     {
       "symbol": "036460.KS",
       "name": "한국가스공사",
-      "sector": "유틸리티"
+      "sector": "유틸리티",
+      "marketCap": 3620000000000
     },
     {
       "symbol": "039490.KS",
       "name": "키움증권",
-      "sector": "금융"
+      "sector": "금융",
+      "marketCap": 5390000000000
     },
     {
       "symbol": "042660.KS",
       "name": "한화오션",
-      "sector": "산업재"
+      "sector": "산업재",
+      "marketCap": 34850000000000
     },
     {
       "symbol": "042670.KS",
       "name": "HD현대인프라코어",
-      "sector": "산업재"
+      "sector": "산업재",
+      "marketCap": 2640000000000
     },
     {
       "symbol": "047050.KS",
       "name": "포스코인터내셔널",
-      "sector": "산업재"
+      "sector": "산업재",
+      "marketCap": 8570000000000
     },
     {
       "symbol": "047810.KS",
       "name": "한국항공우주",
-      "sector": "산업재"
+      "sector": "산업재",
+      "marketCap": 9380000000000
     },
     {
       "symbol": "051900.KS",
       "name": "LG생활건강",
-      "sector": "필수소비재"
+      "sector": "필수소비재",
+      "marketCap": 4870000000000
     },
     {
       "symbol": "051910.KS",
       "name": "LG화학",
-      "sector": "소재"
+      "sector": "소재",
+      "marketCap": 20500000000000
     },
     {
       "symbol": "055550.KS",
       "name": "신한지주",
-      "sector": "금융"
+      "sector": "금융",
+      "marketCap": 31650000000000
     },
     {
       "symbol": "064350.KS",
       "name": "현대로템",
-      "sector": "산업재"
+      "sector": "산업재",
+      "marketCap": 20620000000000
     },
     {
       "symbol": "066570.KS",
       "name": "LG전자",
-      "sector": "경기소비재"
+      "sector": "경기소비재",
+      "marketCap": 12690000000000
     },
     {
       "symbol": "066970.KS",
       "name": "엘앤에프",
-      "sector": "소재"
+      "sector": "소재",
+      "marketCap": 2450000000000
     },
     {
       "symbol": "068270.KS",
       "name": "셀트리온",
-      "sector": "헬스케어"
+      "sector": "헬스케어",
+      "marketCap": 40290000000000
     },
     {
       "symbol": "069260.KS",
       "name": "TKG휴켐스",
-      "sector": "헬스케어"
+      "sector": "헬스케어",
+      "marketCap": 709680000000
     },
     {
       "symbol": "069620.KS",
       "name": "대웅제약",
-      "sector": "헬스케어"
+      "sector": "헬스케어",
+      "marketCap": 1610000000000
     },
     {
       "symbol": "069960.KS",
       "name": "현대백화점",
-      "sector": "경기소비재"
+      "sector": "경기소비재",
+      "marketCap": 1700000000000
     },
     {
       "symbol": "071050.KS",
       "name": "한국금융지주",
-      "sector": "금융"
+      "sector": "금융",
+      "marketCap": 7670000000000
     },
     {
       "symbol": "073240.KS",
       "name": "금호타이어",
-      "sector": "경기소비재"
+      "sector": "경기소비재",
+      "marketCap": 1420000000000
     },
     {
       "symbol": "078930.KS",
       "name": "GS",
-      "sector": "산업재"
+      "sector": "산업재",
+      "marketCap": 4350000000000
     },
     {
       "symbol": "079550.KS",
       "name": "LIG넥스원",
-      "sector": "산업재"
+      "sector": "산업재",
+      "marketCap": 11090000000000
     },
     {
       "symbol": "081660.KS",
       "name": "휠라홀딩스",
-      "sector": "경기소비재"
+      "sector": "경기소비재",
+      "marketCap": 2480000000000
     },
     {
       "symbol": "086280.KS",
       "name": "현대글로비스",
-      "sector": "산업재"
+      "sector": "산업재",
+      "marketCap": 13440000000000
     },
     {
       "symbol": "086790.KS",
       "name": "하나금융지주",
-      "sector": "금융"
+      "sector": "금융",
+      "marketCap": 23400000000000
     },
     {
       "symbol": "088350.KS",
       "name": "한화생명",
-      "sector": "금융"
+      "sector": "금융",
+      "marketCap": 2720000000000
     },
     {
       "symbol": "088980.KS",
       "name": "맥쿼리인프라",
-      "sector": "금융"
+      "sector": "금융",
+      "marketCap": 5590000000000
     },
     {
       "symbol": "090430.KS",
       "name": "아모레퍼시픽",
-      "sector": "필수소비재"
+      "sector": "필수소비재",
+      "marketCap": 7350000000000
     },
     {
       "symbol": "096770.KS",
       "name": "SK이노베이션",
-      "sector": "에너지"
+      "sector": "에너지",
+      "marketCap": 15400000000000
     },
     {
       "symbol": "097950.KS",
       "name": "CJ제일제당",
-      "sector": "필수소비재"
+      "sector": "필수소비재",
+      "marketCap": 3670000000000
     },
     {
       "symbol": "103140.KS",
       "name": "풍산",
-      "sector": "소재"
+      "sector": "소재",
+      "marketCap": 3370000000000
     },
     {
       "symbol": "105560.KS",
       "name": "KB금융",
-      "sector": "금융"
+      "sector": "금융",
+      "marketCap": 41350000000000
     },
     {
       "symbol": "111770.KS",
       "name": "영원무역",
-      "sector": "경기소비재"
+      "sector": "경기소비재",
+      "marketCap": 2530000000000
     },
     {
       "symbol": "114090.KS",
       "name": "GKL",
-      "sector": "경기소비재"
+      "sector": "경기소비재",
+      "marketCap": 993190000000
     },
     {
       "symbol": "120110.KS",
       "name": "코오롱인더",
-      "sector": "소재"
+      "sector": "소재",
+      "marketCap": 1060000000000
     },
     {
       "symbol": "128940.KS",
       "name": "한미약품",
-      "sector": "헬스케어"
+      "sector": "헬스케어",
+      "marketCap": 3950000000000
     },
     {
       "symbol": "137310.KS",
       "name": "에스디바이오센서",
-      "sector": "헬스케어"
+      "sector": "헬스케어",
+      "marketCap": 1230000000000
     },
     {
       "symbol": "138040.KS",
       "name": "메리츠금융지주",
-      "sector": "금융"
+      "sector": "금융",
+      "marketCap": 22540000000000
     },
     {
       "symbol": "139480.KS",
       "name": "이마트",
-      "sector": "필수소비재"
+      "sector": "필수소비재",
+      "marketCap": 2000000000000
     },
     {
       "symbol": "145990.KS",
       "name": "삼양식품",
-      "sector": "필수소비재"
+      "sector": "필수소비재",
+      "marketCap": 527370000000
     },
     {
       "symbol": "161390.KS",
       "name": "한국타이어앤테크놀로지",
-      "sector": "경기소비재"
+      "sector": "경기소비재",
+      "marketCap": 5090000000000
     },
     {
       "symbol": "175330.KS",
       "name": "JB금융지주",
-      "sector": "금융"
+      "sector": "금융",
+      "marketCap": 4540000000000
     },
     {
       "symbol": "180640.KS",
       "name": "한진칼",
-      "sector": "산업재"
+      "sector": "산업재",
+      "marketCap": 7360000000000
     },
     {
       "symbol": "185750.KS",
       "name": "종근당",
-      "sector": "헬스케어"
+      "sector": "헬스케어",
+      "marketCap": 1120000000000
     },
     {
       "symbol": "192080.KS",
       "name": "더블유게임즈",
-      "sector": "커뮤니케이션서비스"
+      "sector": "커뮤니케이션서비스",
+      "marketCap": 1130000000000
     },
     {
       "symbol": "192400.KS",
       "name": "쿠쿠홈시스",
-      "sector": "경기소비재"
+      "sector": "경기소비재",
+      "marketCap": 1090000000000
     },
     {
       "symbol": "192820.KS",
       "name": "코스맥스",
-      "sector": "필수소비재"
+      "sector": "필수소비재",
+      "marketCap": 2420000000000
     },
     {
       "symbol": "204320.KS",
       "name": "HL만도",
-      "sector": "경기소비재"
+      "sector": "경기소비재",
+      "marketCap": 1690000000000
     },
     {
       "symbol": "207940.KS",
       "name": "삼성바이오로직스",
-      "sector": "헬스케어"
+      "sector": "헬스케어",
+      "marketCap": 72030000000000
     },
     {
       "symbol": "214320.KS",
       "name": "이노션",
-      "sector": "커뮤니케이션서비스"
+      "sector": "커뮤니케이션서비스",
+      "marketCap": 740330000000
     },
     {
       "symbol": "241560.KS",
       "name": "두산밥캣",
-      "sector": "산업재"
+      "sector": "산업재",
+      "marketCap": 5140000000000
     },
     {
       "symbol": "251270.KS",
       "name": "넷마블",
-      "sector": "커뮤니케이션서비스"
+      "sector": "커뮤니케이션서비스",
+      "marketCap": 5230000000000
     },
     {
       "symbol": "259960.KS",
       "name": "크래프톤",
-      "sector": "커뮤니케이션서비스"
+      "sector": "커뮤니케이션서비스",
+      "marketCap": 15880000000000
     },
     {
       "symbol": "267250.KS",
       "name": "HD현대",
-      "sector": "산업재"
+      "sector": "산업재",
+      "marketCap": 10890000000000
     },
     {
       "symbol": "267270.KS",
       "name": "HD현대건설기계",
-      "sector": "산업재"
+      "sector": "산업재",
+      "marketCap": 1540000000000
     },
     {
       "symbol": "271560.KS",
       "name": "오리온",
-      "sector": "필수소비재"
+      "sector": "필수소비재",
+      "marketCap": 4270000000000
     },
     {
       "symbol": "272210.KS",
       "name": "한화시스템",
-      "sector": "산업재"
+      "sector": "산업재",
+      "marketCap": 9820000000000
     },
     {
       "symbol": "280360.KS",
       "name": "롯데웰푸드",
-      "sector": "필수소비재"
+      "sector": "필수소비재",
+      "marketCap": 1100000000000
     },
     {
       "symbol": "282330.KS",
       "name": "BGF리테일",
-      "sector": "필수소비재"
+      "sector": "필수소비재",
+      "marketCap": 2000000000000
     },
     {
       "symbol": "285130.KS",
       "name": "SK케미칼",
-      "sector": "소재"
+      "sector": "소재",
+      "marketCap": 1070000000000
     },
     {
       "symbol": "298020.KS",
       "name": "효성티앤씨",
-      "sector": "소재"
+      "sector": "소재",
+      "marketCap": 943400000000
     },
     {
       "symbol": "298050.KS",
       "name": "효성첨단소재",
-      "sector": "소재"
+      "sector": "소재",
+      "marketCap": 848060000000
     },
     {
       "symbol": "302440.KS",
       "name": "SK바이오사이언스",
-      "sector": "헬스케어"
+      "sector": "헬스케어",
+      "marketCap": 3680000000000
     },
     {
       "symbol": "316140.KS",
       "name": "우리금융지주",
-      "sector": "금융"
+      "sector": "금융",
+      "marketCap": 18230000000000
     },
     {
       "symbol": "323410.KS",
       "name": "카카오뱅크",
-      "sector": "금융"
+      "sector": "금융",
+      "marketCap": 11730000000000
     },
     {
       "symbol": "326030.KS",
       "name": "SK바이오팜",
-      "sector": "헬스케어"
+      "sector": "헬스케어",
+      "marketCap": 7820000000000
     },
     {
       "symbol": "329180.KS",
       "name": "HD현대중공업",
-      "sector": "산업재"
+      "sector": "산업재",
+      "marketCap": 44050000000000
     },
     {
       "symbol": "336260.KS",
       "name": "두산퓨얼셀",
-      "sector": "산업재"
+      "sector": "산업재",
+      "marketCap": 1760000000000
     },
     {
       "symbol": "352820.KS",
       "name": "하이브",
-      "sector": "커뮤니케이션서비스"
+      "sector": "커뮤니케이션서비스",
+      "marketCap": 12080000000000
     },
     {
       "symbol": "361610.KS",
       "name": "SK아이이테크놀로지",
-      "sector": "소재"
+      "sector": "소재",
+      "marketCap": 2270000000000
     },
     {
       "symbol": "373220.KS",
       "name": "LG에너지솔루션",
-      "sector": "산업재"
+      "sector": "산업재",
+      "marketCap": 85180000000000
     },
     {
       "symbol": "375500.KS",
       "name": "DL이앤씨",
-      "sector": "산업재"
+      "sector": "산업재",
+      "marketCap": 1730000000000
     },
     {
       "symbol": "377300.KS",
       "name": "카카오페이",
-      "sector": "금융"
+      "sector": "금융",
+      "marketCap": 7860000000000
     },
     {
       "symbol": "383220.KS",
       "name": "F&F",
-      "sector": "경기소비재"
+      "sector": "경기소비재",
+      "marketCap": 2540000000000
     },
     {
       "symbol": "402340.KS",
       "name": "SK스퀘어",
-      "sector": "금융"
+      "sector": "금융",
+      "marketCap": 19460000000000
     }
   ],
   "kosdaq100": [
     {
       "symbol": "005290.KQ",
       "name": "동진쎄미켐",
-      "sector": "소재"
+      "sector": "소재",
+      "marketCap": 1450000000000
     },
     {
       "symbol": "006730.KQ",
       "name": "서부T&D",
-      "sector": "산업재"
+      "sector": "산업재",
+      "marketCap": 608980000000
     },
     {
       "symbol": "007390.KQ",
       "name": "네이처셀",
-      "sector": "헬스케어"
+      "sector": "헬스케어",
+      "marketCap": 1330000000000
     },
     {
       "symbol": "009520.KQ",
       "name": "포스코엠텍",
-      "sector": "소재"
+      "sector": "소재",
+      "marketCap": 541970000000
     },
     {
       "symbol": "018290.KQ",
       "name": "브이티",
-      "sector": "정보기술"
+      "sector": "정보기술",
+      "marketCap": 1220000000000
     },
     {
       "symbol": "028300.KQ",
       "name": "HLB",
-      "sector": "헬스케어"
+      "sector": "헬스케어",
+      "marketCap": 5120000000000
     },
     {
       "symbol": "034230.KQ",
       "name": "파라다이스",
-      "sector": "경기소비재"
+      "sector": "경기소비재",
+      "marketCap": null
     },
     {
       "symbol": "035720.KQ",
       "name": "카카오",
-      "sector": "커뮤니케이션서비스"
+      "sector": "커뮤니케이션서비스",
+      "marketCap": null
     },
     {
       "symbol": "035760.KQ",
       "name": "CJ ENM",
-      "sector": "커뮤니케이션서비스"
+      "sector": "커뮤니케이션서비스",
+      "marketCap": 1680000000000
     },
     {
       "symbol": "036030.KQ",
       "name": "케이씨티",
-      "sector": "정보기술"
+      "sector": "정보기술",
+      "marketCap": 255390000000
     },
     {
       "symbol": "036540.KQ",
       "name": "SFA반도체",
-      "sector": "정보기술"
+      "sector": "정보기술",
+      "marketCap": 534880000000
     },
     {
       "symbol": "036810.KQ",
       "name": "에프에스티",
-      "sector": "정보기술"
+      "sector": "정보기술",
+      "marketCap": 458930000000
     },
     {
       "symbol": "036930.KQ",
       "name": "주성엔지니어링",
-      "sector": "정보기술"
+      "sector": "정보기술",
+      "marketCap": 1260000000000
     },
     {
       "symbol": "038540.KQ",
       "name": "상상인",
-      "sector": "정보기술"
+      "sector": "정보기술",
+      "marketCap": 105400000000
     },
     {
       "symbol": "039030.KQ",
       "name": "이오테크닉스",
-      "sector": "정보기술"
+      "sector": "정보기술",
+      "marketCap": 2460000000000
     },
     {
       "symbol": "041510.KQ",
       "name": "에스엠",
-      "sector": "커뮤니케이션서비스"
+      "sector": "커뮤니케이션서비스",
+      "marketCap": 3260000000000
     },
     {
       "symbol": "042000.KQ",
       "name": "카페24",
-      "sector": "정보기술"
+      "sector": "정보기술",
+      "marketCap": 948240000000
     },
     {
       "symbol": "045660.KQ",
       "name": "에이치엘비",
-      "sector": "헬스케어"
+      "sector": "헬스케어",
+      "marketCap": 107030000000
     },
     {
       "symbol": "047920.KQ",
       "name": "HLB제약",
-      "sector": "헬스케어"
+      "sector": "헬스케어",
+      "marketCap": 456270000000
     },
     {
       "symbol": "048260.KQ",
       "name": "오스템임플란트",
-      "sector": "헬스케어"
+      "sector": "헬스케어",
+      "marketCap": null
     },
     {
       "symbol": "048410.KQ",
       "name": "현대바이오",
-      "sector": "헬스케어"
+      "sector": "헬스케어",
+      "marketCap": 601760000000
     },
     {
       "symbol": "053800.KQ",
       "name": "안랩",
-      "sector": "정보기술"
+      "sector": "정보기술",
+      "marketCap": 670910000000
     },
     {
       "symbol": "054300.KQ",
       "name": "라이콤",
-      "sector": "정보기술"
+      "sector": "정보기술",
+      "marketCap": 112280000000
     },
     {
       "symbol": "056190.KQ",
       "name": "에스에프에이",
-      "sector": "정보기술"
+      "sector": "정보기술",
+      "marketCap": 802650000000
     },
     {
       "symbol": "058470.KQ",
       "name": "리노공업",
-      "sector": "정보기술"
+      "sector": "정보기술",
+      "marketCap": 3600000000000
     },
     {
       "symbol": "060250.KQ",
       "name": "NHN KCP",
-      "sector": "정보기술"
+      "sector": "정보기술",
+      "marketCap": 539760000000
     },
     {
       "symbol": "060310.KQ",
       "name": "3S",
-      "sector": "정보기술"
+      "sector": "정보기술",
+      "marketCap": 95270000000
     },
     {
       "symbol": "064760.KQ",
       "name": "티씨케이",
-      "sector": "정보기술"
+      "sector": "정보기술",
+      "marketCap": 1230000000000
     },
     {
       "symbol": "066970.KQ",
       "name": "엘앤에프",
-      "sector": "소재"
+      "sector": "소재",
+      "marketCap": null
     },
     {
       "symbol": "067160.KQ",
       "name": "아프리카TV",
-      "sector": "커뮤니케이션서비스"
+      "sector": "커뮤니케이션서비스",
+      "marketCap": 903460000000
     },
     {
       "symbol": "067630.KQ",
       "name": "HLB생명과학",
-      "sector": "헬스케어"
+      "sector": "헬스케어",
+      "marketCap": 440810000000
     },
     {
       "symbol": "068760.KQ",
       "name": "셀트리온제약",
-      "sector": "헬스케어"
+      "sector": "헬스케어",
+      "marketCap": 2350000000000
     },
     {
       "symbol": "078340.KQ",
       "name": "컴투스",
-      "sector": "커뮤니케이션서비스"
+      "sector": "커뮤니케이션서비스",
+      "marketCap": 496070000000
     },
     {
       "symbol": "083790.KQ",
       "name": "크리스탈지노믹스",
-      "sector": "헬스케어"
+      "sector": "헬스케어",
+      "marketCap": 130870000000
     },
     {
       "symbol": "084370.KQ",
       "name": "유진테크",
-      "sector": "정보기술"
+      "sector": "정보기술",
+      "marketCap": 1050000000000
     },
     {
       "symbol": "084850.KQ",
       "name": "아이티엠반도체",
-      "sector": "정보기술"
+      "sector": "정보기술",
+      "marketCap": 275400000000
     },
     {
       "symbol": "085660.KQ",
       "name": "차바이오텍",
-      "sector": "헬스케어"
+      "sector": "헬스케어",
+      "marketCap": 806300000000
     },
     {
       "symbol": "086520.KQ",
       "name": "에코프로",
-      "sector": "산업재"
+      "sector": "산업재",
+      "marketCap": 7090000000000
     },
     {
       "symbol": "088390.KQ",
       "name": "이녹스",
-      "sector": "소재"
+      "sector": "소재",
+      "marketCap": 98830000000
     },
     {
       "symbol": "089030.KQ",
       "name": "테크윙",
-      "sector": "정보기술"
+      "sector": "정보기술",
+      "marketCap": 1260000000000
     },
     {
       "symbol": "089980.KQ",
       "name": "상아프론테크",
-      "sector": "정보기술"
+      "sector": "정보기술",
+      "marketCap": 281130000000
     },
     {
       "symbol": "090460.KQ",
       "name": "비에이치",
-      "sector": "정보기술"
+      "sector": "정보기술",
+      "marketCap": null
     },
     {
       "symbol": "091990.KQ",
       "name": "셀트리온헬스케어",
-      "sector": "헬스케어"
+      "sector": "헬스케어",
+      "marketCap": null
     },
     {
       "symbol": "093320.KQ",
       "name": "케이아이엔엑스",
-      "sector": "정보기술"
+      "sector": "정보기술",
+      "marketCap": 405030000000
     },
     {
       "symbol": "094170.KQ",
       "name": "동운아나텍",
-      "sector": "정보기술"
+      "sector": "정보기술",
+      "marketCap": 367380000000
     },
     {
       "symbol": "094360.KQ",
       "name": "칩스앤미디어",
-      "sector": "정보기술"
+      "sector": "정보기술",
+      "marketCap": 327560000000
     },
     {
       "symbol": "095340.KQ",
       "name": "ISC",
-      "sector": "정보기술"
+      "sector": "정보기술",
+      "marketCap": 1200000000000
     },
     {
       "symbol": "095660.KQ",
       "name": "네오위즈",
-      "sector": "커뮤니케이션서비스"
+      "sector": "커뮤니케이션서비스",
+      "marketCap": 528930000000
     },
     {
       "symbol": "098460.KQ",
       "name": "고영",
-      "sector": "정보기술"
+      "sector": "정보기술",
+      "marketCap": 988660000000
     },
     {
       "symbol": "099320.KQ",
       "name": "쎄트렉아이",
-      "sector": "산업재"
+      "sector": "산업재",
+      "marketCap": 571750000000
     },
     {
       "symbol": "100790.KQ",
       "name": "미래생명자원",
-      "sector": "헬스케어"
+      "sector": "헬스케어",
+      "marketCap": 317580000000
     },
     {
       "symbol": "101490.KQ",
       "name": "에스앤에스텍",
-      "sector": "정보기술"
+      "sector": "정보기술",
+      "marketCap": 1180000000000
     },
     {
       "symbol": "102710.KQ",
       "name": "이엔에프테크놀로지",
-      "sector": "정보기술"
+      "sector": "정보기술",
+      "marketCap": 535520000000
     },
     {
       "symbol": "108230.KQ",
       "name": "톱텍",
-      "sector": "정보기술"
+      "sector": "정보기술",
+      "marketCap": 180200000000
     },
     {
       "symbol": "112040.KQ",
       "name": "위메이드",
-      "sector": "커뮤니케이션서비스"
+      "sector": "커뮤니케이션서비스",
+      "marketCap": 963880000000
     },
     {
       "symbol": "119860.KQ",
       "name": "커넥트웨이브",
-      "sector": "정보기술"
+      "sector": "정보기술",
+      "marketCap": null
     },
     {
       "symbol": "121600.KQ",
       "name": "나노신소재",
-      "sector": "소재"
+      "sector": "소재",
+      "marketCap": 656270000000
     },
     {
       "symbol": "122870.KQ",
       "name": "와이지엔터테인먼트",
-      "sector": "커뮤니케이션서비스"
+      "sector": "커뮤니케이션서비스",
+      "marketCap": 1900000000000
     },
     {
       "symbol": "131970.KQ",
       "name": "테스나",
-      "sector": "정보기술"
+      "sector": "정보기술",
+      "marketCap": 660570000000
     },
     {
       "symbol": "137400.KQ",
       "name": "피엔티",
-      "sector": "정보기술"
+      "sector": "정보기술",
+      "marketCap": 924780000000
     },
     {
       "symbol": "140410.KQ",
       "name": "메지온",
-      "sector": "헬스케어"
+      "sector": "헬스케어",
+      "marketCap": 1220000000000
     },
     {
       "symbol": "141080.KQ",
       "name": "레고켐바이오",
-      "sector": "헬스케어"
+      "sector": "헬스케어",
+      "marketCap": 5370000000000
     },
     {
       "symbol": "145020.KQ",
       "name": "휴젤",
-      "sector": "헬스케어"
+      "sector": "헬스케어",
+      "marketCap": 4070000000000
     },
     {
       "symbol": "181710.KQ",
       "name": "NHN",
-      "sector": "정보기술"
+      "sector": "정보기술",
+      "marketCap": null
     },
     {
       "symbol": "183300.KQ",
       "name": "코미코",
-      "sector": "정보기술"
+      "sector": "정보기술",
+      "marketCap": 844970000000
     },
     {
       "symbol": "194480.KQ",
       "name": "데브시스터즈",
-      "sector": "커뮤니케이션서비스"
+      "sector": "커뮤니케이션서비스",
+      "marketCap": 600820000000
     },
     {
       "symbol": "195870.KQ",
       "name": "해성디에스",
-      "sector": "정보기술"
+      "sector": "정보기술",
+      "marketCap": null
     },
     {
       "symbol": "196170.KQ",
       "name": "알테오젠",
-      "sector": "헬스케어"
+      "sector": "헬스케어",
+      "marketCap": 23650000000000
     },
     {
       "symbol": "200670.KQ",
       "name": "휴메딕스",
-      "sector": "헬스케어"
+      "sector": "헬스케어",
+      "marketCap": 598470000000
     },
     {
       "symbol": "213420.KQ",
       "name": "덕산네오룩스",
-      "sector": "소재"
+      "sector": "소재",
+      "marketCap": 1190000000000
     },
     {
       "symbol": "214150.KQ",
       "name": "클래시스",
-      "sector": "헬스케어"
+      "sector": "헬스케어",
+      "marketCap": 3440000000000
     },
     {
       "symbol": "214370.KQ",
       "name": "케어젠",
-      "sector": "헬스케어"
+      "sector": "헬스케어",
+      "marketCap": 2770000000000
     },
     {
       "symbol": "218410.KQ",
       "name": "RFHIC",
-      "sector": "정보기술"
+      "sector": "정보기술",
+      "marketCap": 660420000000
     },
     {
       "symbol": "222080.KQ",
       "name": "씨아이에스",
-      "sector": "정보기술"
+      "sector": "정보기술",
+      "marketCap": 526830000000
     },
     {
       "symbol": "225570.KQ",
       "name": "넥슨게임즈",
-      "sector": "커뮤니케이션서비스"
+      "sector": "커뮤니케이션서비스",
+      "marketCap": 921870000000
     },
     {
       "symbol": "237690.KQ",
       "name": "에스티팜",
-      "sector": "헬스케어"
+      "sector": "헬스케어",
+      "marketCap": 1880000000000
     },
     {
       "symbol": "247540.KQ",
       "name": "에코프로비엠",
-      "sector": "소재"
+      "sector": "소재",
+      "marketCap": 12400000000000
     },
     {
       "symbol": "251630.KQ",
       "name": "브이원텍",
-      "sector": "정보기술"
+      "sector": "정보기술",
+      "marketCap": 86260000000
     },
     {
       "symbol": "253450.KQ",
       "name": "스튜디오드래곤",
-      "sector": "커뮤니케이션서비스"
+      "sector": "커뮤니케이션서비스",
+      "marketCap": 1400000000000
     },
     {
       "symbol": "263750.KQ",
       "name": "펄어비스",
-      "sector": "커뮤니케이션서비스"
+      "sector": "커뮤니케이션서비스",
+      "marketCap": 2100000000000
     },
     {
       "symbol": "272290.KQ",
       "name": "이녹스첨단소재",
-      "sector": "소재"
+      "sector": "소재",
+      "marketCap": 478200000000
     },
     {
       "symbol": "281740.KQ",
       "name": "레이크머티리얼즈",
-      "sector": "소재"
+      "sector": "소재",
+      "marketCap": 792470000000
     },
     {
       "symbol": "293490.KQ",
       "name": "카카오게임즈",
-      "sector": "커뮤니케이션서비스"
+      "sector": "커뮤니케이션서비스",
+      "marketCap": 1350000000000
     },
     {
       "symbol": "319660.KQ",
       "name": "피에스케이",
-      "sector": "정보기술"
+      "sector": "정보기술",
+      "marketCap": 620830000000
     },
     {
       "symbol": "322310.KQ",
       "name": "오로스테크놀로지",
-      "sector": "정보기술"
+      "sector": "정보기술",
+      "marketCap": 188320000000
     },
     {
       "symbol": "328130.KQ",
       "name": "루닛",
-      "sector": "헬스케어"
+      "sector": "헬스케어",
+      "marketCap": 1120000000000
     },
     {
       "symbol": "336570.KQ",
       "name": "원텍",
-      "sector": "소재"
+      "sector": "소재",
+      "marketCap": 933320000000
     },
     {
       "symbol": "348370.KQ",
       "name": "엔켐",
-      "sector": "소재"
+      "sector": "소재",
+      "marketCap": 1690000000000
     },
     {
       "symbol": "352820.KQ",
       "name": "하이브",
-      "sector": "커뮤니케이션서비스"
+      "sector": "커뮤니케이션서비스",
+      "marketCap": null
     },
     {
       "symbol": "357780.KQ",
       "name": "솔브레인",
-      "sector": "소재"
+      "sector": "소재",
+      "marketCap": 1560000000000
     },
     {
       "symbol": "365340.KQ",
       "name": "성일하이텍",
-      "sector": "소재"
+      "sector": "소재",
+      "marketCap": 445820000000
     },
     {
       "symbol": "393890.KQ",
       "name": "더블유씨피",
-      "sector": "소재"
+      "sector": "소재",
+      "marketCap": 258430000000
     },
     {
       "symbol": "399720.KQ",
       "name": "가온칩스",
-      "sector": "정보기술"
+      "sector": "정보기술",
+      "marketCap": 494930000000
     },
     {
       "symbol": "403870.KQ",
       "name": "HPSP",
-      "sector": "정보기술"
+      "sector": "정보기술",
+      "marketCap": 2050000000000
     },
     {
       "symbol": "950130.KQ",
       "name": "엑세스바이오",
-      "sector": "헬스케어"
+      "sector": "헬스케어",
+      "marketCap": null
     }
   ],
-  "generatedAt": "2025-09-01T02:01:02.828Z"
+  "generatedAt": "2025-09-01T02:42:38.279Z"
 }

--- a/src/maps.indexes.schema.json
+++ b/src/maps.indexes.schema.json
@@ -33,7 +33,8 @@
       "properties": {
         "symbol": { "type": "string", "pattern": "^[A-Z]{1,5}(\\.[A-Z]{1,2})?$" },
         "name":   { "type": "string", "minLength": 1 },
-        "sector": { "$ref": "#/$defs/gics" }
+        "sector": { "$ref": "#/$defs/gics" },
+        "marketCap": { "type": ["number", "null"], "minimum": 0 }
       },
       "additionalProperties": false
     },
@@ -43,7 +44,8 @@
       "properties": {
         "symbol": { "type": "string", "pattern": "^\\d{6}\\.(KS|KQ)$" },
         "name":   { "type": "string", "minLength": 1 },
-        "sector": { "$ref": "#/$defs/gics" }
+        "sector": { "$ref": "#/$defs/gics" },
+        "marketCap": { "type": ["number", "null"], "minimum": 0 }
       },
       "additionalProperties": false
     },

--- a/tools/updateIndexMaps.mjs
+++ b/tools/updateIndexMaps.mjs
@@ -61,6 +61,45 @@ function uniqBySymbol(arr){
   return out.sort((a,b)=>a.symbol.localeCompare(b.symbol));
 }
 
+function parseCap(str){
+  if (!str) return null;
+  const m = str.replace(/,/g,'').match(/([\d.]+)\s*([TBMK])\s+[A-Z]{3}/i);
+  if (!m) return null;
+  const mult = { K:1e3, M:1e6, B:1e9, T:1e12 }[m[2].toUpperCase()] || 1;
+  return Math.round(parseFloat(m[1]) * mult);
+}
+
+function exchangesFor(sym){
+  if (sym.endsWith('.KS')) return ['KRX'];
+  if (sym.endsWith('.KQ')) return ['KOSDAQ'];
+  return ['NASDAQ','NYSE','NYSEARCA','NYSEAMERICAN'];
+}
+
+async function fetchCap(sym){
+  const exs = exchangesFor(sym);
+  const base = sym.replace(/\.KS$|\.KQ$/,'');
+  for (const ex of exs){
+    const html = await netText(`https://www.google.com/finance/quote/${base}:${ex}`);
+    if (!html) continue;
+    const m = html.match(/Market cap<\/div><div[^>]*>.*?<\/div><\/span><div[^>]*>([^<]+)/);
+    if (m) return parseCap(m[1]);
+  }
+  return null;
+}
+
+async function fetchMarketCaps(symbols, limit=5){
+  const caps = {};
+  const queue = symbols.slice();
+  const workers = Array(limit).fill(0).map(async () => {
+    while(queue.length){
+      const sym = queue.shift();
+      caps[sym] = await fetchCap(sym);
+    }
+  });
+  await Promise.all(workers);
+  return caps;
+}
+
 // ---- Parsers (with fallbacks)
 
 // S&P 500: prefer Name,Symbol,Sector order; fallback to Symbol,Name,Sector
@@ -148,6 +187,37 @@ async function main() {
   nasdaq100 = uniqBySymbol(nasdaq100);
   kospi200  = uniqBySymbol(kospi200);
   kosdaq100 = uniqBySymbol(kosdaq100);
+
+  const allSymbols = Array.from(new Set([
+    ...sp500,
+    ...nasdaq100,
+    ...kospi200,
+    ...kosdaq100,
+  ].map(r => r.symbol)));
+
+  const caps = OFFLINE ? {} : await fetchMarketCaps(allSymbols);
+  const oldCaps = new Map();
+  for (const key of ['sp500','nasdaq100','kospi200','kosdaq100']) {
+    for (const r of current[key] || []) {
+      if (typeof r.marketCap === 'number') oldCaps.set(r.symbol, r.marketCap);
+    }
+  }
+
+  function attachCaps(list){
+    for (const r of list) {
+      const mc = caps[r.symbol] ?? null;
+      const prev = oldCaps.get(r.symbol);
+      if (prev != null && mc != null && prev !== mc) {
+        console.log(`[cap] ${r.symbol}: ${prev} -> ${mc}`);
+      }
+      r.marketCap = mc;
+    }
+  }
+
+  attachCaps(sp500);
+  attachCaps(nasdaq100);
+  attachCaps(kospi200);
+  attachCaps(kosdaq100);
 
   const next = {
     sp500,


### PR DESCRIPTION
## Summary
- Extend index schema and map entries to include `marketCap`
- Fetch and compare market caps against Google Finance in `updateIndexMaps.mjs`
- Update `maps.indexes.json` with current market capitalization values

## Testing
- `node tools/updateIndexMaps.mjs`
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68b506b09e58832a82476ad0f4de3838