### PR TITLE
Add localized keyword search buttons and weight pools by keyword score

### DIFF
--- a/newsKeywords.json
+++ b/newsKeywords.json
@@ -27,7 +27,11 @@
           "url": "https://example.com/samsung-ai",
           "source": "naver"
         }
-      ]
+      ],
+      "searchUrl": {
+        "ko": "https://www.google.com/search?q=AI+%EB%B0%98%EB%8F%84%EC%B2%B4+%ED%88%AC%EC%9E%90&tbm=nws&hl=ko&gl=KR&ceid=KR%3Ako",
+        "en": "https://www.google.com/search?q=AI+semiconductor+investment&tbm=nws&hl=en&gl=US&ceid=US%3Aen"
+      }
     },
     {
       "text": {
@@ -50,7 +54,11 @@
           "url": "https://example.com/ira",
           "source": "newsapi"
         }
-      ]
+      ],
+      "searchUrl": {
+        "ko": "https://www.google.com/search?q=%EC%B9%9C%ED%99%98%EA%B2%BD+%EC%97%90%EB%84%88%EC%A7%80&tbm=nws&hl=ko&gl=KR&ceid=KR%3Ako",
+        "en": "https://www.google.com/search?q=Green+energy&tbm=nws&hl=en&gl=US&ceid=US%3Aen"
+      }
     },
     {
       "text": {
@@ -65,7 +73,11 @@
       ],
       "mentions": 7,
       "score": 0.58,
-      "sampleHeadlines": []
+      "sampleHeadlines": [],
+      "searchUrl": {
+        "ko": "https://www.google.com/search?q=%EC%9B%90%2F%EB%8B%AC%EB%9F%AC+%ED%99%98%EC%9C%A8+%EC%95%88%EC%A0%95&tbm=nws&hl=ko&gl=KR&ceid=KR%3Ako",
+        "en": "https://www.google.com/search?q=KRW%2FUSD+stability&tbm=nws&hl=en&gl=US&ceid=US%3Aen"
+      }
     },
     {
       "text": {
@@ -81,7 +93,11 @@
       ],
       "mentions": 6,
       "score": 0.5,
-      "sampleHeadlines": []
+      "sampleHeadlines": [],
+      "searchUrl": {
+        "ko": "https://www.google.com/search?q=%EB%B0%94%EC%9D%B4%EC%98%A4+%ED%97%AC%EC%8A%A4%EC%BC%80%EC%96%B4&tbm=nws&hl=ko&gl=KR&ceid=KR%3Ako",
+        "en": "https://www.google.com/search?q=Bio+healthcare&tbm=nws&hl=en&gl=US&ceid=US%3Aen"
+      }
     },
     {
       "text": {
@@ -97,7 +113,11 @@
       ],
       "mentions": 5,
       "score": 0.42,
-      "sampleHeadlines": []
+      "sampleHeadlines": [],
+      "searchUrl": {
+        "ko": "https://www.google.com/search?q=IT+%EC%84%9C%EB%B9%84%EC%8A%A4+%EC%97%85%ED%99%A9&tbm=nws&hl=ko&gl=KR&ceid=KR%3Ako",
+        "en": "https://www.google.com/search?q=IT+services+outlook&tbm=nws&hl=en&gl=US&ceid=US%3Aen"
+      }
     },
     {
       "text": {
@@ -113,7 +133,11 @@
       ],
       "mentions": 5,
       "score": 0.42,
-      "sampleHeadlines": []
+      "sampleHeadlines": [],
+      "searchUrl": {
+        "ko": "https://www.google.com/search?q=%EB%B0%98%EB%8F%84%EC%B2%B4+%EA%B3%B5%EA%B8%89%EB%A7%9D&tbm=nws&hl=ko&gl=KR&ceid=KR%3Ako",
+        "en": "https://www.google.com/search?q=Semiconductor+supply+chain&tbm=nws&hl=en&gl=US&ceid=US%3Aen"
+      }
     },
     {
       "text": {
@@ -128,7 +152,11 @@
       ],
       "mentions": 4,
       "score": 0.33,
-      "sampleHeadlines": []
+      "sampleHeadlines": [],
+      "searchUrl": {
+        "ko": "https://www.google.com/search?q=2%EC%B0%A8%EC%A0%84%EC%A7%80+%EC%86%8C%EC%9E%AC&tbm=nws&hl=ko&gl=KR&ceid=KR%3Ako",
+        "en": "https://www.google.com/search?q=Battery+materials&tbm=nws&hl=en&gl=US&ceid=US%3Aen"
+      }
     },
     {
       "text": {
@@ -143,7 +171,11 @@
       ],
       "mentions": 4,
       "score": 0.33,
-      "sampleHeadlines": []
+      "sampleHeadlines": [],
+      "searchUrl": {
+        "ko": "https://www.google.com/search?q=%EB%AF%B8%EA%B5%AD+CPI&tbm=nws&hl=ko&gl=KR&ceid=KR%3Ako",
+        "en": "https://www.google.com/search?q=US+CPI&tbm=nws&hl=en&gl=US&ceid=US%3Aen"
+      }
     },
     {
       "text": {
@@ -158,7 +190,11 @@
       ],
       "mentions": 3,
       "score": 0.25,
-      "sampleHeadlines": []
+      "sampleHeadlines": [],
+      "searchUrl": {
+        "ko": "https://www.google.com/search?q=%ED%99%98%EC%9C%A8+%EB%B3%80%EB%8F%99%EC%84%B1&tbm=nws&hl=ko&gl=KR&ceid=KR%3Ako",
+        "en": "https://www.google.com/search?q=FX+volatility&tbm=nws&hl=en&gl=US&ceid=US%3Aen"
+      }
     },
     {
       "text": {
@@ -173,7 +209,11 @@
       ],
       "mentions": 3,
       "score": 0.25,
-      "sampleHeadlines": []
+      "sampleHeadlines": [],
+      "searchUrl": {
+        "ko": "https://www.google.com/search?q=%EB%AF%B8+%EC%97%B0%EC%A4%80+%EA%B8%88%EB%A6%AC&tbm=nws&hl=ko&gl=KR&ceid=KR%3Ako",
+        "en": "https://www.google.com/search?q=US+Fed+rate&tbm=nws&hl=en&gl=US&ceid=US%3Aen"
+      }
     }
   ],
   "markets": [

--- a/src/news/fetchByTicker.js
+++ b/src/news/fetchByTicker.js
@@ -139,6 +139,25 @@ function normalizeWord(word){
   return String(word || '').replace(/["'`’”\(\)\[\]\{\}:;!?]/g, '').trim();
 }
 
+function buildGoogleSearchUrl(query, locale = 'en'){
+  const q = String(query || '').trim();
+  if (!q) return '';
+  const params = new URLSearchParams();
+  params.set('q', q);
+  params.set('tbm', 'nws');
+  const lang = locale === 'ko' ? 'ko' : 'en';
+  if (lang === 'ko') {
+    params.set('hl', 'ko');
+    params.set('gl', 'KR');
+    params.set('ceid', 'KR:ko');
+  } else {
+    params.set('hl', 'en');
+    params.set('gl', 'US');
+    params.set('ceid', 'US:en');
+  }
+  return `https://www.google.com/search?${params.toString()}`;
+}
+
 function extractEnglishKeywords(text){
   if (!text) return [];
   const tokens = [];
@@ -397,7 +416,18 @@ function buildKeywordSummary(articles){
   const maxScore = Math.max(...top.map(it => it.score), 1);
   return top.map(item => ({
     ...item,
-    score: Number((item.score / maxScore).toFixed(3))
+    score: Number((item.score / maxScore).toFixed(3)),
+    searchUrl: (() => {
+      const koQuery = item.text.ko || item.text.en || '';
+      const enQuery = item.text.en || item.text.ko || '';
+      const localized = {
+        ko: buildGoogleSearchUrl(koQuery, 'ko'),
+        en: buildGoogleSearchUrl(enQuery, 'en')
+      };
+      if (!localized.ko) delete localized.ko;
+      if (!localized.en) delete localized.en;
+      return localized;
+    })()
   }));
 }
 

--- a/stocks.html
+++ b/stocks.html
@@ -74,10 +74,50 @@
     flex-direction: column;
     gap: 0.35rem;
   }
+  .keyword-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
   .keyword-text {
     font-weight: 600;
     font-size: 1rem;
     color: #2c3e50;
+  }
+  .keyword-actions {
+    display: inline-flex;
+    gap: 0.4rem;
+    flex-wrap: wrap;
+  }
+  .keyword-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.25rem 0.65rem;
+    border-radius: 4px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    text-decoration: none;
+    color: #fff;
+    background: #2563eb;
+    border: 1px solid #1d4ed8;
+    transition: background-color 0.2s ease, box-shadow 0.2s ease;
+  }
+  .keyword-btn:hover,
+  .keyword-btn:focus-visible {
+    background: #1e40af;
+    box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.25);
+  }
+  .keyword-btn[data-lang="ko"] {
+    background: #0f766e;
+    border-color: #0f5e55;
+  }
+  .keyword-btn[data-lang="ko"]:hover,
+  .keyword-btn[data-lang="ko"]:focus-visible {
+    background: #0d5f59;
+    box-shadow: 0 0 0 2px rgba(15, 118, 110, 0.25);
   }
   .keyword-markets {
     font-size: 0.85rem;
@@ -413,7 +453,31 @@
           const marketsHtml = markets
             ? `<span class="keyword-markets">${escapeHtml(translations[currentLang].keywordMarkets)}: ${markets}</span>`
             : '';
-          return `<li><span class="keyword-text">${label}</span>${marketsHtml}</li>`;
+          const urls = (() => {
+            const urlField = entry?.searchUrl;
+            if (typeof urlField === 'string') {
+              return { en: urlField };
+            }
+            if (urlField && typeof urlField === 'object') {
+              const result = {};
+              if (typeof urlField.ko === 'string' && urlField.ko) result.ko = urlField.ko;
+              if (typeof urlField.en === 'string' && urlField.en) result.en = urlField.en;
+              return result;
+            }
+            return {};
+          })();
+          if (!urls.ko && urls.en) urls.ko = urls.en;
+          if (!urls.en && urls.ko) urls.en = urls.ko;
+          const buttons = [];
+          if (urls.ko) {
+            buttons.push(`<a class="keyword-btn" data-lang="ko" href="${escapeHtml(urls.ko)}" target="_blank" rel="noopener noreferrer">한국어</a>`);
+          }
+          if (urls.en) {
+            buttons.push(`<a class="keyword-btn" data-lang="en" href="${escapeHtml(urls.en)}" target="_blank" rel="noopener noreferrer">English</a>`);
+          }
+          const actionsHtml = buttons.length ? `<div class="keyword-actions">${buttons.join('')}</div>` : '';
+          const header = `<div class="keyword-header"><span class="keyword-text">${label}</span>${actionsHtml}</div>`;
+          return `<li>${header}${marketsHtml}</li>`;
         }).join('');
         listEl.innerHTML = items || `<li class="empty">${translations[currentLang].keywordError}</li>`;
         errorEl.style.display = 'none';

