### PR TITLE
Display leaderboard date

### DIFF
--- a/index.html
+++ b/index.html
@@ -727,7 +727,12 @@
             const name = document.getElementById('playerName').value.trim();
             if (name) {
                 const finalScore = score + Math.max(0, 1000 - Math.floor(elapsedTime * 10));
-                const newScore = { name, score: finalScore, time: parseFloat(elapsedTime) };
+                const newScore = {
+                    name,
+                    score: finalScore,
+                    time: parseFloat(elapsedTime),
+                    date: new Date().toISOString()
+                };
 
                 fetch(GOOGLE_SCRIPT_URL, {
                     method: 'POST', mode: 'no-cors',
@@ -797,11 +802,17 @@
                 else if (index === 2) trophy = '🥉 ';
                 else trophy = `${index + 1}. `;
 
+                const dateLabel = entry.date
+                    ? new Date(entry.date).toLocaleDateString(undefined, {
+                        year: 'numeric', month: 'short', day: 'numeric'
+                      })
+                    : '';
+
                 div.innerHTML = `
                     <span>${trophy}${entry.name}</span>
                     <span style="display: flex; flex-direction: column; align-items: flex-end;">
                         <span style="font-weight: bold;">${entry.score} pts</span>
-                        <span style="font-size: 0.8rem; opacity: 0.7;">${entry.time}s</span>
+                        <span style="font-size: 0.8rem; opacity: 0.7;">${dateLabel}</span>
                     </span>
                 `;
                 list.appendChild(div);


### PR DESCRIPTION
## Summary
- show saved date in leaderboard entries
- include date when saving scores locally

## Testing
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68bead7b2200832a881ee63efe22be0d