### PR TITLE
feat: derive relative blog and naver metrics

### DIFF
--- a/fetchStockInfo.js
+++ b/fetchStockInfo.js
@@ -790,6 +790,25 @@ async function tryFetchAndEnrich() {
           else if (typeof metrics?.score?.total === 'number') baseScore = Math.round(metrics.score.total);
           else if (typeof metrics?.score?.safe === 'number') baseScore = Math.round(metrics.score.safe * 100);
           if (baseScore == null) baseScore = 50;
+
+          const reputationScore = metrics?.reputationScore ?? news.reputationScore ?? null;
+          const topKeywords = (metrics?.topKeywords && metrics.topKeywords.length)
+            ? metrics.topKeywords
+            : (news.topKeywords || []);
+          const sentiment = Number.isFinite(metrics?.sentiment)
+            ? +metrics.sentiment.toFixed(2)
+            : (Number.isFinite(news.sentiment) ? +news.sentiment.toFixed(2) : 0);
+          const blog = Number.isFinite(metrics?.blogScore)
+            ? +metrics.blogScore.toFixed(2)
+            : (Number.isFinite(metrics?.blogMentions)
+                ? +metrics.blogMentions.toFixed(2)
+                : (Number.isFinite(news.blogMentions) ? news.blogMentions|0 : 0));
+          const naver = Number.isFinite(metrics?.naverScore)
+            ? +metrics.naverScore.toFixed(2)
+            : (Number.isFinite(metrics?.naverPopularity)
+                ? +metrics.naverPopularity.toFixed(2)
+                : (Number.isFinite(trend.naverPopularity) ? +trend.naverPopularity.toFixed(2) : 0));
+
           updated.push({
             name: displayName,
             sector,
@@ -797,12 +816,12 @@ async function tryFetchAndEnrich() {
             searchUrl,
             score: baseScore,
             reasons: {
-              reputationScore: news.reputationScore ?? null,
-              topKeywords: news.topKeywords || [],
+              reputationScore,
+              topKeywords,
               signals: {
-                sentiment: Number.isFinite(news.sentiment) ? +news.sentiment.toFixed(2) : 0,
-                blog: Number.isFinite(news.blogMentions) ? news.blogMentions|0 : 0,
-                naver: Number.isFinite(trend.naverPopularity) ? +trend.naverPopularity.toFixed(2) : 0
+                sentiment,
+                blog,
+                naver
               }
             }
           });
@@ -816,7 +835,14 @@ async function tryFetchAndEnrich() {
           else if (typeof metrics?.score?.total === 'number') baseScore = Math.round(metrics.score.total);
           else if (typeof metrics?.score?.safe === 'number') baseScore = Math.round(metrics.score.safe * 100);
           if (baseScore == null) baseScore = 50;
-          updated.push({ name: rawName, sector: null, ticker: null, searchUrl: null, score: baseScore, reasons: { reputationScore: null, topKeywords: [], signals: { sentiment: 0, blog: 0, naver: 0 } } });
+          const sentiment = Number.isFinite(metrics?.sentiment) ? +metrics.sentiment.toFixed(2) : 0;
+          const blog = Number.isFinite(metrics?.blogScore)
+            ? +metrics.blogScore.toFixed(2)
+            : (Number.isFinite(metrics?.blogMentions) ? +metrics.blogMentions.toFixed(2) : 0);
+          const naver = Number.isFinite(metrics?.naverScore)
+            ? +metrics.naverScore.toFixed(2)
+            : (Number.isFinite(metrics?.naverPopularity) ? +metrics.naverPopularity.toFixed(2) : 0);
+          updated.push({ name: rawName, sector: null, ticker: null, searchUrl: null, score: baseScore, reasons: { reputationScore: null, topKeywords: [], signals: { sentiment, blog, naver } } });
           noteStatus(err);
         }
 

--- a/tools/buildPoolsTrendy.js
+++ b/tools/buildPoolsTrendy.js
@@ -1860,6 +1860,16 @@ async function main(){
     const rankedSafe = filterOutEarlier(safeSorted);
     const rankedAggr = filterOutEarlier(aggrSorted);
 
+    // --- relative normalization for blog and Naver popularity ---
+    const blogMax = Math.max(...names.map(n => byName[n].blogMentions || 0), 0);
+    const naverMax = Math.max(...names.map(n => byName[n].naverPopularity || 0), 0);
+    for (const n of names) {
+      const blogRaw = byName[n].blogMentions || 0;
+      const navRaw  = byName[n].naverPopularity || 0;
+      byName[n].blogScore  = blogMax > 0 ? clamp01(blogRaw / blogMax) : 0;
+      byName[n].naverScore = naverMax > 0 ? clamp01(navRaw / naverMax) : 0;
+    }
+
     pools[market] = { safe: rankedSafe, aggressive: rankedAggr };
 
     // Record for later markets
@@ -1893,7 +1903,9 @@ async function main(){
         naverCount: byName[n].naverCount,
         naverCountKO: byName[n].naverCountKO,
         naverCountEN: byName[n].naverCountEN,
-        blogMentions: clamp01((byName[n].blogMentions || 0) / 10),
+        blogMentions: byName[n].blogMentions || 0,
+        blogScore: byName[n].blogScore,
+        naverScore: byName[n].naverScore,
         wikiViews: byName[n].wikiViews,
         fmpNewsCount: byName[n].fmpNewsCount,
         googleNewsCount: byName[n].googleNewsCount,


### PR DESCRIPTION
## Summary
- normalize Naver popularity and blog mentions per market in buildPoolsTrendy and persist the relative scores
- populate recommendations signals from pools-metrics, including reputation and keyword data

## Testing
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68bcc9241ae4832aa01549714e70ec1b