### PR TITLE
Add multi-source quote helper and ESM smoke tests

### DIFF
--- a/.github/workflows/stock-recs.yml
+++ b/.github/workflows/stock-recs.yml
@@ -166,6 +166,12 @@ jobs:
           echo "npm ci failed after retries."
           exit 1
 
+      - name: Run ESM smoke tests (non-blocking)
+        shell: bash
+        run: |
+          node --version
+          node --test tests/*.test.js || echo "No tests or tests failed — continuing"
+
       - name: Build index ticker maps
         run: node tools/updateIndexMaps.mjs
         env:
@@ -251,7 +257,8 @@ jobs:
             echo "recommendations.json valid."
           else
             echo "Rebuilding recommendations (pools already built this run)..."
-            node fetchStockInfo.js --force
+            # Prefer the enhanced path first (multi-source quotes); fall back to legacy
+            node fetchStockInfo.js --force --enhanced || node fetchStockInfo.js --force
             validate_json
           fi
 

--- a/fetchStockInfo.js
+++ b/fetchStockInfo.js
@@ -1,8 +1,62 @@
 // fetchStockInfo.js — improved version with fallbacks and KOSDAQ stocks
+// === ADDITIVE ENHANCEMENT (ESM) ============================================
+// Usage:
+//   node fetchStockInfo.js --enhanced [--force]
+// Behavior:
+//   - Reads symbolNames.json to get the universe
+//   - If recommendations.json is stale (> RECO_TTL_HOURS), refresh using fetchByTickers
+//   - Writes recommendations.json { lastUpdated, items:[{symbol,name,...quoteFields}] }
+// Notes:
+//   - Does NOT remove or alter your existing logic; this block runs only with --enhanced.
+// ==========================================================================
 import fs, { writeFile, rename, readFile } from 'fs/promises';
 import { existsSync } from 'fs';
 import path from 'node:path';
 import { nowKSTISO } from './utils/time.js';
+import { fetchByTickers } from './src/data/quotes.js';
+
+async function readJSON(p, fallback=null){
+  try { return JSON.parse(await fs.readFile(p, 'utf8')); }
+  catch { return fallback; }
+}
+function isFresh(obj, ttlMs){
+  const ts = obj?.lastUpdated && Date.parse(obj.lastUpdated);
+  return !!ts && (Date.now() - ts < ttlMs);
+}
+
+export async function enhancedBuildStockInfo() {
+  const names = await readJSON('./symbolNames.json', {});
+  const tickers = Object.keys(names || {});
+  if (!tickers.length) {
+    console.warn('[enhancedStockInfo] No symbols in symbolNames.json — skipping enhanced path');
+    return;
+  }
+  const outFile = './recommendations.json';
+  const current = await readJSON(outFile, null);
+  const TTL_MS = Number(process.env.RECO_TTL_HOURS || 6) * 3600_000;
+  const force = process.argv.includes('--force');
+  if (current && isFresh(current, TTL_MS) && !force) {
+    console.log('[enhancedStockInfo] cache is fresh; skip');
+    return;
+  }
+  const quotes = await fetchByTickers(tickers);
+  const by = Object.fromEntries(quotes.map(q => [q.symbol, q]));
+  const items = tickers.map(t => ({
+    symbol: t,
+    name: names[t] || t,
+    ...(by[t] || {})
+  }));
+  const payload = { lastUpdated: new Date().toISOString(), items };
+  await fs.writeFile(outFile, JSON.stringify(payload, null, 2));
+  console.log(`[enhancedStockInfo] wrote ${items.length} items`);
+}
+
+if (process.argv.includes('--enhanced')) {
+  enhancedBuildStockInfo().catch(e => {
+    console.error('[enhancedStockInfo] failed:', e?.message || e);
+    process.exitCode = 1;
+  });
+}
 
 const poolsMetricsRaw = JSON.parse(
   await readFile(new URL('./pools-metrics.json', import.meta.url), 'utf8')

--- a/src/data/quotes.js
+++ b/src/data/quotes.js
@@ -1,0 +1,142 @@
+// ESM helper: multi-source quotes with merging & de-duplication.
+// Provides: fetchByTickers(tickers, { prefer })
+// Sources: Yahoo (no key), Finnhub (token), TwelveData (token)
+// Notes:
+//  - Purely additive; does not replace existing data paths.
+//  - Keep concurrency small to respect provider limits.
+//  - Normalizes to a compact shape used by fetchStockInfo's enhanced path.
+
+const MAX_CONCURRENCY = Number(process.env.MAX_CONCURRENCY || 2);
+const REQ_TIMEOUT_MS = Number(process.env.REQ_TIMEOUT_MS || 12000);
+
+function toTicker(s) { return String(s || '').trim().toUpperCase(); }
+
+function normalizeQuote(raw) {
+  if (!raw) return null;
+  const q = raw.quote || raw;
+  const out = {
+    symbol: toTicker(q.symbol || q.ticker),
+    name: q.longName || q.shortName || q.name || null,
+    sector: q.sector || q.industry || null,
+    regularMarketPrice: Number(q.regularMarketPrice ?? q.price ?? q.c ?? 0),
+    regularMarketPreviousClose: Number(q.regularMarketPreviousClose ?? q.previousClose ?? q.pc ?? 0),
+    marketCap: Number(q.marketCap ?? q.market_cap ?? q.mktCap ?? 0),
+  };
+  return out;
+}
+
+function mergeQuotes(list) {
+  const by = new Map();
+  for (const item of (list || []).filter(Boolean)) {
+    const q = normalizeQuote(item);
+    if (!q || !q.symbol) continue;
+    const ex = by.get(q.symbol) || {};
+    by.set(q.symbol, { ...ex, ...q });
+  }
+  return [...by.values()];
+}
+
+function abortableFetch(url, opts = {}, timeoutMs = REQ_TIMEOUT_MS) {
+  const ctrl = new AbortController();
+  const t = setTimeout(() => ctrl.abort(new Error('timeout')), timeoutMs);
+  return fetch(url, { ...opts, signal: ctrl.signal }).finally(() => clearTimeout(t));
+}
+
+async function fetchJSON(url, { retries = 2, timeoutMs = REQ_TIMEOUT_MS, retryOn = s => s === 429 || s >= 500 } = {}) {
+  let last;
+  for (let i = 0; i <= retries; i++) {
+    try {
+      const res = await abortableFetch(url, {}, timeoutMs);
+      if (!res.ok) {
+        const body = await res.text().catch(() => '');
+        const err = new Error(`HTTP ${res.status} for ${url}: ${body.slice(0, 160)}`);
+        err.status = res.status;
+        throw err;
+      }
+      const ct = res.headers.get('content-type') || '';
+      if (/json|javascript/i.test(ct)) return res.json();
+      const text = await res.text();
+      try { return JSON.parse(text); } catch { throw new Error(`Non-JSON from ${url}`); }
+    } catch (e) {
+      last = e;
+      if (i < retries && retryOn(e.status || 0)) {
+        const backoff = Math.pow(2, i) * 300 + Math.random() * 100;
+        await new Promise(r => setTimeout(r, backoff));
+        continue;
+      }
+      break;
+    }
+  }
+  throw last;
+}
+
+async function yahooQuotes(tickers) {
+  if (!tickers.length) return [];
+  const url = 'https://query1.finance.yahoo.com/v7/finance/quote?symbols=' +
+              encodeURIComponent(tickers.join(','));
+  const json = await fetchJSON(url);
+  const items = (json?.quoteResponse?.result) || [];
+  return items.map(q => ({ quote: q }));
+}
+
+async function finnhubQuotes(tickers) {
+  const key = process.env.FINNHUB_API_KEY;
+  if (!key || !tickers.length) return [];
+  const out = [];
+  // simple p-map with low concurrency
+  let i = 0;
+  async function worker() {
+    while (i < tickers.length) {
+      const t = tickers[i++]; // take next
+      try {
+        const j = await fetchJSON(`https://finnhub.io/api/v1/quote?symbol=${encodeURIComponent(t)}&token=${key}`);
+        out.push({ quote: { symbol: toTicker(t), c: j.c, pc: j.pc } });
+      } catch (e) {
+        console.warn(`[finnhub] ${t} failed: ${e.message || e}`);
+      }
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(MAX_CONCURRENCY, tickers.length || 1) }, worker));
+  return out;
+}
+
+async function twelvedataQuotes(tickers) {
+  const key = process.env.TWELVEDATA_API_KEY;
+  if (!key || !tickers.length) return [];
+  const url = `https://api.twelvedata.com/price?symbol=${encodeURIComponent(tickers.join(','))}&apikey=${key}`;
+  const json = await fetchJSON(url);
+  const out = [];
+  if (Array.isArray(json?.data)) {
+    for (const it of json.data) out.push({ quote: { symbol: toTicker(it.symbol), price: Number(it.price) } });
+  } else if (json && typeof json === 'object') {
+    for (const [sym, val] of Object.entries(json)) {
+      if (val && val.price != null) out.push({ quote: { symbol: toTicker(sym), price: Number(val.price) } });
+    }
+  }
+  return out;
+}
+
+/**
+ * Multi-source fetch with merging & de-duplication.
+ * @param {string[]} tickers
+ * @param {{prefer?: ('yahoo'|'finnhub'|'twelvedata')[]}} opts
+ * @returns {Promise<Array<{symbol:string,name?:string,sector?:string,regularMarketPrice?:number,regularMarketPreviousClose?:number,marketCap?:number}>>}
+ */
+export async function fetchByTickers(tickers, { prefer = ['yahoo', 'finnhub', 'twelvedata'] } = {}) {
+  const unique = [...new Set(tickers.map(toTicker))].filter(Boolean);
+  if (!unique.length) return [];
+  const results = [];
+  for (const src of prefer) {
+    try {
+      if (src === 'yahoo') results.push(...await yahooQuotes(unique));
+      else if (src === 'finnhub') results.push(...await finnhubQuotes(unique));
+      else if (src === 'twelvedata') results.push(...await twelvedataQuotes(unique));
+    } catch (e) {
+      console.warn(`[fetchByTickers] ${src} failed: ${e.message || e}`);
+    }
+  }
+  return mergeQuotes(results);
+}
+
+export { toTicker, mergeQuotes, normalizeQuote };
+

