### PR TITLE
Add lunch menu quick link

### DIFF
--- a/index.html
+++ b/index.html
@@ -272,6 +272,9 @@
                 <a href="http://singaseongj.github.io/singaseong_pinball" class="game-btn" style="margin: 0.5rem; text-decoration: none; display: inline-block;">
                     🕹️ Pin ball
                 </a>
+                <a href="http://singaseongj.github.io/lunch_menu" class="game-btn" style="margin: 0.5rem; text-decoration: none; display: inline-block;">
+                    🍱 급식메뉴
+                </a>
             </div>
 
             <div class="game-container">


### PR DESCRIPTION
## Summary
- add a quick launch button linking to the lunch menu alongside the pinball shortcut on the homepage

## Testing
- node tests/apple_association.test.js

------
https://chatgpt.com/codex/tasks/task_b_68c96c09e358832ab889d98b8a27ca04