--- a/tools/buildPoolsTrendy.js
+++ b/tools/buildPoolsTrendy.js
@@ -206,8 +206,11 @@ function saveNameToSymbol(map) {
 const NAME_TO_SYMBOL = loadNameToSymbol();
 const SYMBOL_TO_NAME = {};
 const KEYWORD_SNAPSHOT_PATH = path.join(process.cwd(), 'newsKeywords.json');
-const KEYWORD_BONUS_SAFE = Number(process.env.KEYWORD_BONUS_SAFE || 0.05);
-const KEYWORD_BONUS_AGGR = Number(process.env.KEYWORD_BONUS_AGGR || 0.07);
+const KEYWORD_SCORE_WEIGHT = (() => {
+  const raw = Number(process.env.KEYWORD_SCORE_WEIGHT ?? 0.1);
+  if (!Number.isFinite(raw)) return 0.1;
+  return Math.max(0, Math.min(0.5, raw));
+})();
 let NEWS_KEYWORD_SNAPSHOT = null;
 const CONFIRMED_KEYS = new Set();
 
@@ -1837,15 +1840,20 @@ async function main(){
         const hits = keywordMatchesForName(n, sym);
         if (!hits.length) continue;
         const limited = hits.slice(0, 3);
-        const liftSafe = KEYWORD_BONUS_SAFE * limited.length;
-        const liftAggr = KEYWORD_BONUS_AGGR * limited.length;
-        if (liftSafe > 0) {
-          scoreSafe[n] = clamp01(scoreSafe[n] + liftSafe);
-        }
-        if (liftAggr > 0) {
-          scoreAggr[n] = clamp01(scoreAggr[n] + liftAggr);
-        }
+        const keywordScore = limited.reduce((max, entry) => {
+          const val = Number(entry?.score ?? 0);
+          return Math.max(max, clamp01(val));
+        }, 0);
         byName[n].reasons = byName[n].reasons || {};
+        if (keywordScore > 0 && KEYWORD_SCORE_WEIGHT > 0) {
+          const baseSafe = clamp01(scoreSafe[n]);
+          const baseAggr = clamp01(scoreAggr[n]);
+          const blendedSafe = clamp01((1 - KEYWORD_SCORE_WEIGHT) * baseSafe + KEYWORD_SCORE_WEIGHT * keywordScore);
+          const blendedAggr = clamp01((1 - KEYWORD_SCORE_WEIGHT) * baseAggr + KEYWORD_SCORE_WEIGHT * keywordScore);
+          scoreSafe[n] = clamp01(Math.max(scoreSafe[n], blendedSafe));
+          scoreAggr[n] = clamp01(Math.max(scoreAggr[n], blendedAggr));
+          byName[n].reasons.keywordScore = keywordScore;
+        }
         const texts = limited.map(entry => entry?.text?.ko && entry?.text?.en
           ? `${entry.text.ko} / ${entry.text.en}`
           : (entry?.text?.ko || entry?.text?.en || ''));
@@ -1854,6 +1862,7 @@ async function main(){
           (metricsOut[market] ||= {});
           (metricsOut[market][n] ||= {});
           metricsOut[market][n].keywordMatches = limited.map(entry => entry.text);
+          metricsOut[market][n].keywordScore = keywordScore;
         } catch {}
       }
     }


### PR DESCRIPTION
## Summary
- generate both Korean and English Google News search URLs when building the keyword snapshot and refresh the checked-in sample
- refresh the stocks keyword UI so each entry offers 한국어 and English buttons that open the localized search results
- fold keyword snapshot scores into pool scoring with a 10% weight and surface the contribution in pool metrics

## Testing
- node tests/apple_association.test.js

------
https://chatgpt.com/codex/tasks/task_b_68da9949b584832a862ccc51279e5a18