### PR TITLE
Style FX ticker text in sky blue

### DIFF
--- a/stocks.html
+++ b/stocks.html
@@ -22,7 +22,7 @@
   <style>
   .fx-ticker {
     background-color: #000;
-    color: yellow;
+    color: #00bfff;
     font-weight: bold;
     font-size: 1.0em;
     height: 1.5em;
@@ -41,7 +41,7 @@
     white-space: nowrap;
     line-height: inherit;
     color: inherit;
-    text-decoration: none;
+    text-decoration: underline;
     cursor: pointer;
   }
   .fx-item { margin: 0 .6rem; }


### PR DESCRIPTION
## Summary
- update the FX ticker styling to use a bright sky blue color and underline the rate text for emphasis

## Testing
- node tests/apple_association.test.js

------
https://chatgpt.com/codex/tasks/task_b_68c95fe574f4832a934f8e7b4ecd1ccc