### PR TITLE
Improve Linear Transformation Lab controls

### DIFF
--- a/Linear_Transformation_Lab/index.html
+++ b/Linear_Transformation_Lab/index.html
@@ -35,8 +35,8 @@
     .controls fieldset { border: 1px solid #444; margin: 8px 0; padding: 6px 10px; }
     .controls legend { font-weight: 600; }
     .row { display:flex; gap:8px; align-items:center; margin:4px 0; flex-wrap: wrap; }
-    .grid3x3 { display:grid; grid-template-columns:repeat(3, 64px); gap:6px; }
-    .grid3x3 input[type=number]{ width:64px; }
+    .matrix-grid { display:grid; grid-template-columns:repeat(2, 64px); gap:6px; }
+    .matrix-grid input[type=number]{ width:64px; }
     .knob { display:flex; gap:6px; align-items:center; }
     .knob label { width: 22px; opacity: 0.85; }
     .knob input[type=number]{ width:72px; }
@@ -90,7 +90,7 @@
         <input id="vk_slider" type="range" min="-10" max="10" step="0.25" value="0">
       </div>
       <label class="row">
-        <input type="checkbox" id="clickSet">
+        <input type="checkbox" id="clickSet" checked>
         Click to set \( \vec v \)
         <span class="dim3d" style="margin-left:6px;">(on selected plane)</span>
       </label>
@@ -103,7 +103,7 @@
 
     <fieldset>
       <legend>Matrix \( A \)</legend>
-      <div class="grid3x3">
+      <div id="matrixGrid" class="matrix-grid">
         <input id="a11" type="number" step="0.25" value="1">
         <input id="a12" type="number" step="0.25" value="0">
         <input id="a13" class="dim3d" type="number" step="0.25" value="0">

--- a/Linear_Transformation_Lab/lt2d.js
+++ b/Linear_Transformation_Lab/lt2d.js
@@ -456,6 +456,8 @@
   function setVectorFromInputs(){
     vi = parseFloat($('vi_in')?.value) || 0;
     vj = parseFloat($('vj_in')?.value) || 0;
+    if ($('vi_slider')) $('vi_slider').value = vi;
+    if ($('vj_slider')) $('vj_slider').value = vj;
     handleResize();
     updateLabels();
   }
@@ -463,6 +465,17 @@
   function setInputsFromVector(){
     if ($('vi_in')) $('vi_in').value = vi;
     if ($('vj_in')) $('vj_in').value = vj;
+    if ($('vi_slider')) $('vi_slider').value = vi;
+    if ($('vj_slider')) $('vj_slider').value = vj;
+    updateLabels();
+  }
+
+  function setVectorFromSliders(){
+    vi = parseFloat($('vi_slider')?.value) || 0;
+    vj = parseFloat($('vj_slider')?.value) || 0;
+    if ($('vi_in')) $('vi_in').value = vi;
+    if ($('vj_in')) $('vj_in').value = vj;
+    handleResize();
     updateLabels();
   }
 
@@ -525,8 +538,10 @@
     canvas.addEventListener('wheel', onWheel, { passive: false });
     canvas.addEventListener('click', onCanvasClick);
 
-    $('vi_in')?.addEventListener('change', setVectorFromInputs);
-    $('vj_in')?.addEventListener('change', setVectorFromInputs);
+    $('vi_in')?.addEventListener('input', setVectorFromInputs);
+    $('vj_in')?.addEventListener('input', setVectorFromInputs);
+    $('vi_slider')?.addEventListener('input', setVectorFromSliders);
+    $('vj_slider')?.addEventListener('input', setVectorFromSliders);
 
     $('applyA')?.addEventListener('click', applyAClick);
     $('composeA')?.addEventListener('click', composeAClick);

--- a/Linear_Transformation_Lab/lt3d.js
+++ b/Linear_Transformation_Lab/lt3d.js
@@ -335,6 +335,20 @@ import { OrbitControls } from 'https://unpkg.com/three@0.161.0/examples/jsm/cont
     vi = parseFloat($('vi_in')?.value) || 0;
     vj = parseFloat($('vj_in')?.value) || 0;
     vk = parseFloat($('vk_in')?.value) || 0;
+    if ($('vi_slider')) $('vi_slider').value = vi;
+    if ($('vj_slider')) $('vj_slider').value = vj;
+    if ($('vk_slider')) $('vk_slider').value = vk;
+    update3DObjects();
+  }
+
+  function onVectorSliders(){
+    if (!is3D()) return;
+    vi = parseFloat($('vi_slider')?.value) || 0;
+    vj = parseFloat($('vj_slider')?.value) || 0;
+    vk = parseFloat($('vk_slider')?.value) || 0;
+    if ($('vi_in')) $('vi_in').value = vi;
+    if ($('vj_in')) $('vj_in').value = vj;
+    if ($('vk_in')) $('vk_in').value = vk;
     update3DObjects();
   }
   function onApplyA(){
@@ -367,6 +381,9 @@ import { OrbitControls } from 'https://unpkg.com/three@0.161.0/examples/jsm/cont
     if ($('vi_in')) $('vi_in').value = vi;
     if ($('vj_in')) $('vj_in').value = vj;
     if ($('vk_in')) $('vk_in').value = vk;
+    if ($('vi_slider')) $('vi_slider').value = vi;
+    if ($('vj_slider')) $('vj_slider').value = vj;
+    if ($('vk_slider')) $('vk_slider').value = vk;
     // reset A to identity
     ['a11','a22','a33'].forEach(id => { if ($(id)) $(id).value = 1; });
     ['a12','a13','a21','a23','a31','a32'].forEach(id => { if ($(id)) $(id).value = 0; });
@@ -396,6 +413,8 @@ import { OrbitControls } from 'https://unpkg.com/three@0.161.0/examples/jsm/cont
     if (canvas2d)  canvas2d.style.display  = show3D ? 'none'  : 'block';
     // toggle 3D-only rows
     document.querySelectorAll('.dim3d').forEach(el => el.style.display = show3D ? '' : 'none');
+    const grid = $('matrixGrid');
+    if (grid) grid.style.gridTemplateColumns = show3D ? 'repeat(3,64px)' : 'repeat(2,64px)';
   }
 
   function onModeChange(){
@@ -410,9 +429,12 @@ import { OrbitControls } from 'https://unpkg.com/three@0.161.0/examples/jsm/cont
   // ===== init =====
   function init(){
     // wire controls (safe even if elements are missing)
-    $('vi_in')?.addEventListener('change', onVectorInputs);
-    $('vj_in')?.addEventListener('change', onVectorInputs);
-    $('vk_in')?.addEventListener('change', onVectorInputs);
+    $('vi_in')?.addEventListener('input', onVectorInputs);
+    $('vj_in')?.addEventListener('input', onVectorInputs);
+    $('vk_in')?.addEventListener('input', onVectorInputs);
+    $('vi_slider')?.addEventListener('input', onVectorSliders);
+    $('vj_slider')?.addEventListener('input', onVectorSliders);
+    $('vk_slider')?.addEventListener('input', onVectorSliders);
 
     $('applyA')?.addEventListener('click', onApplyA);
     $('composeA')?.addEventListener('click', onComposeA);


### PR DESCRIPTION
## Summary
- Default "Click to set" enabled for vector placement and align matrix inputs in a responsive 2x2 grid that expands to 3x3 in 3D mode.
- Synchronize vector sliders with number fields in both 2D and 3D, and toggle matrix grid size when switching modes.

## Testing
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68bd956bc8a8832a914fb72a40670520