### PR TITLE
fix: stage recommendation files before pull

### DIFF
--- a/.github/workflows/stock-recs.yml
+++ b/.github/workflows/stock-recs.yml
@@ -312,7 +312,7 @@ jobs:
       - name: Stage new data files
         shell: bash
         run: |
-          git add data/market-news.json data/fx_rates.json summary.json summary.md data/articles pools-metrics.json || true
+          git add data/market-news.json data/fx_rates.json summary.json summary.md data/articles pools-metrics.json recommendations.json ticker-cache.json pools.json pools-cache.json || true
           echo "Files staged for commit"
 
       - name: Commit & push changes


### PR DESCRIPTION
## Summary
- stage recommendations and cache files in stock-recs workflow to avoid unstaged changes during pull

## Testing
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68b54fa57cbc832ab75d9113e40733d2