### PR TITLE
Remove debug and refresh buttons

### DIFF
--- a/src/template.html
+++ b/src/template.html
@@ -78,8 +78,6 @@
       <li><strong>S&P 500:</strong> <span data-i18n="spDesc">미국 대표 대형주 지수</span></li>
       <li><strong>NASDAQ 100:</strong> <span data-i18n="nasdaqDesc">나스닥 상장 비금융 대형주 100종목으로 기술주 비중 높음</span></li>
     </ul>
-    <button onclick="toggleDebug()" data-i18n="toggleDebug">디버그 모드 토글</button>
-    <button onclick="refreshAllData(event)" data-i18n="refreshData">데이터 새로고침</button>
   </div>
 
   <div id="disclaimer" role="note" data-i18n="disclaimer">
@@ -114,9 +112,6 @@
         // nyseDesc: '뉴욕 증권거래소 상장 종목 전체를 반영한 지수', // removed: site no longer covers NYSE
         spDesc: '미국 대표 대형주 지수',
         nasdaqDesc: '나스닥 상장 비금융 대형주 100종목으로 기술주 비중 높음',
-        toggleDebug: '디버그 모드 토글',
-        refreshData: '데이터 새로고침',
-        refreshing: '새로고침 중...',
         disclaimer: '본 페이지의 정보는 투자 참고용이며, 제공된 데이터의 정확성을 보장하지 않습니다. 투자 판단의 책임은 이용자에게 있습니다.',
         marketNews: '최신 마켓 뉴스',
         portfolioRecs: '포트폴리오 추천',
@@ -141,9 +136,6 @@
         // nyseDesc: 'Index reflecting all NYSE listings', // removed: site no longer covers NYSE
         spDesc: 'Major U.S. large-cap index',
         nasdaqDesc: 'Tech-heavy index of 100 non-financial NASDAQ stocks',
-        toggleDebug: 'Toggle Debug Mode',
-        refreshData: 'Refresh Data',
-        refreshing: 'Refreshing...',
         disclaimer: 'Information on this page is for reference only and accuracy is not guaranteed. Investment decisions are your responsibility.',
         marketNews: 'Latest Market News',
         portfolioRecs: 'Portfolio Recommendations',

--- a/stocks.html
+++ b/stocks.html
@@ -3,9 +3,6 @@
 <head>
     <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-3360521146359419" crossorigin="anonymous"></script>
     <meta name="google-adsense-account" content="ca-pub-3360521146359419">
-  <!-- additive runtime metrics; safe no-op if duplicated -->
-  <script defer src="src/stocks.runtime.js"></script>
-
 
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -65,7 +62,7 @@
   <a href="index.html" class="home-button" aria-label="Home">&#x21A9;</a>
   <h1 data-i18n="title">데일리 주식 리포트 자동화</h1>
   <p class="dashboard-link"><a data-i18n="dashboardLink" href="stocks/index.html">Stock News Summary Dashboard</a></p>
-  <p id="currentDate"><span id="datePrefix" data-i18n="today">오늘:</span> 2025년 8월 27일</p>
+  <p id="currentDate"><span id="datePrefix" data-i18n="today">오늘:</span> 2025년 9월 7일</p>
   
   <div id="debugInfo" class="debug" style="display: none;">
     <h4>디버그 정보:</h4>
@@ -81,8 +78,6 @@
       <li><strong>S&P 500:</strong> <span data-i18n="spDesc">미국 대표 대형주 지수</span></li>
       <li><strong>NASDAQ 100:</strong> <span data-i18n="nasdaqDesc">나스닥 상장 비금융 대형주 100종목으로 기술주 비중 높음</span></li>
     </ul>
-    <button onclick="toggleDebug()" data-i18n="toggleDebug">디버그 모드 토글</button>
-    <button onclick="refreshAllData(event)" data-i18n="refreshData">데이터 새로고침</button>
   </div>
 
   <div id="disclaimer" role="note" data-i18n="disclaimer">
@@ -117,9 +112,6 @@
         // nyseDesc: '뉴욕 증권거래소 상장 종목 전체를 반영한 지수', // removed: site no longer covers NYSE
         spDesc: '미국 대표 대형주 지수',
         nasdaqDesc: '나스닥 상장 비금융 대형주 100종목으로 기술주 비중 높음',
-        toggleDebug: '디버그 모드 토글',
-        refreshData: '데이터 새로고침',
-        refreshing: '새로고침 중...',
         disclaimer: '본 페이지의 정보는 투자 참고용이며, 제공된 데이터의 정확성을 보장하지 않습니다. 투자 판단의 책임은 이용자에게 있습니다.',
         marketNews: '최신 마켓 뉴스',
         portfolioRecs: '포트폴리오 추천',
@@ -144,9 +136,6 @@
         // nyseDesc: 'Index reflecting all NYSE listings', // removed: site no longer covers NYSE
         spDesc: 'Major U.S. large-cap index',
         nasdaqDesc: 'Tech-heavy index of 100 non-financial NASDAQ stocks',
-        toggleDebug: 'Toggle Debug Mode',
-        refreshData: 'Refresh Data',
-        refreshing: 'Refreshing...',
         disclaimer: 'Information on this page is for reference only and accuracy is not guaranteed. Investment decisions are your responsibility.',
         marketNews: 'Latest Market News',
         portfolioRecs: 'Portfolio Recommendations',


### PR DESCRIPTION
## Summary
- drop debug and refresh buttons from stocks page template
- rebuild stocks.html without debug toggle or manual refresh controls

## Testing
- `OFFLINE=1 node src/build.js`
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68bd676cafdc832a97e271af73b7a01e