### PR TITLE
Add home navigation and manifest links to HTML pages

### DIFF
--- a/Linear_Transformation_Lab/index.html
+++ b/Linear_Transformation_Lab/index.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="icon" type="image/png" sizes="32x32" href="../src/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="../src/favicon-16x16.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="../src/apple-touch-icon.png">
+  <link rel="manifest" href="../src/site.webmanifest">
   <title>Linear Transformation Lab</title>
   <script src="./plotly-latest.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>

--- a/appdownload.html
+++ b/appdownload.html
@@ -10,6 +10,7 @@
   <link rel="icon" type="image/png" sizes="32x32" href="src/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="src/favicon-16x16.png">
   <link rel="apple-touch-icon" sizes="180x180" href="src/apple-touch-icon.png">
+  <link rel="manifest" href="src/site.webmanifest">
   <style>
     body { font-family: Arial, sans-serif; max-width: 800px; margin: 0 auto; padding: 20px; line-height: 1.6; }
     header, section { margin-bottom: 2rem; }

--- a/appdownloadGS.html
+++ b/appdownloadGS.html
@@ -10,6 +10,7 @@
     <link rel="icon" type="image/png" sizes="32x32" href="src/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="src/favicon-16x16.png">
     <link rel="apple-touch-icon" sizes="180x180" href="src/apple-touch-icon.png">
+  <link rel="manifest" href="src/site.webmanifest">
     <style>
         body {
             font-family: Arial, sans-serif;
@@ -35,24 +36,10 @@
         }
         .store-badge:hover {
             transform: scale(1.05);
-        }
-        .home-button {
-      position: fixed;
-      top: 10px;
-      left: 10px;
-      text-decoration: none;
-      font-size: 24px;
-      color: #000;
-      opacity: 0.6;
-      z-index: 1000;
-    }
-    .home-button:hover {
-      opacity: 1;
-    }
-    </style>
+        }    </style>
 </head>
 <body>
-    <a href="index.html" class="home-button" aria-label="Home">&#x21A9;</a>
+  <nav><a href="index.html" aria-label="Home">&#x21A9; Home</a></nav>
     <h1>Gridlock Shooter</h1>
     <p>Download our app from your device's app store</p>
     <p>플레이스토어 또는 앱스토어에서 다운로드하세요.</p>

--- a/appdownloadLFE.html
+++ b/appdownloadLFE.html
@@ -10,6 +10,7 @@
     <link rel="icon" type="image/png" sizes="32x32" href="src/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="src/favicon-16x16.png">
     <link rel="apple-touch-icon" sizes="180x180" href="src/apple-touch-icon.png">
+  <link rel="manifest" href="src/site.webmanifest">
     <style>
         body {
             font-family: Arial, sans-serif;
@@ -35,24 +36,10 @@
         }
         .store-badge:hover {
             transform: scale(1.05);
-        }
-        .home-button {
-      position: fixed;
-      top: 10px;
-      left: 10px;
-      text-decoration: none;
-      font-size: 24px;
-      color: #000;
-      opacity: 0.6;
-      z-index: 1000;
-    }
-    .home-button:hover {
-      opacity: 1;
-    }
-    </style>
+        }    </style>
 </head>
 <body>
-    <a href="index.html" class="home-button" aria-label="Home">&#x21A9;</a>
+  <nav><a href="index.html" aria-label="Home">&#x21A9; Home</a></nav>
     <h1>Log for Everything</h1>
     <p>Download our app from your device's app store</p>
     <p>플레이스토어 또는 앱스토어에서 다운로드하세요.</p>

--- a/articles/manage-students-tracking.html
+++ b/articles/manage-students-tracking.html
@@ -5,9 +5,14 @@
     <meta name="google-adsense-account" content="ca-pub-3360521146359419">
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" type="image/png" sizes="32x32" href="../src/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="../src/favicon-16x16.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="../src/apple-touch-icon.png">
+  <link rel="manifest" href="../src/site.webmanifest">
     <title>How I track classroom data with Manage Students</title>
 </head>
 <body>
