### PR TITLE
feat: improve linear transformation lab ui

### DIFF
--- a/Linear_Transformation_Lab/index.html
+++ b/Linear_Transformation_Lab/index.html
@@ -61,8 +61,8 @@
     .controls fieldset { border: 1px solid #444; margin: 8px 0; padding: 6px 10px; }
     .controls legend { font-weight: 600; }
     .row { display:flex; gap:8px; align-items:center; margin:4px 0; flex-wrap: wrap; }
-    .grid3x3 { display:grid; grid-template-columns:repeat(3, 64px); gap:6px; }
-    .grid3x3 input[type=number]{ width:64px; }
+    #matGrid { display:grid; grid-template-columns:repeat(3, 64px); gap:6px; }
+    #matGrid input[type=number]{ width:64px; }
     .knob { display:flex; gap:6px; align-items:center; }
     .knob label { width: 22px; opacity: 0.85; }
     .knob input[type=number]{ width:72px; }
@@ -82,6 +82,17 @@
     }
     #scene3d { display:none; }
     #scene3d canvas { display:block; }
+    #splitter {
+      position: fixed;
+      top: var(--topbar-h);
+      bottom: 0;
+      left: var(--sidebar-w);
+      width: 4px;
+      margin-left: -2px;
+      cursor: ew-resize;
+      background: #333;
+      z-index: 6;
+    }
     button { cursor: pointer; }
     select, input, button { background:#2a2a2a; color:#eee; border:1px solid #444; border-radius:4px; padding:3px 6px; }
     input[type=checkbox], input[type=radio] { transform: translateY(1px); }
@@ -137,7 +148,7 @@
 
     <fieldset>
       <legend>Matrix \( A \)</legend>
-      <div class="grid3x3">
+      <div id="matGrid" class="grid3x3">
         <input id="a11" type="number" step="0.25" value="1">
         <input id="a12" type="number" step="0.25" value="0">
         <input id="a13" class="dim3d" type="number" step="0.25" value="0">
@@ -178,6 +189,8 @@
     </fieldset>
   </div>
 
+  <div id="splitter"></div>
+
   <!-- Drawing areas -->
   <div id="scene3d"></div>
   <canvas id="graph"></canvas>
@@ -189,6 +202,9 @@
 const q = s => document.querySelector(s);
 const $ = id => document.getElementById(id);
 function fmt(n){ return Math.round(n*1000)/1000; }
+function getSidebarWidth(){
+  return parseInt(getComputedStyle(document.documentElement).getPropertyValue('--sidebar-w')) || 205;
+}
 
 /* =========================
    Canvas & 2D State
@@ -228,7 +244,7 @@ let kvector=[0,0,1];
 ========================= */
 function sizingCanvas(){
   const dpr = window.devicePixelRatio || 1;
-  const cssWidth = window.innerWidth - 205;
+  const cssWidth = window.innerWidth - getSidebarWidth();
   const cssHeight = window.innerHeight - 50;
   canvas.style.width = cssWidth + 'px';
   canvas.style.height = cssHeight + 'px';
@@ -644,6 +660,9 @@ function setInputsFromVector(){
   $('#vi_in').value = vi;
   $('#vj_in').value = vj;
   if ($('#vk_in')) $('#vk_in').value = vk;
+  if ($('#vi_slider')) $('#vi_slider').value = vi;
+  if ($('#vj_slider')) $('#vj_slider').value = vj;
+  if ($('#vk_slider')) $('#vk_slider').value = vk;
   updateLabels();
 }
 
@@ -744,6 +763,25 @@ canvas.addEventListener("wheel", (event) => {
   handleResize();
 });
 
+/* resizable sidebar */
+(function(){
+  const split = document.getElementById('splitter');
+  if (!split) return;
+  let drag=false, startX=0, startW=0;
+  split.addEventListener('mousedown', e=>{
+    drag=true; startX=e.clientX; startW=getSidebarWidth();
+    document.body.style.userSelect='none';
+  });
+  window.addEventListener('mousemove', e=>{
+    if (!drag) return;
+    const newW = Math.min(400, Math.max(150, startW + e.clientX - startX));
+    document.documentElement.style.setProperty('--sidebar-w', newW+'px');
+    handleResize();
+    resize3D();
+  });
+  window.addEventListener('mouseup', ()=>{ if(drag){ drag=false; document.body.style.userSelect=''; }});
+})();
+
 /* inputs ↔ state */
 $('#vi_in').addEventListener('change', setVectorFromInputs);
 $('#vj_in').addEventListener('change', setVectorFromInputs);
@@ -798,20 +836,20 @@ $('#resetAll').addEventListener('click', () => {
   if (is3D()){ update3DObjects(); fitToView3D(); }
 });
 
-canvas.addEventListener('click', (e) => {
-  // guard: plain getElementById expects id without '#'
-  const clickSetEl = $('clickSet');
-  if (!clickSetEl || !clickSetEl.checked) return;
-  if (is3D()) return; // 3D uses raycast
+function setVectorFromMouse(e, constrain){
   const rect = canvas.getBoundingClientRect();
-  const xpx = e.clientX - rect.left - CW/2;
-  const ypx = CH/2 - (e.clientY - rect.top);
-  const X = xpx / absscale;
-  const Y = ypx / absscale;
+  let X = (e.clientX - rect.left - CW/2) / absscale;
+  let Y = (CH/2 - (e.clientY - rect.top)) / absscale;
+  if (constrain){
+    const r = Math.hypot(X,Y);
+    const ang = Math.atan2(Y,X);
+    const snap = Math.round(ang/(Math.PI/4))*(Math.PI/4);
+    X = r*Math.cos(snap);
+    Y = r*Math.sin(snap);
+  }
   const B = basisMatrix();
   const Binv = invert2x2(B);
   if (!Binv){
-    console.warn('기저가 퇴화(Det=0)되어 v를 계산할 수 없음');
     alert('기저가 퇴화하여 v를 계산할 수 없습니다.');
     return;
   }
@@ -819,7 +857,21 @@ canvas.addEventListener('click', (e) => {
   vj = Binv[1][0]*X + Binv[1][1]*Y;
   setInputsFromVector();
   handleResize();
+}
+
+let dragging=false;
+canvas.addEventListener('mousedown', (e) => {
+  const clickSetEl = $('clickSet');
+  if (!clickSetEl || !clickSetEl.checked) return;
+  if (is3D()) return;
+  dragging=true;
+  setVectorFromMouse(e, e.shiftKey);
 });
+canvas.addEventListener('mousemove', (e) => {
+  if (!dragging) return;
+  setVectorFromMouse(e, e.shiftKey);
+});
+window.addEventListener('mouseup', () => { dragging=false; });
 
 window.addEventListener('keydown', (e) => {
   const step = (e.shiftKey ? 1 : 0.25);
@@ -859,11 +911,23 @@ linkKnob('vk_in','vk_slider');
    3D: scene, objects, interactions
 ========================= */
 function is3D(){ return document.getElementById('mode3d')?.checked; }
+function setupMatrixLayout(){
+  const grid = document.getElementById('matGrid');
+  if (!grid) return;
+  if (is3D()){
+    grid.style.gridTemplateColumns = 'repeat(3, 64px)';
+    ['a13','a23','a31','a32','a33'].forEach(id => { const el=$(id); if (el){ el.disabled=false; el.tabIndex=0; } });
+  }else{
+    grid.style.gridTemplateColumns = 'repeat(2, 64px)';
+    ['a13','a23','a31','a32','a33'].forEach(id => { const el=$(id); if (el){ el.disabled=true; el.tabIndex=-1; } });
+  }
+}
 function toggleDim(){
   document.querySelectorAll('.dim3d').forEach(el => el.style.display = is3D() ? '' : 'none');
   document.querySelectorAll('.dim2d').forEach(el => el.style.display = is3D() ? 'none' : '');
   document.getElementById('scene3d').style.display = is3D() ? 'block' : 'none';
   canvas.style.display  = is3D() ? 'none'  : 'block';
+  setupMatrixLayout();
   updateLabels();
 }
 $('#mode2d').addEventListener('change', toggleDim);
@@ -872,12 +936,22 @@ $('#mode3d').addEventListener('change', toggleDim);
 const __three = { ready:false };
 let __goalI=null, __goalJ=null, __goalK=null, __steps3D=0;
 
+function resize3D(){
+  if (!__three.ready) return;
+  const w = window.innerWidth - getSidebarWidth();
+  const h = window.innerHeight - 50;
+  __three.renderer.setPixelRatio(window.devicePixelRatio||1);
+  __three.renderer.setSize(w,h);
+  __three.camera.aspect = w/h;
+  __three.camera.updateProjectionMatrix();
+}
+
 function ensure3D(){
   if (__three.ready) return;
   const THREE = window.__THREE__;
   const OrbitControls = window.__OrbitControls__;
   // renderer & camera
-  const w = window.innerWidth - 205;
+  const w = window.innerWidth - getSidebarWidth();
   const h = window.innerHeight - 50;
   const renderer = new THREE.WebGLRenderer({antialias:true});
   renderer.setPixelRatio(window.devicePixelRatio||1);
@@ -974,13 +1048,7 @@ function ensure3D(){
   });
 
   // resize Three.js on window resize
-  window.addEventListener('resize', () => {
-    const w = window.innerWidth - 205, h = window.innerHeight - 50;
-    renderer.setPixelRatio(window.devicePixelRatio||1);
-    renderer.setSize(w,h);
-    camera.aspect = w/h;
-    camera.updateProjectionMatrix();
-  });
+  window.addEventListener('resize', resize3D);
 }
 
 function updateParallelepiped(){


### PR DESCRIPTION
## Summary
- Allow resizing the lab's sidebar with a draggable splitter and resize the scene accordingly
- Simplify 2D mode matrix inputs to a true 2×2 grid and re-enable 3×3 in 3D
- Support click-and-drag vector placement with optional axis/45° snapping and keep sliders synced

## Testing
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68bd8a1e6128832a8ff7ff3e0a43e1b0