### PR TITLE
feat: prune cache in stock recs workflow

### DIFF
--- a/.github/workflows/stock-recs.yml
+++ b/.github/workflows/stock-recs.yml
@@ -309,10 +309,17 @@ jobs:
       - name: Build article cache
         run: node build-articles.js
 
+      - name: Prune cache directory
+        env:
+          CACHE_LIMIT: 1000
+        run: node tools/prune-cache.js
+
       - name: Stage new data files
         shell: bash
         run: |
-          git add data/market-news.json data/fx_rates.json summary.json summary.md data/articles pools-metrics.json recommendations.json ticker-cache.json pools.json pools-cache.json || true
+          git add data/market-news.json data/fx_rates.json summary.json summary.md data/articles \
+                  pools-metrics.json recommendations.json ticker-cache.json pools.json pools-cache.json \
+                  cache || true
           echo "Files staged for commit"
 
       - name: Commit & push changes

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "stocks:refresh": "node fetchStockInfo.js --force",
     "build:recs": "node src/index.js --force",
     "check:recs": "node tools/validate-recs.js recommendations.json",
-    "check:structure": "node tools/validate-structure.js"
+    "check:structure": "node tools/validate-structure.js",
+    "prune:cache": "node tools/prune-cache.js"
   },
   "engines": {
     "node": ">=18"

--- a/tools/prune-cache.js
+++ b/tools/prune-cache.js
@@ -1,0 +1,56 @@
+import { promises as fsp } from 'fs';
+import path from 'path';
+
+const ROOT = process.cwd();
+const CACHE_DIR = path.join(ROOT, 'cache');
+const LIMIT = Number(process.env.CACHE_LIMIT || 1000);
+const DRY_RUN = process.env.DRY_RUN === '1';
+
+async function *walk(dir) {
+  const dirh = await fsp.opendir(dir);
+  for await (const dirent of dirh) {
+    const p = path.join(dir, dirent.name);
+    if (dirent.isDirectory()) {
+      yield *walk(p);
+    } else if (dirent.isFile()) {
+      yield p;
+    }
+  }
+}
+
+async function prune() {
+  // Collect all files under cache/
+  const files = [];
+  for await (const filePath of walk(CACHE_DIR)) {
+    const stat = await fsp.stat(filePath);
+    files.push({ filePath, mtime: stat.mtimeMs });
+  }
+
+  // Sort newest first
+  files.sort((a, b) => b.mtime - a.mtime);
+
+  if (files.length <= LIMIT) {
+    console.log(`Cache has ${files.length} files (<= ${LIMIT}); nothing to prune.`);
+    return;
+  }
+
+  const toRemove = files.slice(LIMIT);
+  console.log(`Keeping ${LIMIT}, pruning ${toRemove.length} older files in ${CACHE_DIR}…`);
+
+  if (DRY_RUN) {
+    toRemove.slice(0, 10).forEach(f => console.log(`[dry-run] would remove ${f.filePath}`));
+    if (toRemove.length > 10) console.log(`[dry-run] …and ${toRemove.length - 10} more`);
+    return;
+  }
+
+  // Delete older files
+  for (const f of toRemove) {
+    await fsp.unlink(f.filePath);
+  }
+  console.log(`Done. Pruned ${toRemove.length} files.`);
+}
+
+prune().catch(err => {
+  console.error('Failed to prune cache:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add tools/prune-cache.js to keep newest cache files
- wire pruner and cache staging into stock-recs workflow
- expose `prune:cache` npm script

## Testing
- `DRY_RUN=1 node tools/prune-cache.js`
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68b567171978832abc664e469886fa3a