+  <nav><a href="../index.html" aria-label="Home">&#x21A9; Home</a></nav>
     <h1>How I track classroom data with Manage Students</h1>
     <p>Tracking classroom data used to involve scattered notebooks and spreadsheets. When I built the Manage Students app I finally had a single place to store attendance, behavior notes, and mastery of standards. In this article I want to walk through the workflow I settled on and share a few templates that make the process painless.</p>
     <p>The first step is deciding what to collect. For me the must haves are attendance, behavior incidents, assessment scores, and anecdotal notes. I created a custom form inside the app with fields for each of these. Because the interface supports quick entry on a phone, I can tap a student name and log an event without breaking the flow of a lesson. The trick is to keep the form short so it is not a distraction; anything that takes longer than fifteen seconds tends to be ignored in the heat of the moment.</p>

--- a/articles/mobile-puzzle-game-lessons.html
+++ b/articles/mobile-puzzle-game-lessons.html
@@ -5,9 +5,14 @@
     <meta name="google-adsense-account" content="ca-pub-3360521146359419">
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" type="image/png" sizes="32x32" href="../src/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="../src/favicon-16x16.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="../src/apple-touch-icon.png">
+  <link rel="manifest" href="../src/site.webmanifest">
     <title>Shipping a mobile puzzle game: lessons learned</title>
 </head>
 <body>
+  <nav><a href="../index.html" aria-label="Home">&#x21A9; Home</a></nav>
     <h1>Shipping a mobile puzzle game: lessons learned</h1>
     <p>Earlier this year I wrapped up Gridlock Shooter, a small puzzle game that combines sliding blocks with physics. Building it in my spare time taught me more about project scope and player expectations than any book. While the game itself is modest, the journey from prototype to app store release was full of surprises. Here are the lessons that stood out.</p>
     <p>I started with a simple premise: move blocks to clear a path for a projectile. The prototype used plain rectangles and circles on a gray background. Friends enjoyed the concept but quickly found exploits that trivialized levels. Balancing the mechanics took weeks of iteration. I kept a spreadsheet of every tweak—friction values, block mass, spawn delays—and played each level dozens of times. The lesson was that puzzle games live or die by the tiny numbers hidden under the hood. There is no substitute for playtesting, even if it means scrapping entire level sets.</p>

--- a/articles/universal-logging-schema.html
+++ b/articles/universal-logging-schema.html
@@ -5,9 +5,14 @@
     <meta name="google-adsense-account" content="ca-pub-3360521146359419">
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" type="image/png" sizes="32x32" href="../src/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="../src/favicon-16x16.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="../src/apple-touch-icon.png">
+  <link rel="manifest" href="../src/site.webmanifest">
     <title>Designing a universal logging schema for real life workflows</title>
 </head>
 <body>
+  <nav><a href="../index.html" aria-label="Home">&#x21A9; Home</a></nav>
     <h1>Designing a universal logging schema for real life workflows</h1>
     <p>When I started building small utilities to track habits and expenses I quickly ran into a problem: every tool used a different format. My workout tracker stored records as CSV rows, my finance app wrote JSON objects, and a homemade notebook export used a custom text syntax. Analyzing data across projects meant writing conversion scripts for each source. I wanted a single schema that could describe any event in a human friendly way. This article outlines the approach I took to design a universal logging format that now powers several of my apps.</p>
     <p>The design goals were simple. The schema needed to be easy to read in plain text, flexible enough to capture most personal data, and efficient to parse. After experimenting with YAML and JSON I settled on a line oriented structure inspired by logfmt. Each record is a single line with key value pairs, separated by spaces. Timestamps appear first in ISO format, followed by a category field. Additional keys can be added as needed. The result looks like this:</p>

