### PR TITLE
fix: guard click set toggle

### DIFF
--- a/Linear_Transformation_Lab/index.html
+++ b/Linear_Transformation_Lab/index.html
@@ -799,7 +799,9 @@ $('#resetAll').addEventListener('click', () => {
 });
 
 canvas.addEventListener('click', (e) => {
-  if (!$('#clickSet').checked) return;
+  // guard: plain getElementById expects id without '#'
+  const clickSetEl = $('clickSet');
+  if (!clickSetEl || !clickSetEl.checked) return;
   if (is3D()) return; // 3D uses raycast
   const rect = canvas.getBoundingClientRect();
   const xpx = e.clientX - rect.left - CW/2;
@@ -946,7 +948,9 @@ function ensure3D(){
   const raycaster = new THREE.Raycaster();
   const mouse = new THREE.Vector2();
   renderer.domElement.addEventListener('click', (ev) => {
-    if (!is3D() || !$('#clickSet').checked) return;
+    // guard: plain getElementById expects id without '#'
+    const clickSetEl = $('clickSet');
+    if (!is3D() || !clickSetEl || !clickSetEl.checked) return;
     const rect = renderer.domElement.getBoundingClientRect();
     mouse.x = ((ev.clientX - rect.left)/rect.width)*2 - 1;
     mouse.y = -((ev.clientY - rect.top)/rect.height)*2 + 1;


### PR DESCRIPTION
## Summary
- add click-set checkbox guard for 2D and 3D event handlers

## Testing
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68bd87f4b1c4832aa35ee6817042dde6