### PR TITLE
Center vector knob and enrich math details

### DIFF
--- a/Linear_Transformation_Lab/index.html
+++ b/Linear_Transformation_Lab/index.html
@@ -77,18 +77,18 @@
       <legend>Vector \( \vec v \)</legend>
       <div class="knob">
         <label>v<sub>i</sub></label>
-        <input id="vi_in" type="number" step="0.25" value="1">
-        <input id="vi_slider" type="range" min="-10" max="10" step="0.25" value="1">
+        <input id="vi_in" type="number" step="0.25" value="0">
+        <input id="vi_slider" type="range" min="-20" max="20" step="0.25" value="0">
       </div>
       <div class="knob">
         <label>v<sub>j</sub></label>
-        <input id="vj_in" type="number" step="0.25" value="2">
-        <input id="vj_slider" type="range" min="-10" max="10" step="0.25" value="2">
+        <input id="vj_in" type="number" step="0.25" value="0">
+        <input id="vj_slider" type="range" min="-20" max="20" step="0.25" value="0">
       </div>
       <div class="knob dim3d">
         <label>v<sub>k</sub></label>
         <input id="vk_in" type="number" step="0.25" value="0">
-        <input id="vk_slider" type="range" min="-10" max="10" step="0.25" value="0">
+        <input id="vk_slider" type="range" min="-20" max="20" step="0.25" value="0">
       </div>
       <label class="row">
         <input type="checkbox" id="clickSet" checked>
@@ -140,6 +140,12 @@
         <div class="detB">\( \det(B)=1 \)</div>
         <div class="detA">\( \det(A)=1 \)</div>
         <div class="vol">Volume scale \(=|\det(A)|=1\), orientation: preserved</div>
+        <div class="direction">방향: 0°</div>
+        <div class="distance">거리: 0</div>
+        <div class="movement">이동: (0,0)</div>
+        <div class="anglei">\(각도(\vec v,\hat i)=0^\circ,\;\text{넓이}=0\)</div>
+        <div class="anglej">\(각도(\vec v,\hat j)=0^\circ,\;\text{넓이}=0\)</div>
+        <div class="anglek dim3d">\(각도(\vec v,\hat k)=0^\circ,\;\text{넓이}=0\)</div>
         <div class="warn"></div>
       </div>
     </fieldset>

--- a/Linear_Transformation_Lab/lt2d.js
+++ b/Linear_Transformation_Lab/lt2d.js
@@ -27,7 +27,7 @@
   const minaxisnum = 4;
 
   // vector & basis (2D)
-  let vi = 1, vj = 2;
+  let vi = 0, vj = 0;
   let ivector = [1, 0];
   let jvector = [0, 1];
 
@@ -349,6 +349,23 @@
     if (vBox) vBox.innerHTML = `\\(\\vec{v}=${fmt(vi)}\\hat{i}+${fmt(vj)}\\hat{j}\\)`;
     if (iBox) iBox.innerHTML = `\\(\\hat{i}=(${fmt(ivector[0])},\\,${fmt(ivector[1])})\\)`;
     if (jBox) jBox.innerHTML = `\\(\\hat{j}=(${fmt(jvector[0])},\\,${fmt(jvector[1])})\\)`;
+
+    const dirBox = q('.direction');
+    const distBox = q('.distance');
+    const moveBox = q('.movement');
+    const angleIBox = q('.anglei');
+    const angleJBox = q('.anglej');
+    const mag = Math.hypot(vi, vj);
+    const deg = mag ? fmt(Math.atan2(vj, vi) * 180 / Math.PI) : 0;
+    if (dirBox) dirBox.textContent = `방향: ${deg}°`;
+    if (distBox) distBox.textContent = `거리: ${fmt(mag)}`;
+    if (moveBox) moveBox.textContent = `이동: (${fmt(vi)}, ${fmt(vj)})`;
+    const angleI = mag ? fmt(Math.acos(vi / mag) * 180 / Math.PI) : 0;
+    const areaI = fmt(Math.abs(vj));
+    if (angleIBox) angleIBox.innerHTML = `\\(각도(\\vec v,\\hat i)=${angleI}^\\circ,\\;\\text{넓이}=${areaI}\\)`;
+    const angleJ = mag ? fmt(Math.acos(vj / mag) * 180 / Math.PI) : 0;
+    const areaJ = fmt(Math.abs(vi));
+    if (angleJBox) angleJBox.innerHTML = `\\(각도(\\vec v,\\hat j)=${angleJ}^\\circ,\\;\\text{넓이}=${areaJ}\\)`;
     if (window.MathJax && MathJax.typeset) MathJax.typeset();
   }
 