--- a/cardbenefitapp.html
+++ b/cardbenefitapp.html
@@ -10,25 +10,12 @@
     <link rel="icon" type="image/png" sizes="32x32" href="src/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="src/favicon-16x16.png">
     <link rel="apple-touch-icon" sizes="180x180" href="src/apple-touch-icon.png">
+  <link rel="manifest" href="src/site.webmanifest">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/tailwindcss/2.2.19/tailwind.min.css" rel="stylesheet">
-    <style>
-        .home-button {
-      position: fixed;
-      top: 10px;
-      left: 10px;
-      text-decoration: none;
-      font-size: 24px;
-      color: #000;
-      opacity: 0.6;
-      z-index: 1000;
-    }
-    .home-button:hover {
-      opacity: 1;
-    }
-    </style>
+    <style>    </style>
 </head>
 <body class="bg-gray-100 font-sans leading-normal tracking-normal">
-    <a href="index.html" class="home-button" aria-label="Home">&#x21A9;</a>
+  <nav><a href="index.html" aria-label="Home">&#x21A9; Home</a></nav>
     <div class="container mx-auto p-8">
         <header class="mb-8">
             <h1 class="text-4xl font-bold text-gray-800 mb-2">Privacy Policy</h1>

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
     <link rel="icon" type="image/png" sizes="32x32" href="src/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="src/favicon-16x16.png">
     <link rel="apple-touch-icon" sizes="180x180" href="src/apple-touch-icon.png">
+    <link rel="manifest" href="src/site.webmanifest">
     <!-- Google Fonts -->
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
     <style>

--- a/layout-content.html
+++ b/layout-content.html
@@ -5,9 +5,14 @@
     <meta name="google-adsense-account" content="ca-pub-3360521146359419">
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" type="image/png" sizes="32x32" href="src/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="src/favicon-16x16.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="src/apple-touch-icon.png">
+  <link rel="manifest" href="src/site.webmanifest">
     <title>{{title}}</title>
 </head>
 <body>
+  <nav><a href="index.html" aria-label="Home">&#x21A9; Home</a></nav>
 <!-- Page content here -->
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-3360521146359419" crossorigin="anonymous"></script>
 <!-- display_ad -->

--- a/layout-utility.html
+++ b/layout-utility.html
@@ -4,9 +4,14 @@
     <meta name="google-adsense-platform" content="none">
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="icon" type="image/png" sizes="32x32" href="src/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="src/favicon-16x16.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="src/apple-touch-icon.png">
+  <link rel="manifest" href="src/site.webmanifest">
     <title>{{title}}</title>
 </head>
 <body>
+  <nav><a href="index.html" aria-label="Home">&#x21A9; Home</a></nav>
 <!-- Utility page content -->
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-3360521146359419" crossorigin="anonymous"></script>
 <!-- display_ad -->

--- a/logforeverything.html
+++ b/logforeverything.html
@@ -10,26 +10,13 @@
     <link rel="icon" type="image/png" sizes="32x32" href="src/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="src/favicon-16x16.png">
     <link rel="apple-touch-icon" sizes="180x180" href="src/apple-touch-icon.png">
+  <link rel="manifest" href="src/site.webmanifest">
     <link rel="canonical" href="https://singaseongj.github.io/logforeverything.html">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/tailwindcss/2.2.19/tailwind.min.css" rel="stylesheet">
-    <style>
-        .home-button {
-      position: fixed;
-      top: 10px;
-      left: 10px;
-      text-decoration: none;
-      font-size: 24px;
-      color: #000;
-      opacity: 0.6;
-      z-index: 1000;
-    }
-    .home-button:hover {
-      opacity: 1;
-    }
-    </style>
+    <style>    </style>
 </head>
 <body class="bg-gray-100 font-sans leading-normal tracking-normal">
-    <a href="index.html" class="home-button" aria-label="Home">&#x21A9;</a>
+  <nav><a href="index.html" aria-label="Home">&#x21A9; Home</a></nav>
     <div class="container mx-auto p-8">
         <header class="mb-8">
             <h1 class="text-4xl font-bold text-gray-800 mb-2">Privacy Policy</h1>

