### PR TITLE
ci: enable autostash during workflow pull

### DIFF
--- a/.github/workflows/stock-recs.yml
+++ b/.github/workflows/stock-recs.yml
@@ -326,7 +326,7 @@ jobs:
             exit 0
           fi
           git commit -m "chore: data update (news/fx/summary) [skip ci]"
-          git pull --rebase origin "${{ github.ref_name }}"
+          git pull --rebase --autostash origin "${{ github.ref_name }}"
           git push origin HEAD:"${{ github.ref_name }}"
 
       - name: Verify HEAD has fresh data


### PR DESCRIPTION
## Summary
- Use `git pull --rebase --autostash` to keep workflow commits clean

## Testing
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68b5531079ac832ab90ff7ccdf89e9a2