### PR TITLE
Add go back icons to stock dashboards

### DIFF
--- a/stocks/fx_rates/index.html
+++ b/stocks/fx_rates/index.html
@@ -27,10 +27,20 @@
     .legend{ font-size:12px; color:#c8d3ff; margin-top:6px }
     .footer{ max-width:1100px; margin:0 auto 40px; padding:0 16px; color:#a9b6ff; font-size:12px }
     .muted{ color:var(--muted) }
+    .back-btn{ display:inline-flex; align-items:center; justify-content:center; width:40px; height:40px; border-radius:999px; border:1px solid #233060; background:#0f1530; color:#cfe1ff; text-decoration:none; transition:background .2s ease,border-color .2s ease,color .2s ease; margin-bottom:12px }
+    .back-btn svg{ width:18px; height:18px }
+    .back-btn:hover{ background:#1a2450; border-color:#3a4aa0; color:#fff }
+    .back-btn:focus-visible{ outline:2px solid #8fb4ff; outline-offset:3px }
   </style>
 </head>
 <body>
   <header>
+    <a href="../../stocks.html" class="back-btn" aria-label="주식 페이지로 돌아가기">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M15 6l-6 6 6 6"></path>
+        <path d="M9 12h12"></path>
+      </svg>
+    </a>
     <h1>환율 대시보드</h1>
     <div class="meta">
       <span>데이터 경로: <code>/stocks/fx_rates/fx_history.json</code></span>

--- a/stocks/index.html
+++ b/stocks/index.html
@@ -16,7 +16,17 @@
   </style>
 </head>
 <body class="bg-slate-50 text-slate-800">
-  <nav><a href="../index.html" aria-label="Home">&#x21A9; Home</a></nav>
+  <nav class="px-4 py-3">
+    <div class="max-w-7xl mx-auto flex items-center gap-3">
+      <a href="../stocks.html" aria-label="Back to stocks overview" class="inline-flex items-center justify-center w-10 h-10 rounded-full border border-slate-200 bg-white text-slate-600 shadow-sm hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-slate-400 focus:ring-offset-2 focus:ring-offset-slate-50">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" class="w-5 h-5">
+          <path d="M15 6l-6 6 6 6"></path>
+          <path d="M9 12h12"></path>
+        </svg>
+      </a>
+      <a href="../index.html" aria-label="Home" class="text-sm text-slate-600 hover:text-slate-900">&#x21A9; Home</a>
+    </div>
+  </nav>
   <div class="max-w-7xl mx-auto p-4 md:p-6">
     <header class="mb-6">
       <h1 class="text-2xl md:text-3xl font-bold tracking-tight">Stock News Summary</h1>


### PR DESCRIPTION
## Summary
- add a top-left back icon on stocks/index.html that routes to stocks.html
- style and include the same back navigation on the FX rates dashboard

## Testing
- node tests/apple_association.test.js

------
https://chatgpt.com/codex/tasks/task_b_68c8ee61f658832a9558367ae21fcd8a