--- a/privacy_policy.html
+++ b/privacy_policy.html
@@ -9,6 +9,7 @@
     <link rel="icon" type="image/png" sizes="32x32" href="src/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="src/favicon-16x16.png">
     <link rel="apple-touch-icon" sizes="180x180" href="src/apple-touch-icon.png">
+  <link rel="manifest" href="src/site.webmanifest">
     <link rel="stylesheet" href="style.css">
     <style>
         .privacy-policy {
@@ -21,24 +22,10 @@
             border: 1px solid #ccc;
             border-radius: 8px;
             background-color: #f9f9f9;
-        }
-        .home-button {
-      position: fixed;
-      top: 10px;
-      left: 10px;
-      text-decoration: none;
-      font-size: 24px;
-      color: #000;
-      opacity: 0.6;
-      z-index: 1000;
-    }
-    .home-button:hover {
-      opacity: 1;
-    }
-    </style>
+        }    </style>
 </head>
 <body>
-    <a href="index.html" class="home-button" aria-label="Home">&#x21A9;</a>
+  <nav><a href="index.html" aria-label="Home">&#x21A9; Home</a></nav>
     <header>
         <h1>SingaseongApp 개인정보 처리방침</h1>
     </header>

--- a/privacy_policy_gs.html
+++ b/privacy_policy_gs.html
@@ -9,25 +9,12 @@
     <link rel="icon" type="image/png" sizes="32x32" href="src/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="src/favicon-16x16.png">
     <link rel="apple-touch-icon" sizes="180x180" href="src/apple-touch-icon.png">
+  <link rel="manifest" href="src/site.webmanifest">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/tailwindcss/2.2.19/tailwind.min.css" rel="stylesheet">
-    <style>
-        .home-button {
-      position: fixed;
-      top: 10px;
-      left: 10px;
-      text-decoration: none;
-      font-size: 24px;
-      color: #000;
-      opacity: 0.6;
-      z-index: 1000;
-    }
-    .home-button:hover {
-      opacity: 1;
-    }
-    </style>
+    <style>    </style>
 </head>
 <body class="bg-gray-100 font-sans leading-normal tracking-normal">
-    <a href="index.html" class="home-button" aria-label="Home">&#x21A9;</a>
+  <nav><a href="index.html" aria-label="Home">&#x21A9; Home</a></nav>
     <div class="container mx-auto p-8">
         <header class="mb-8">
             <h1 class="text-4xl font-bold text-gray-800 mb-2">Privacy Policy</h1>

--- a/privacy_policy_ms.html
+++ b/privacy_policy_ms.html
@@ -9,25 +9,12 @@
     <link rel="icon" type="image/png" sizes="32x32" href="src/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="src/favicon-16x16.png">
     <link rel="apple-touch-icon" sizes="180x180" href="src/apple-touch-icon.png">
+  <link rel="manifest" href="src/site.webmanifest">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/tailwindcss/2.2.19/tailwind.min.css" rel="stylesheet">
-    <style>
-        .home-button {
-      position: fixed;
-      top: 10px;
-      left: 10px;
-      text-decoration: none;
-      font-size: 24px;
-      color: #000;
-      opacity: 0.6;
-      z-index: 1000;
-    }
-    .home-button:hover {
-      opacity: 1;
-    }
-    </style>
+    <style>    </style>
 </head>
 <body class="bg-gray-100 font-sans leading-normal tracking-normal">
-    <a href="index.html" class="home-button" aria-label="Home">&#x21A9;</a>
+  <nav><a href="index.html" aria-label="Home">&#x21A9; Home</a></nav>
     <div class="container mx-auto p-8">
         <header class="mb-8">
             <h1 class="text-4xl font-bold text-gray-800 mb-2">Privacy Policy</h1>

