### PR TITLE
fix: ensure daily build refreshes pools

### DIFF
--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -37,7 +37,7 @@ jobs:
           TWELVEDATA_API_KEY: ${{ secrets.TWELVEDATA_API_KEY }}
           RECO_TTL_HOURS: 6
         run: |
-          node fetchStockInfo.js --force || true
+          node fetchStockInfo.js --force --refresh-pools || true
       - name: Rebuild stocks page (if applicable)
         run: |
           node src/build.js || true


### PR DESCRIPTION
## Summary
- ensure daily workflow forces a pools refresh when fetching stock info

## Testing
- `bash .github/scripts/check-refresh-pools.sh`
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68bd5de156e8832a8b1fe03b095a8428