### PR TITLE
Ensure FX history outputs are staged

### DIFF
--- a/.github/workflows/stock-recs.yml
+++ b/.github/workflows/stock-recs.yml
@@ -362,7 +362,7 @@ jobs:
                   summary.json summary.md data/articles \
                   pools-metrics.json recommendations.json ticker-cache.json pools.json pools-cache.json \
                   cache \
-                  stocks/fx_rates/fx_rates.json stocks/fx_rates/fx_history.json \
+                  stocks/fx_rates/fx_rates.json stocks/fx_rates/fx_history*.json \
                   stocks/fx_rates/index.html || true
           echo "Files staged for commit"
 
@@ -389,6 +389,17 @@ jobs:
           git show HEAD:stocks/fx_rates/fx_rates.json | jq -r .lastUpdated
           echo "history HEAD lastUpdated:"
           git show HEAD:stocks/fx_rates/fx_history.json | jq -r .lastUpdated
+          manifest_tmp="$(mktemp)"
+          git show HEAD:stocks/fx_rates/fx_history_manifest.json > "$manifest_tmp"
+          echo "fx_history manifest HEAD files:"
+          jq -r '.files[]?' "$manifest_tmp"
+          echo "fx_history HEAD per-file updatedAt values:"
+          jq -r '.files[]?' "$manifest_tmp" | while read -r file; do
+            [ -n "$file" ] || continue
+            echo "$file updatedAt:"
+            git show HEAD:stocks/fx_rates/"$file" | jq -r '.updatedAt // .lastUpdated // "missing"'
+          done
+          rm -f "$manifest_tmp"
 
       - name: "Show last commit (debug)"
         if: always()


### PR DESCRIPTION
## Summary
- stage all FX history JSON outputs from the stock recommendations workflow so new yearly files are committed
- extend the verification step to confirm the FX history manifest and per-file timestamps are present in HEAD

## Testing
- node tests/apple_association.test.js

------
https://chatgpt.com/codex/tasks/task_b_68ca0ab1b880832aa0271e74fadba222