### PR TITLE
Handle GDELT outages gracefully

### DIFF
--- a/.github/workflows/stock-recs.yml
+++ b/.github/workflows/stock-recs.yml
@@ -27,6 +27,7 @@ jobs:
       # Keep the run under typical 60s shells; script respects this.
       HARD_DEADLINE_MS: "55000"           # news deadline (now enforced)
       SKIP_NAVER: "0"
+      SKIP_GDELT: "0"
       PREFER_NAVER: "1"
       NAVER_WEIGHT: "1.6"
       OTHER_NEWS_WEIGHT: "1.0"
@@ -242,7 +243,10 @@ jobs:
 
           echo "HTTP head checks:"
           curl -4sS -I https://serpapi.com | head -n 1
-          curl -4sS -I https://api.gdeltproject.org | head -n 1
+          if ! curl -4sS -I https://api.gdeltproject.org | head -n 1; then
+            echo "GDELT head check failed; setting SKIP_GDELT=1"
+            echo "SKIP_GDELT=1" >> "$GITHUB_ENV"
+          fi
 
           echo "SerpApi auth check (status only; key masked by Actions):"
           curl -4sS --get 'https://serpapi.com/search.json' \

--- a/src/news/fetchByTicker.js
+++ b/src/news/fetchByTicker.js
@@ -680,13 +680,16 @@ export async function buildNewsFeatures(symbols, opts={}){
     const q = queries[sym];
     const name = symbolToName[sym] || sym;
     let feat = { count: 0, sentiment: 0, blogMentions: 0 };
-    const providers = preferNaver
+    const baseProviders = preferNaver
       ? (isKR(sym)
           ? ['naver','gnews','serpapi','kotra','newsapi','gdelt','finnhub','polygon']
           : ['naver','gnews','serpapi','newsapi','gdelt','finnhub','kotra','polygon'])
       : (isKR(sym)
           ? ['gnews','naver','serpapi','kotra','finnhub','newsapi','gdelt']
           : ['gnews','polygon','serpapi','newsapi','gdelt','finnhub','kotra','naver']);
+    const providers = process.env.SKIP_GDELT === '1'
+      ? baseProviders.filter(p => p !== 'gdelt')
+      : baseProviders;
 
     let lastErr = null;
     for (const p of providers) {


### PR DESCRIPTION
## Summary
- add `SKIP_GDELT` environment flag and filter out the GDELT provider
- mark GDELT as optional in the stock-recs workflow, setting `SKIP_GDELT=1` when preflight fails

## Testing
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68b529e1f138832abae762e2e05a7d8a