--- a/privacy_policy_ms_kr.html
+++ b/privacy_policy_ms_kr.html
@@ -9,25 +9,12 @@
     <link rel="icon" type="image/png" sizes="32x32" href="src/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="src/favicon-16x16.png">
     <link rel="apple-touch-icon" sizes="180x180" href="src/apple-touch-icon.png">
+  <link rel="manifest" href="src/site.webmanifest">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/tailwindcss/2.2.19/tailwind.min.css" rel="stylesheet">
-    <style>
-        .home-button {
-      position: fixed;
-      top: 10px;
-      left: 10px;
-      text-decoration: none;
-      font-size: 24px;
-      color: #000;
-      opacity: 0.6;
-      z-index: 1000;
-    }
-    .home-button:hover {
-      opacity: 1;
-    }
-    </style>
+    <style>    </style>
 </head>
 <body class="bg-gray-100 font-sans leading-normal tracking-normal">
-    <a href="index.html" class="home-button" aria-label="Home">&#x21A9;</a>
+  <nav><a href="index.html" aria-label="Home">&#x21A9; Home</a></nav>
     <div class="container mx-auto p-8">
         <header class="mb-8">
             <h1 class="text-4xl font-bold text-gray-800 mb-2">개인정보처리방침</h1>

--- a/seongsigan/dongsin1-2.html
+++ b/seongsigan/dongsin1-2.html
@@ -9,6 +9,7 @@
   <link rel="icon" type="image/png" sizes="32x32" href="../src/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="../src/favicon-16x16.png">
   <link rel="apple-touch-icon" sizes="180x180" href="../src/apple-touch-icon.png">
