### PR TITLE
Animate 2D to 3D transition in transformation lab

### DIFF
--- a/Linear_Transformation_Lab/index.html
+++ b/Linear_Transformation_Lab/index.html
@@ -48,9 +48,10 @@
     /* drawing areas */
     #graph, #scene3d {
       position: fixed; top: var(--topbar-h); left: var(--sidebar-w); right: 0; bottom: 0;
+      transition: opacity 0.6s ease;
     }
-    #scene3d { display:none; }
     #scene3d canvas { display:block; }
+    .hidden { opacity:0; pointer-events:none; }
 
     button { cursor: pointer; }
     select, input, button { background:#2a2a2a; color:#eee; border:1px solid #444; border-radius:4px; padding:3px 6px; }
@@ -145,7 +146,7 @@
   </div>
 
   <!-- Drawing areas -->
-  <div id="scene3d"></div>
+  <div id="scene3d" class="hidden"></div>
   <canvas id="graph"></canvas>
 
   <!-- Load scripts -->

--- a/Linear_Transformation_Lab/lt3d.js
+++ b/Linear_Transformation_Lab/lt3d.js
@@ -302,6 +302,40 @@ import { OrbitControls } from 'https://unpkg.com/three@0.161.0/examples/jsm/cont
     cam.updateProjectionMatrix();
   }
 
+  function animate2Dto3D(){
+    if (!S.ready) return;
+    // start with no k component to mimic 2D
+    kvector = [0,0,0];
+    update3DObjects();
+
+    fitToView3D();
+    const cam = S.camera;
+    const dist = cam.position.x; // after fitToView3D x=y=z=dist
+    cam.position.set(0,0,dist);
+    cam.lookAt(0,0,0);
+
+    S.gridXZ.material.transparent = true;
+    S.gridYZ.material.transparent = true;
+    S.gridXZ.material.opacity = 0;
+    S.gridYZ.material.opacity = 0;
+
+    goalI = ivector;
+    goalJ = jvector;
+    goalK = [0,0,1];
+    animateBasis3D();
+
+    let step = 0, steps = 60;
+    (function anim(){
+      const t = step/steps;
+      cam.position.set(dist*t, dist*t, dist);
+      S.gridXZ.material.opacity = t;
+      S.gridYZ.material.opacity = t;
+      cam.lookAt(0,0,0);
+      step++;
+      if (step <= steps) requestAnimationFrame(anim);
+    })();
+  }
+
   // ===== animations for basis under A =====
   let goalI=null, goalJ=null, goalK=null, steps=0;
   function animateBasis3D(){
@@ -409,8 +443,8 @@ import { OrbitControls } from 'https://unpkg.com/three@0.161.0/examples/jsm/cont
     const threeHost = $('scene3d');
     const canvas2d = $('graph');
     const show3D = is3D();
-    if (threeHost) threeHost.style.display = show3D ? 'block' : 'none';
-    if (canvas2d)  canvas2d.style.display  = show3D ? 'none'  : 'block';
+    if (threeHost) threeHost.classList.toggle('hidden', !show3D);
+    if (canvas2d)  canvas2d.classList.toggle('hidden', show3D);
     // toggle 3D-only rows
     document.querySelectorAll('.dim3d').forEach(el => el.style.display = show3D ? '' : 'none');
     const grid = $('matrixGrid');
@@ -418,11 +452,11 @@ import { OrbitControls } from 'https://unpkg.com/three@0.161.0/examples/jsm/cont
   }
 
   function onModeChange(){
+    const to3D = is3D();
     applyModeVisibility();
-    if (is3D()){
+    if (to3D){
       ensure3D();
-      update3DObjects();
-      fitToView3D();
+      animate2Dto3D();
     }
   }
 


### PR DESCRIPTION
## Summary
- Add cross-fading canvas setup with `.hidden` class to allow animated transitions
- Introduce `animate2Dto3D` to morph basis and camera from 2D plane to 3D cube
- Switch mode toggle to use CSS classes and run 3D animation on activation

## Testing
- `node tests/apple_association.test.js`
- `node --check Linear_Transformation_Lab/lt3d.js`


------
https://chatgpt.com/codex/tasks/task_b_68bd9a7e62ec832a80a6f7085dfc44f2