### PR TITLE
Add custom date range controls to FX dashboard

### DIFF
--- a/stocks/fx_rates/index.html
+++ b/stocks/fx_rates/index.html
@@ -16,9 +16,27 @@
     header{ padding:24px 16px 8px; max-width:1100px; margin:0 auto; }
     h1{ margin:0 0 4px; font-size:28px; letter-spacing:0.2px }
     .meta{ color:#b9c4ff; font-size:13px }
-    .controls{ display:flex; gap:8px; flex-wrap:wrap; margin-top:12px }
-    .btn{ border:1px solid #2a3560; background:#0f1530; color:#cfe1ff; padding:8px 10px; border-radius:10px; font-size:13px; cursor:pointer }
+    .controls{ display:flex; gap:8px; flex-wrap:wrap; margin-top:12px; position:relative }
+    .btn{ display:inline-flex; align-items:center; justify-content:center; gap:6px; border:1px solid #2a3560; background:#0f1530; color:#cfe1ff; padding:8px 10px; border-radius:10px; font-size:13px; cursor:pointer; text-decoration:none }
     .btn[aria-pressed="true"]{ background:#1a2450; border-color:#3a4aa0; color:#fff }
+    .icon-btn svg{ width:16px; height:16px; flex-shrink:0 }
+    .custom-range-text{ font-size:12px; white-space:nowrap; max-width:140px; overflow:hidden; text-overflow:ellipsis }
+    .range-picker{ position:relative }
+    .range-panel{ position:absolute; top:calc(100% + 8px); right:0; min-width:240px; background:#0f1530; border:1px solid #2a3560; border-radius:14px; padding:14px; display:flex; flex-direction:column; gap:12px; box-shadow:0 16px 36px rgba(0,0,0,0.45); z-index:50; color:#dfe7ff }
+    .range-panel[hidden]{ display:none }
+    .range-panel h3{ margin:0; font-size:13px }
+    .range-fields{ display:flex; flex-direction:column; gap:10px }
+    .range-panel label{ display:flex; flex-direction:column; gap:6px; font-size:12px; color:#b9c4ff }
+    .range-panel input{ font:inherit; font-size:13px; padding:8px 10px; border-radius:10px; border:1px solid #2a3560; background:#141a31; color:#fff; outline:none; transition:border-color .2s ease, box-shadow .2s ease }
+    .range-panel input:focus-visible{ border-color:#3a4aa0; box-shadow:0 0 0 2px #3a4aa044 }
+    .range-panel input::-webkit-calendar-picker-indicator{ filter:invert(0.8) }
+    .range-actions{ display:flex; gap:8px; justify-content:flex-end }
+    .panel-btn{ font:inherit; font-size:12px; padding:7px 10px; border-radius:9px; border:1px solid #2a3560; background:#111735; color:#cfe1ff; cursor:pointer; transition:background .2s ease,border-color .2s ease,color .2s ease }
+    .panel-btn:hover{ background:#1a2450 }
+    .panel-btn.primary{ background:#1a2450; border-color:#3a4aa0; color:#fff }
+    .panel-btn:focus-visible{ outline:2px solid #8fb4ff; outline-offset:2px }
+    .range-error{ min-height:16px; font-size:11px; color:#ff9da4 }
+    .sr-only{ position:absolute; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden; clip:rect(0,0,0,0); border:0 }
     main{ max-width:1100px; margin:16px auto 40px; padding:0 16px; display:grid; grid-template-columns:repeat(auto-fit,minmax(280px,1fr)); gap:16px }
     .card{ background:var(--card); border:1px solid #233060; border-radius:16px; padding:14px 14px 8px; box-shadow:0 0 0 1px #0003 inset }
     .card h2{ margin:0 0 8px; font-size:16px }
@@ -52,6 +70,35 @@
       <button class="btn" data-range="90">90일</button>
       <button class="btn" data-range="365">1년</button>
       <button class="btn" data-range="all">전체</button>
+      <div class="range-picker" id="custom-range">
+        <button type="button" class="btn icon-btn" data-range="custom" id="custom-range-btn" aria-haspopup="dialog" aria-controls="custom-range-form" aria-expanded="false" aria-pressed="false" title="기간 직접 선택">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <rect x="3" y="4.5" width="18" height="16" rx="2"></rect>
+            <line x1="3" y1="9" x2="21" y2="9"></line>
+            <line x1="8" y1="2.5" x2="8" y2="6.5"></line>
+            <line x1="16" y1="2.5" x2="16" y2="6.5"></line>
+          </svg>
+          <span class="custom-range-text" id="custom-range-label">직접 선택</span>
+        </button>
+        <form id="custom-range-form" class="range-panel" aria-label="사용자 지정 기간 선택" hidden>
+          <h3>사용자 지정 기간</h3>
+          <div class="range-fields">
+            <label for="custom-range-from">
+              <span>시작일</span>
+              <input type="date" id="custom-range-from" required>
+            </label>
+            <label for="custom-range-to">
+              <span>종료일</span>
+              <input type="date" id="custom-range-to" required>
+            </label>
+          </div>
+          <div class="range-error" id="custom-range-error" role="alert" aria-live="assertive"></div>
+          <div class="range-actions">
+            <button type="button" class="panel-btn" id="custom-range-cancel">취소</button>
+            <button type="submit" class="panel-btn primary">적용</button>
+          </div>
+        </form>
+      </div>
     </div>
   </header>
 
@@ -102,9 +149,41 @@
     let historyData = { lastUpdated: null, series: createEmptySeries(), years: [] };
     let activeRange = '30';
     const charts = new Map();
+    const MS_IN_DAY = 24 * 60 * 60 * 1000;
+    const inputDateFormatter = new Intl.DateTimeFormat('en-CA', { timeZone: 'Asia/Seoul', year: 'numeric', month: '2-digit', day: '2-digit' });
+    const rangeButtons = Array.from(document.querySelectorAll('.btn[data-range]'));
+    const presetRangeButtons = rangeButtons.filter(btn => btn.dataset.range !== 'custom');
+    const customRangeContainer = document.getElementById('custom-range');
+    const customRangeBtn = document.getElementById('custom-range-btn');
+    const customRangeForm = document.getElementById('custom-range-form');
+    const customRangeFromInput = document.getElementById('custom-range-from');
+    const customRangeToInput = document.getElementById('custom-range-to');
+    const customRangeError = document.getElementById('custom-range-error');
+    const customRangeLabel = document.getElementById('custom-range-label');
+    const customRangeCancelBtn = document.getElementById('custom-range-cancel');
+    let historyBounds = { min: null, max: null };
+    let customRange = { from: '', to: '' };
 
     function createEmptySeries() {
       return Object.fromEntries(SERIES_KEYS.map(key => [key, []]));
+    }
+
+    function dateToInputValue(date) {
+      if (!(date instanceof Date) || Number.isNaN(date.getTime())) return '';
+      return inputDateFormatter.format(date);
+    }
+
+    function formatInputDisplay(value) {
+      if (typeof value !== 'string' || !value) return '';
+      return value.replace(/-/g, '.');
+    }
+
+    function parseDateInput(value, endOfDay = false) {
+      if (typeof value !== 'string' || !value) return null;
+      const time = endOfDay ? '23:59:59' : '00:00:00';
+      const iso = `${value}T${time}+09:00`;
+      const parsed = new Date(iso);
+      return Number.isNaN(parsed.getTime()) ? null : parsed;
     }
 
     function formatKST(iso) {
@@ -125,8 +204,47 @@
       return latest;
     }
 
+    function findEarliestInSeries(series) {
+      let earliest = null;
+      for (const key of SERIES_KEYS) {
+        const arr = series[key] || [];
+        const first = arr[0];
+        if (first && typeof first.t === 'string') {
+          if (!earliest || new Date(first.t) < new Date(earliest)) {
+            earliest = first.t;
+          }
+        }
+      }
+      return earliest;
+    }
+
     function getLatestTimestamp() {
       return historyData.lastUpdated ?? findLatestInSeries(historyData.series);
+    }
+
+    function updateHistoryBounds() {
+      const earliestIso = findEarliestInSeries(historyData.series);
+      const latestIso = findLatestInSeries(historyData.series);
+      historyBounds = {
+        min: earliestIso ? new Date(earliestIso) : null,
+        max: latestIso ? new Date(latestIso) : null
+      };
+    }
+
+    function getAllRangeBounds() {
+      if (!historyBounds.min || !historyBounds.max) return null;
+      const start = new Date(Date.UTC(historyBounds.min.getUTCFullYear(), 0, 1));
+      const end = new Date(historyBounds.max);
+      end.setUTCHours(23, 59, 59, 999);
+      return { min: start, max: end };
+    }
+
+    function getCustomRangeBounds() {
+      if (!customRange.from || !customRange.to) return null;
+      const fromDate = parseDateInput(customRange.from);
+      const toDate = parseDateInput(customRange.to, true);
+      if (!fromDate || !toDate) return null;
+      return { min: fromDate, max: toDate };
     }
 
     function getSixMonthBucket(date) {
@@ -140,7 +258,7 @@
 
     function downsampleToSixMonths(points) {
       if (!Array.isArray(points) || points.length === 0) return [];
-      const latestByBucket = new Map();
+      const bucketMap = new Map();
       for (const point of points) {
         if (!point || typeof point.t !== 'string' || typeof point.v !== 'number') continue;
         const dt = new Date(point.t);
@@ -148,23 +266,31 @@
         const bucket = getSixMonthBucket(dt);
         if (!bucket) continue;
         const key = `${bucket.year}-${bucket.half}`;
-        const existing = latestByBucket.get(key);
-        if (!existing || dt > existing.date) {
-          latestByBucket.set(key, {
-            date: dt,
-            year: bucket.year,
-            half: bucket.half,
-            point: { t: point.t, v: point.v }
-          });
+        let entry = bucketMap.get(key);
+        if (!entry) {
+          entry = { year: bucket.year, half: bucket.half, earliest: null, latest: null };
+          bucketMap.set(key, entry);
+        }
+        const safePoint = { t: point.t, v: point.v };
+        if (!entry.earliest || dt < entry.earliest.date) {
+          entry.earliest = { date: dt, point: safePoint };
+        }
+        if (!entry.latest || dt > entry.latest.date) {
+          entry.latest = { date: dt, point: safePoint };
         }
       }
 
-      const aggregated = Array.from(latestByBucket.values())
-        .sort((a, b) => {
-          if (a.year === b.year) return a.half - b.half;
-          return a.year - b.year;
+      const aggregated = Array.from(bucketMap.values())
+        .sort((a, b) => (a.year === b.year ? a.half - b.half : a.year - b.year))
+        .flatMap(entry => {
+          const arr = [];
+          if (entry.earliest) arr.push(entry.earliest.point);
+          if (entry.latest && entry.latest.point.t !== entry.earliest?.point.t) {
+            arr.push(entry.latest.point);
+          }
+          return arr;
         })
-        .map(entry => entry.point);
+        .sort((a, b) => new Date(a.t) - new Date(b.t));
 
       return aggregated.length ? aggregated : points;
     }
@@ -172,6 +298,15 @@
     function filterByRange(points, range) {
       if (!Array.isArray(points) || points.length === 0) return [];
       if (range === 'all') return downsampleToSixMonths(points);
+      if (range === 'custom') {
+        const bounds = getCustomRangeBounds();
+        if (!bounds) return [];
+        return points.filter(p => {
+          const dt = new Date(p.t);
+          if (Number.isNaN(dt.getTime())) return false;
+          return dt >= bounds.min && dt <= bounds.max;
+        });
+      }
       const days = Number(range);
       if (!Number.isFinite(days)) return points;
       const refIso = getLatestTimestamp();
@@ -195,7 +330,8 @@
           pointHoverRadius: 4,
           borderWidth: 2,
           fill: false,
-          borderColor: '#8fb4ff'
+          borderColor: '#8fb4ff',
+          spanGaps: true
         }]
       };
     }
@@ -204,10 +340,20 @@
       return {
         responsive: true,
         maintainAspectRatio: false,
+        layout: { padding: { top: 8, right: 14, bottom: 8, left: 8 } },
         interaction: { mode: 'index', intersect: false },
         scales: {
-          x: { type: 'time', time: { unit: 'day', tooltipFormat: 'yyyy-MM-dd HH:mm' }, grid: { color: '#233060' }, ticks: { color: '#cfe1ff' } },
-          y: { grid: { color: '#233060' }, ticks: { color: '#cfe1ff', callback: v => `${meta.unit}${fmtKRW.format(v)}` } }
+          x: {
+            type: 'time',
+            time: { unit: 'day', tooltipFormat: 'yyyy-MM-dd HH:mm' },
+            grid: { color: '#233060', lineWidth: 0.7 },
+            ticks: { color: '#cfe1ff', padding: 6, maxTicksLimit: 14 }
+          },
+          y: {
+            grid: { color: '#233060', lineWidth: 0.7 },
+            ticks: { color: '#cfe1ff', padding: 6, callback: v => `${meta.unit}${fmtKRW.format(v)}` },
+            grace: '5%'
+          }
         },
         plugins: {
           legend: { display: false },
@@ -257,6 +403,271 @@
           chartInstance.draw();
         }
       };
+    }
+
+    function setCustomRangeError(message) {
+      if (!customRangeError) return;
+      customRangeError.textContent = message ?? '';
+    }
+
+    function updateCustomRangeInputBounds() {
+      if (!customRangeFromInput || !customRangeToInput) return;
+      const bounds = getAllRangeBounds();
+      const minSource = bounds?.min ?? historyBounds.min;
+      const maxSource = bounds?.max ?? historyBounds.max;
+      const minValue = dateToInputValue(minSource);
+      const maxValue = dateToInputValue(maxSource);
+      if (minValue) {
+        customRangeFromInput.min = minValue;
+        customRangeToInput.min = minValue;
+      } else {
+        customRangeFromInput.removeAttribute('min');
+        customRangeToInput.removeAttribute('min');
+      }
+      if (maxValue) {
+        customRangeFromInput.max = maxValue;
+        customRangeToInput.max = maxValue;
+      } else {
+        customRangeFromInput.removeAttribute('max');
+        customRangeToInput.removeAttribute('max');
+      }
+      if (customRange.from && minValue && customRange.from < minValue) {
+        customRange.from = minValue;
+      }
+      if (customRange.to && maxValue && customRange.to > maxValue) {
+        customRange.to = maxValue;
+      }
+    }
+
+    function populateCustomRangeInputs() {
+      if (!customRangeFromInput || !customRangeToInput) return;
+      updateCustomRangeInputBounds();
+      const bounds = getAllRangeBounds();
+      const minSource = bounds?.min ?? historyBounds.min;
+      const maxSource = bounds?.max ?? historyBounds.max;
+      const minValue = dateToInputValue(minSource);
+      const maxValue = dateToInputValue(maxSource);
+      customRangeFromInput.value = customRange.from || minValue || '';
+      customRangeToInput.value = customRange.to || maxValue || '';
+    }
+
+    function openCustomRangePanel() {
+      if (!customRangeForm || !customRangeBtn) return;
+      populateCustomRangeInputs();
+      customRangeForm.removeAttribute('hidden');
+      customRangeBtn.setAttribute('aria-expanded', 'true');
+      setCustomRangeError('');
+      const focusTarget = customRangeFromInput || customRangeToInput;
+      focusTarget?.focus();
+    }
+
+    function closeCustomRangePanel() {
+      if (!customRangeForm || !customRangeBtn) return;
+      if (customRangeForm.hasAttribute('hidden')) return;
+      customRangeForm.setAttribute('hidden', '');
+      customRangeBtn.setAttribute('aria-expanded', 'false');
+      setCustomRangeError('');
+    }
+
+    function toggleCustomRangePanel() {
+      if (!customRangeForm) return;
+      if (customRangeForm.hasAttribute('hidden')) {
+        openCustomRangePanel();
+      } else {
+        closeCustomRangePanel();
+      }
+    }
+
+    function updateCustomRangeLabel() {
+      if (!customRangeLabel) return;
+      if (activeRange === 'custom' && customRange.from && customRange.to) {
+        const label = `${formatInputDisplay(customRange.from)} ~ ${formatInputDisplay(customRange.to)}`;
+        customRangeLabel.textContent = label;
+        if (customRangeBtn) {
+          customRangeBtn.setAttribute('aria-label', `사용자 지정 기간 ${label}`);
+          customRangeBtn.title = `사용자 지정 기간 ${label}`;
+        }
+      } else {
+        customRangeLabel.textContent = '직접 선택';
+        if (customRangeBtn) {
+          customRangeBtn.setAttribute('aria-label', '기간 직접 선택 (달력)');
+          customRangeBtn.title = '기간 직접 선택';
+        }
+      }
+    }
+
+    function updateRangeButtonStates() {
+      rangeButtons.forEach(btn => {
+        const isActive = btn.dataset.range === activeRange;
+        btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+      });
+      updateCustomRangeLabel();
+    }
+
+    function setActiveRange(range) {
+      activeRange = range;
+      updateRangeButtonStates();
+      SERIES_META.forEach(updateCard);
+    }
+
+    function handleCustomRangeSubmit(event) {
+      event.preventDefault();
+      if (!customRangeFromInput || !customRangeToInput) return;
+      const fromVal = customRangeFromInput.value;
+      const toVal = customRangeToInput.value;
+      if (!fromVal || !toVal) {
+        setCustomRangeError('기간을 모두 선택해주세요.');
+        return;
+      }
+      const fromDate = parseDateInput(fromVal);
+      const toDate = parseDateInput(toVal, true);
+      if (!fromDate || !toDate) {
+        setCustomRangeError('유효한 날짜를 입력해주세요.');
+        return;
+      }
+      if (fromDate > toDate) {
+        setCustomRangeError('시작일이 종료일보다 늦습니다.');
+        return;
+      }
+      customRange = { from: fromVal, to: toVal };
+      setCustomRangeError('');
+      closeCustomRangePanel();
+      setActiveRange('custom');
+      if (customRangeBtn) customRangeBtn.focus();
+    }
+
+    function setupCustomRangeUI() {
+      if (!customRangeBtn || !customRangeForm) return;
+      customRangeBtn.addEventListener('click', event => {
+        event.preventDefault();
+        event.stopPropagation();
+        toggleCustomRangePanel();
+      });
+      customRangeCancelBtn?.addEventListener('click', () => {
+        closeCustomRangePanel();
+        customRangeBtn?.focus();
+      });
+      customRangeForm.addEventListener('submit', handleCustomRangeSubmit);
+      document.addEventListener('click', event => {
+        if (!customRangeForm || customRangeForm.hasAttribute('hidden')) return;
+        if (!customRangeContainer) return;
+        if (!customRangeContainer.contains(event.target)) {
+          closeCustomRangePanel();
+        }
+      });
+      document.addEventListener('keydown', event => {
+        if (event.key === 'Escape' && customRangeForm && !customRangeForm.hasAttribute('hidden')) {
+          event.preventDefault();
+          closeCustomRangePanel();
+          customRangeBtn?.focus();
+        }
+      });
+    }
+
+    function setupRangeButtonEvents() {
+      presetRangeButtons.forEach(btn => {
+        btn.addEventListener('click', () => {
+          setActiveRange(btn.dataset.range);
+          closeCustomRangePanel();
+        });
+      });
+    }
+
+    function initializeCustomRangeDefaults() {
+      updateCustomRangeInputBounds();
+      const bounds = getAllRangeBounds();
+      const minSource = bounds?.min ?? historyBounds.min;
+      const maxSource = bounds?.max ?? historyBounds.max;
+      const minValue = dateToInputValue(minSource);
+      const maxValue = dateToInputValue(maxSource);
+      if (minValue && !customRange.from) customRange.from = minValue;
+      if (maxValue && !customRange.to) customRange.to = maxValue;
+      updateCustomRangeLabel();
+    }
+
+    function applyRangeOptions(chart, points) {
+      const xScale = chart.options?.scales?.x;
+      if (!xScale) return;
+      let min = undefined;
+      let max = undefined;
+      let unit = 'day';
+      let ticksLimit;
+
+      if (activeRange === 'all') {
+        const bounds = getAllRangeBounds();
+        if (bounds) {
+          min = bounds.min;
+          max = bounds.max;
+          const diffDays = Math.max(1, Math.round((bounds.max - bounds.min) / MS_IN_DAY));
+          if (diffDays > 365 * 3) {
+            unit = 'year';
+            ticksLimit = 8;
+          } else if (diffDays > 365) {
+            unit = 'month';
+            ticksLimit = 12;
+          } else if (diffDays > 90) {
+            unit = 'week';
+            ticksLimit = 12;
+          } else {
+            unit = 'day';
+            ticksLimit = Math.min(16, diffDays + 1);
+          }
+        }
+      } else if (activeRange === 'custom') {
+        const bounds = getCustomRangeBounds();
+        if (bounds) {
+          min = bounds.min;
+          max = bounds.max;
+          const diffDays = Math.max(1, Math.round((bounds.max - bounds.min) / MS_IN_DAY));
+          if (diffDays > 365 * 2) {
+            unit = 'year';
+            ticksLimit = 8;
+          } else if (diffDays > 200) {
+            unit = 'month';
+            ticksLimit = 12;
+          } else if (diffDays > 60) {
+            unit = 'week';
+            ticksLimit = 12;
+          } else {
+            unit = 'day';
+            ticksLimit = Math.min(16, diffDays + 1);
+          }
+        }
+      } else {
+        if (points.length) {
+          const first = new Date(points[0].t);
+          const last = new Date(points[points.length - 1].t);
+          if (!Number.isNaN(first.getTime())) min = first;
+          if (!Number.isNaN(last.getTime())) max = last;
+        }
+        if (min && max) {
+          const diffDays = Math.max(1, Math.round((max - min) / MS_IN_DAY));
+          if (diffDays > 200) {
+            unit = 'month';
+            ticksLimit = 12;
+          } else if (diffDays > 60) {
+            unit = 'week';
+            ticksLimit = 12;
+          } else {
+            unit = 'day';
+            ticksLimit = Math.min(16, diffDays + 1);
+          }
+        }
+      }
+
+      if (min && max && max <= min) {
+        max = new Date(min.getTime() + MS_IN_DAY);
+      }
+
+      xScale.min = min ?? undefined;
+      xScale.max = max ?? undefined;
+      xScale.time = xScale.time || {};
+      xScale.time.unit = unit;
+      xScale.time.tooltipFormat = 'yyyy-MM-dd HH:mm';
+      xScale.ticks = xScale.ticks || {};
+      xScale.ticks.maxTicksLimit = ticksLimit ?? 14;
+      xScale.ticks.padding = 6;
+      xScale.ticks.source = 'auto';
     }
 
     function setHighlight(metaKey, point) {
@@ -381,6 +792,8 @@
         years: loadedYears
       };
 
+      updateHistoryBounds();
+      initializeCustomRangeDefaults();
       updateDataFilesIndicator(manifestYears, loadedYears);
     }
 
@@ -414,6 +827,7 @@
       if (chart.data.datasets.length) {
         chart.data.datasets[0].data = points.map(p => p.v);
       }
+      applyRangeOptions(chart, points);
       chart.tooltip.setActiveElements([], { x: 0, y: 0 });
       chart.update();
 
@@ -438,15 +852,7 @@
 
         SERIES_META.forEach(renderCard);
         SERIES_META.forEach(updateCard);
-
-        document.querySelectorAll('.btn[data-range]').forEach(btn => {
-          btn.addEventListener('click', () => {
-            document.querySelectorAll('.btn[data-range]').forEach(b => b.setAttribute('aria-pressed','false'));
-            btn.setAttribute('aria-pressed','true');
-            activeRange = btn.dataset.range;
-            SERIES_META.forEach(updateCard);
-          });
-        });
+        updateRangeButtonStates();
       } catch (err) {
         updateDataFilesIndicator([], []);
         const lastUpdatedEl = document.getElementById('last-updated');
@@ -456,6 +862,9 @@
       }
     }
 
+    setupRangeButtonEvents();
+    setupCustomRangeUI();
+    updateRangeButtonStates();
     load();
   </script>
 </body>


### PR DESCRIPTION
## Summary
- add a calendar range picker with custom date inputs and accessibility tweaks
- enhance chart range handling to start the 전체 view at the beginning of the first year and improve grid spacing
- update chart rendering to honour custom ranges and refresh axis bounds dynamically

## Testing
- `node tests/apple_association.test.js`


------
https://chatgpt.com/codex/tasks/task_b_68c90c9d7864832a8bb06ee913f3298c