@@ -503,7 +520,7 @@
     // reset scales
     scale = 70; scaleunit = 1; absscale = 70;
     // reset basis & vector
-    ivector = [1,0]; jvector = [0,1]; vi = 1; vj = 2;
+    ivector = [1,0]; jvector = [0,1]; vi = 0; vj = 0;
     // reset A inputs
     if ($('a11')) { $('a11').value = 1; $('a12').value = 0; $('a21').value = 0; $('a22').value = 1; }
     setInputsFromVector();

--- a/Linear_Transformation_Lab/lt3d.js
+++ b/Linear_Transformation_Lab/lt3d.js
@@ -12,7 +12,7 @@ import { OrbitControls } from 'https://unpkg.com/three@0.161.0/examples/jsm/cont
 
   // ===== shared inputs (read from DOM) =====
   // v components (basis coefficients) — only used when mode3d checked
-  let vi = 1, vj = 2, vk = 0;
+  let vi = 0, vj = 0, vk = 0;
 
   // basis vectors in R^3
   let ivector = [1, 0, 0];
@@ -89,6 +89,29 @@ import { OrbitControls } from 'https://unpkg.com/three@0.161.0/examples/jsm/cont
     if (kBox) kBox.innerHTML = `\\(\\hat{k}=(${fmt(kvector[0])},\\,${fmt(kvector[1])},\\,${fmt(kvector[2])})\\)`;
     if (matB3) matB3.innerHTML =
       `\\(B=\\begin{bmatrix}${fmt(ivector[0])}&${fmt(jvector[0])}&${fmt(kvector[0])}\\\\${fmt(ivector[1])}&${fmt(jvector[1])}&${fmt(kvector[1])}\\\\${fmt(ivector[2])}&${fmt(jvector[2])}&${fmt(kvector[2])}\\end{bmatrix}\\)`;
+
+    const dirBox = q('.direction');
+    const distBox = q('.distance');
+    const moveBox = q('.movement');
+    const angleIBox = q('.anglei');
+    const angleJBox = q('.anglej');
+    const angleKBox = q('.anglek');
+    const mag = Math.hypot(vi, vj, vk);
+    if (dirBox) {
+      if (mag) dirBox.textContent = `방향: (${fmt(vi/mag)}, ${fmt(vj/mag)}, ${fmt(vk/mag)})`;
+      else dirBox.textContent = '방향: (0,0,0)';
+    }
+    if (distBox) distBox.textContent = `거리: ${fmt(mag)}`;
+    if (moveBox) moveBox.textContent = `이동: (${fmt(vi)}, ${fmt(vj)}, ${fmt(vk)})`;
+    const angleI = mag ? fmt(Math.acos(vi / mag) * 180 / Math.PI) : 0;
+    const areaI = fmt(Math.hypot(vj, vk));
+    if (angleIBox) angleIBox.innerHTML = `\\(각도(\\vec v,\\hat i)=${angleI}^\\circ,\\;\\text{넓이}=${areaI}\\)`;
+    const angleJ = mag ? fmt(Math.acos(vj / mag) * 180 / Math.PI) : 0;
+    const areaJ = fmt(Math.hypot(vi, vk));
+    if (angleJBox) angleJBox.innerHTML = `\\(각도(\\vec v,\\hat j)=${angleJ}^\\circ,\\;\\text{넓이}=${areaJ}\\)`;
+    const angleK = mag ? fmt(Math.acos(vk / mag) * 180 / Math.PI) : 0;
+    const areaK = fmt(Math.hypot(vi, vj));
+    if (angleKBox) angleKBox.innerHTML = `\\(각도(\\vec v,\\hat k)=${angleK}^\\circ,\\;\\text{넓이}=${areaK}\\)`;
 
     const A = readMatrix3();
     const dA = det3(A);
@@ -411,7 +434,7 @@ import { OrbitControls } from 'https://unpkg.com/three@0.161.0/examples/jsm/cont
   function onReset(){
     if (!is3D()) return;
     ivector=[1,0,0]; jvector=[0,1,0]; kvector=[0,0,1];
-    vi=1; vj=2; vk=0;
+    vi=0; vj=0; vk=0;
     if ($('vi_in')) $('vi_in').value = vi;
     if ($('vj_in')) $('vj_in').value = vj;
     if ($('vk_in')) $('vk_in').value = vk;


### PR DESCRIPTION
## Summary
- Center vector knob at (0,0) and expand sliders to ±20
- Display direction, distance, movement, and angle/area info for vectors in Math (live)
- Initialize 3D mode with zero vector and matching reset behavior

## Testing
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68bd9f543ae8832a9dfc7701079bf22a