--- a/tests/quotes.test.js
+++ b/tests/quotes.test.js
@@ -1,0 +1,9 @@
+// Minimal smoke test for ESM export shape
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+test('fetchByTickers export exists', async (t) => {
+  const mod = await import('../src/data/quotes.js');
+  assert.equal(typeof mod.fetchByTickers, 'function');
+});
+

--- a/tools/buildPoolsTrendy.js
+++ b/tools/buildPoolsTrendy.js
@@ -134,13 +134,13 @@ async function fetchFmpNewsCount(sym){
 async function fetchGoogleNewsCount(sym){
   if (!sym || OFFLINE) return 0;
   const url = `https://news.google.com/rss/search?q=${encodeURIComponent(sym)}&hl=en-US&gl=US&ceid=US:en`;
-  return fetchCountTextGeneric(url, txt => (txt.match(/<item>/g) || []).length, TTL.newsRss);
+  return fetchCountTextGeneric(url, txt => (txt.match(/<item\b/gi) || []).length, TTL.newsRss);
 }
 
 async function fetchYahooNewsCount(sym){
   if (!sym || OFFLINE) return 0;
   const url = `https://feeds.finance.yahoo.com/rss/2.0/headline?s=${encodeURIComponent(sym)}&region=US&lang=en-US`;
-  return fetchCountTextGeneric(url, txt => (txt.match(/<item>/g) || []).length, TTL.newsRss);
+  return fetchCountTextGeneric(url, txt => (txt.match(/<item\b/gi) || []).length, TTL.newsRss);
 }
 
 async function fetchInvestingNewsCount(sym){


### PR DESCRIPTION
## Summary
- add ESM helper for fetching quotes from Yahoo, Finnhub and TwelveData
- update stock recommendations script with optional enhanced path using new helper
- run non-blocking Node smoke tests in workflow and fix RSS item counting

## Testing
- `node tests/apple_association.test.js`
- `node --test tests/quotes.test.js`
- `node --test tests/*.test.js` *(fails: pools_rotation.test.js assertion)*

------
https://chatgpt.com/codex/tasks/task_b_68bd26df06a0832ab6a47a4628299ba2