+  <link rel="manifest" href="../src/site.webmanifest">
   <style>
     h2 {
       text-align: center;
@@ -70,24 +71,10 @@
     .subject-통사       { background: #f8d7da; }
     .subject-지구과학   { background: #dbe7fa; }
     .subject-진로       { background: #fff4e5; }
-    .subject-창체       { background: #f0f0f0; }
-    .home-button {
-      position: fixed;
-      top: 10px;
-      left: 10px;
-      text-decoration: none;
-      font-size: 24px;
-      color: #000;
-      opacity: 0.6;
-      z-index: 1000;
-    }
-    .home-button:hover {
-      opacity: 1;
-    }
-  </style>
+    .subject-창체       { background: #f0f0f0; }  </style>
 </head>
 <body>
-  <a href="../index.html" class="home-button" aria-label="Home">&#x21A9;</a>
+  <nav><a href="../index.html" aria-label="Home">&#x21A9; Home</a></nav>
   <h2>1-2반 2학기 시간표</h2>
   <table>
     <thead>

--- a/seongsigan/readme.html
+++ b/seongsigan/readme.html
@@ -10,6 +10,7 @@
   <link rel="icon" type="image/png" sizes="32x32" href="../src/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="../src/favicon-16x16.png">
   <link rel="apple-touch-icon" sizes="180x180" href="../src/apple-touch-icon.png">
+  <link rel="manifest" href="../src/site.webmanifest">
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles/main.css" />
   <style>
@@ -34,24 +35,10 @@
       background: #eee;
       padding: 10px;
       overflow-x: auto;
-    }
-    .home-button {
-      position: fixed;
-      top: 10px;
-      left: 10px;
-      text-decoration: none;
-      font-size: 24px;
-      color: #000;
-      opacity: 0.6;
-      z-index: 1000;
-    }
-    .home-button:hover {
-      opacity: 1;
-    }
-  </style>
+    }  </style>
 </head>
 <body>
-  <a href="../index.html" class="home-button" aria-label="Home">&#x21A9;</a>
+  <nav><a href="../index.html" aria-label="Home">&#x21A9; Home</a></nav>
   <header>
     <h1>SeongSigan Demo - 프로젝트 개요</h1>
   </header>

--- a/seongsigan/seongsigan.html
+++ b/seongsigan/seongsigan.html
@@ -10,27 +10,14 @@
   <link rel="icon" type="image/png" sizes="32x32" href="../src/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="../src/favicon-16x16.png">
   <link rel="apple-touch-icon" sizes="180x180" href="../src/apple-touch-icon.png">
+  <link rel="manifest" href="../src/site.webmanifest">
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
   <link rel="stylesheet" href="styles/main.css">
-  <style>
-    .home-button {
-      position: fixed;
-      top: 10px;
-      left: 10px;
-      text-decoration: none;
-      font-size: 24px;
-      color: #000;
-      opacity: 0.6;
-      z-index: 1000;
-    }
-    .home-button:hover {
-      opacity: 1;
-    }
-  </style>
+  <style>  </style>
 </head>
 <body>
-  <a href="../index.html" class="home-button" aria-label="Home">&#x21A9;</a>
+  <nav><a href="../index.html" aria-label="Home">&#x21A9; Home</a></nav>
   <header class="app-bar">
     <h1 class="logo">SeongSigan <span id="backendStatus" class="status" aria-label="백엔드 상태" title="Backend status"></span></h1>
     <select id="teacherSelect" aria-label="선생님 선택"></select>

--- a/src/template.html
+++ b/src/template.html
@@ -10,21 +10,9 @@
   <link rel="icon" type="image/png" sizes="32x32" href="src/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="src/favicon-16x16.png">
   <link rel="apple-touch-icon" sizes="180x180" href="src/apple-touch-icon.png">
+  <link rel="manifest" href="src/site.webmanifest">
   <link rel="stylesheet" href="stocks.css">
   <style>
-    .home-button {
-      position: fixed;
-      top: 10px;
-      left: 10px;
-      text-decoration: none;
-      font-size: 24px;
-      color: #000;
-      opacity: 0.6;
-      z-index: 1000;
-    }
-    .home-button:hover {
-      opacity: 1;
-    }
     .skeleton li {
       background: #eee;
       height: 1em;
@@ -59,7 +47,7 @@
   </style>
 </head>
 <body>
-  <a href="index.html" class="home-button" aria-label="Home">&#x21A9;</a>
+  <nav><a href="index.html" aria-label="Home">&#x21A9; Home</a></nav>
   <h1 data-i18n="title">데일리 주식 리포트 자동화</h1>
   <p class="dashboard-link"><a data-i18n="dashboardLink" href="stocks/index.html">👉 Stock News Summary Dashboard</a></p>
   <p id="currentDate"><span id="datePrefix" data-i18n="today">오늘:</span> {{CURRENT_DATE}}</p>

--- a/stocks.html
+++ b/stocks.html
@@ -10,21 +10,9 @@
   <link rel="icon" type="image/png" sizes="32x32" href="src/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="src/favicon-16x16.png">
   <link rel="apple-touch-icon" sizes="180x180" href="src/apple-touch-icon.png">
+  <link rel="manifest" href="src/site.webmanifest">
   <link rel="stylesheet" href="stocks.css">
   <style>
-    .home-button {
-      position: fixed;
-      top: 10px;
-      left: 10px;
-      text-decoration: none;
-      font-size: 24px;
-      color: #000;
-      opacity: 0.6;
-      z-index: 1000;
-    }
-    .home-button:hover {
-      opacity: 1;
-    }
     .skeleton li {
       background: #eee;
       height: 1em;
@@ -59,10 +47,10 @@
   </style>
 </head>
 <body>
-  <a href="index.html" class="home-button" aria-label="Home">&#x21A9;</a>
+  <nav><a href="index.html" aria-label="Home">&#x21A9; Home</a></nav>
   <h1 data-i18n="title">데일리 주식 리포트 자동화</h1>
   <p class="dashboard-link"><a data-i18n="dashboardLink" href="stocks/index.html">👉 Stock News Summary Dashboard</a></p>
-  <p id="currentDate"><span id="datePrefix" data-i18n="today">오늘:</span> 2025년 9월 7일</p>
+  <p id="currentDate"><span id="datePrefix" data-i18n="today">오늘:</span> 2025년 9월 9일</p>
   
   <div id="debugInfo" class="debug" style="display: none;">
     <h4>디버그 정보:</h4>

--- a/stocks/index.html
+++ b/stocks/index.html
@@ -3,6 +3,10 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="icon" type="image/png" sizes="32x32" href="../src/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="../src/favicon-16x16.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="../src/apple-touch-icon.png">
+  <link rel="manifest" href="../src/site.webmanifest">
   <title>Stock News Summary </title>
   <!-- Tailwind via CDN -->
   <script src="https://cdn.tailwindcss.com"></script>
@@ -12,6 +16,7 @@
   </style>
 </head>
 <body class="bg-slate-50 text-slate-800">
+  <nav><a href="../index.html" aria-label="Home">&#x21A9; Home</a></nav>
   <div class="max-w-7xl mx-auto p-4 md:p-6">
     <header class="mb-6">
       <h1 class="text-2xl md:text-3xl font-bold tracking-tight">Stock News Summary</h1>

--- a/stocks_ex.html
+++ b/stocks_ex.html
@@ -10,6 +10,7 @@
   <link rel="icon" type="image/png" sizes="32x32" href="src/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="src/favicon-16x16.png">
   <link rel="apple-touch-icon" sizes="180x180" href="src/apple-touch-icon.png">
+  <link rel="manifest" href="src/site.webmanifest">
   <style>
     /* 기본 스타일 */
     body {
@@ -56,20 +57,6 @@
     ul li {
       margin-bottom: 0.5rem;
     }
-    .home-button {
-      position: fixed;
-      top: 10px;
-      left: 10px;
-      text-decoration: none;
-      font-size: 24px;
-      color: #000;
-      opacity: 0.6;
-      z-index: 1000;
-    }
-    .home-button:hover {
-      opacity: 1;
-    }
-
     /* 모바일 반응형 */
     @media (max-width: 600px) {
       body {
@@ -91,7 +78,7 @@
   </style>
 </head>
 <body>
-  <a href="index.html" class="home-button" aria-label="Home">&#x21A9;</a>
+  <nav><a href="index.html" aria-label="Home">&#x21A9; Home</a></nav>
   <div class="container">
     <h1>📊 한국 시장 종목 선정 로직 상세 설명</h1>
     

--- a/voice-hotkey/index.html
+++ b/voice-hotkey/index.html
@@ -9,29 +9,16 @@
   <link rel="icon" type="image/png" sizes="32x32" href="../src/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="../src/favicon-16x16.png">
   <link rel="apple-touch-icon" sizes="180x180" href="../src/apple-touch-icon.png">
+  <link rel="manifest" href="../src/site.webmanifest">
   <link rel="stylesheet" href="styles.css">
   <script type="module" src="keymap.js"></script>
   <script type="module" src="llm.js"></script>
   <script type="module" src="stt.js"></script>
   <script type="module" src="app.js"></script>
-  <style>
-    .home-button {
-      position: fixed;
-      top: 10px;
-      left: 10px;
-      text-decoration: none;
-      font-size: 24px;
-      color: #000;
-      opacity: 0.6;
-      z-index: 1000;
-    }
-    .home-button:hover {
-      opacity: 1;
-    }
-  </style>
+  <style>  </style>
 </head>
 <body>
-  <a href="../index.html" class="home-button" aria-label="Home">&#x21A9;</a>
+  <nav><a href="../index.html" aria-label="Home">&#x21A9; Home</a></nav>
   <header class="top-bar">
     <div class="title-block">
       <h1>voice to keys</h1>


### PR DESCRIPTION
## Summary
- Add consistent “Home” navigation buttons across site pages
- Reference favicons and `site.webmanifest` in all HTML files for PWA compatibility
- Update stock template and rebuild `stocks.html`

## Testing
- `OFFLINE=1 node src/build.js`
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68bf6eb60970832aa0026260937dc4f2