### PR TITLE
Enhance market keyword extraction

### DIFF
--- a/newsKeywords.json
+++ b/newsKeywords.json
@@ -1,11 +1,221 @@
 {
-  "generatedAt": null,
+  "generatedAt": "2025-09-29T14:27:17.672Z",
   "timezone": "Asia/Seoul",
   "updatedAt": {
-    "ko": null,
-    "en": null
+    "ko": "2025. 9. 29. 23시 27분 17초",
+    "en": "9/29/2025, 11:27:17 PM"
   },
-  "keywords": [],
+  "keywords": [
+    {
+      "text": {
+        "ko": "AI 반도체 투자",
+        "en": "AI semiconductor investment"
+      },
+      "markets": [
+        "KOSPI",
+        "NASDAQ 100"
+      ],
+      "sources": [
+        "naver",
+        "newsapi"
+      ],
+      "mentions": 12,
+      "score": 1,
+      "sampleHeadlines": [
+        {
+          "title": "AI 반도체 수요 확대에 삼성전자 투자 확대",
+          "url": "https://example.com/samsung-ai",
+          "source": "naver"
+        }
+      ],
+      "searchUrl": {
+        "ko": "https://www.google.com/search?q=AI+%EB%B0%98%EB%8F%84%EC%B2%B4+%ED%88%AC%EC%9E%90&tbm=nws&hl=ko&gl=KR&ceid=KR%3Ako",
+        "en": "https://www.google.com/search?q=AI+semiconductor+investment&tbm=nws&hl=en&gl=US&ceid=US%3Aen"
+      }
+    },
+    {
+      "text": {
+        "ko": "친환경 에너지",
+        "en": "Green energy"
+      },
+      "markets": [
+        "KOSDAQ",
+        "S&P 500"
+      ],
+      "sources": [
+        "gnews",
+        "serpapi"
+      ],
+      "mentions": 9,
+      "score": 0.75,
+      "sampleHeadlines": [
+        {
+          "title": "미국 신재생 에너지 세액공제 확대",
+          "url": "https://example.com/ira",
+          "source": "newsapi"
+        }
+      ],
+      "searchUrl": {
+        "ko": "https://www.google.com/search?q=%EC%B9%9C%ED%99%98%EA%B2%BD+%EC%97%90%EB%84%88%EC%A7%80&tbm=nws&hl=ko&gl=KR&ceid=KR%3Ako",
+        "en": "https://www.google.com/search?q=Green+energy&tbm=nws&hl=en&gl=US&ceid=US%3Aen"
+      }
+    },
+    {
+      "text": {
+        "ko": "원/달러 환율 안정",
+        "en": "KRW/USD stability"
+      },
+      "markets": [
+        "KOSPI"
+      ],
+      "sources": [
+        "naver"
+      ],
+      "mentions": 7,
+      "score": 0.58,
+      "sampleHeadlines": [],
+      "searchUrl": {
+        "ko": "https://www.google.com/search?q=%EC%9B%90%2F%EB%8B%AC%EB%9F%AC+%ED%99%98%EC%9C%A8+%EC%95%88%EC%A0%95&tbm=nws&hl=ko&gl=KR&ceid=KR%3Ako",
+        "en": "https://www.google.com/search?q=KRW%2FUSD+stability&tbm=nws&hl=en&gl=US&ceid=US%3Aen"
+      }
+    },
+    {
+      "text": {
+        "ko": "바이오 헬스케어",
+        "en": "Bio healthcare"
+      },
+      "markets": [
+        "KOSDAQ",
+        "NASDAQ 100"
+      ],
+      "sources": [
+        "newsdata"
+      ],
+      "mentions": 6,
+      "score": 0.5,
+      "sampleHeadlines": [],
+      "searchUrl": {
+        "ko": "https://www.google.com/search?q=%EB%B0%94%EC%9D%B4%EC%98%A4+%ED%97%AC%EC%8A%A4%EC%BC%80%EC%96%B4&tbm=nws&hl=ko&gl=KR&ceid=KR%3Ako",
+        "en": "https://www.google.com/search?q=Bio+healthcare&tbm=nws&hl=en&gl=US&ceid=US%3Aen"
+      }
+    },
+    {
+      "text": {
+        "ko": "IT 서비스 업황",
+        "en": "IT services outlook"
+      },
+      "markets": [
+        "KOSPI",
+        "S&P 500"
+      ],
+      "sources": [
+        "serpapi"
+      ],
+      "mentions": 5,
+      "score": 0.42,
+      "sampleHeadlines": [],
+      "searchUrl": {
+        "ko": "https://www.google.com/search?q=IT+%EC%84%9C%EB%B9%84%EC%8A%A4+%EC%97%85%ED%99%A9&tbm=nws&hl=ko&gl=KR&ceid=KR%3Ako",
+        "en": "https://www.google.com/search?q=IT+services+outlook&tbm=nws&hl=en&gl=US&ceid=US%3Aen"
+      }
+    },
+    {
+      "text": {
+        "ko": "반도체 공급망",
+        "en": "Semiconductor supply chain"
+      },
+      "markets": [
+        "NASDAQ 100",
+        "S&P 500"
+      ],
+      "sources": [
+        "newsapi"
+      ],
+      "mentions": 5,
+      "score": 0.42,
+      "sampleHeadlines": [],
+      "searchUrl": {
+        "ko": "https://www.google.com/search?q=%EB%B0%98%EB%8F%84%EC%B2%B4+%EA%B3%B5%EA%B8%89%EB%A7%9D&tbm=nws&hl=ko&gl=KR&ceid=KR%3Ako",
+        "en": "https://www.google.com/search?q=Semiconductor+supply+chain&tbm=nws&hl=en&gl=US&ceid=US%3Aen"
+      }
+    },
+    {
+      "text": {
+        "ko": "2차전지 소재",
+        "en": "Battery materials"
+      },
+      "markets": [
+        "KOSDAQ"
+      ],
+      "sources": [
+        "naver"
+      ],
+      "mentions": 4,
+      "score": 0.33,
+      "sampleHeadlines": [],
+      "searchUrl": {
+        "ko": "https://www.google.com/search?q=2%EC%B0%A8%EC%A0%84%EC%A7%80+%EC%86%8C%EC%9E%AC&tbm=nws&hl=ko&gl=KR&ceid=KR%3Ako",
+        "en": "https://www.google.com/search?q=Battery+materials&tbm=nws&hl=en&gl=US&ceid=US%3Aen"
+      }
+    },
+    {
+      "text": {
+        "ko": "미국 CPI",
+        "en": "US CPI"
+      },
+      "markets": [
+        "S&P 500"
+      ],
+      "sources": [
+        "gnews"
+      ],
+      "mentions": 4,
+      "score": 0.33,
+      "sampleHeadlines": [],
+      "searchUrl": {
+        "ko": "https://www.google.com/search?q=%EB%AF%B8%EA%B5%AD+CPI&tbm=nws&hl=ko&gl=KR&ceid=KR%3Ako",
+        "en": "https://www.google.com/search?q=US+CPI&tbm=nws&hl=en&gl=US&ceid=US%3Aen"
+      }
+    },
+    {
+      "text": {
+        "ko": "환율 변동성",
+        "en": "FX volatility"
+      },
+      "markets": [
+        "KOSPI"
+      ],
+      "sources": [
+        "newsdata"
+      ],
+      "mentions": 3,
+      "score": 0.25,
+      "sampleHeadlines": [],
+      "searchUrl": {
+        "ko": "https://www.google.com/search?q=%ED%99%98%EC%9C%A8+%EB%B3%80%EB%8F%99%EC%84%B1&tbm=nws&hl=ko&gl=KR&ceid=KR%3Ako",
+        "en": "https://www.google.com/search?q=FX+volatility&tbm=nws&hl=en&gl=US&ceid=US%3Aen"
+      }
+    },
+    {
+      "text": {
+        "ko": "미 연준 금리",
+        "en": "US Fed rate"
+      },
+      "markets": [
+        "S&P 500"
+      ],
+      "sources": [
+        "newsapi"
+      ],
+      "mentions": 3,
+      "score": 0.25,
+      "sampleHeadlines": [],
+      "searchUrl": {
+        "ko": "https://www.google.com/search?q=%EB%AF%B8+%EC%97%B0%EC%A4%80+%EA%B8%88%EB%A6%AC&tbm=nws&hl=ko&gl=KR&ceid=KR%3Ako",
+        "en": "https://www.google.com/search?q=US+Fed+rate&tbm=nws&hl=en&gl=US&ceid=US%3Aen"
+      }
+    }
+  ],
   "markets": [
     "KOSPI",
     "KOSDAQ",

--- a/src/news/fetchByTicker.js
+++ b/src/news/fetchByTicker.js
@@ -187,6 +187,53 @@ function extractKoreanKeywords(text){
   return tokens;
 }
 
+function splitMeaningfulWords(text){
+  if (!text) return [];
+  const cleaned = stripHtml(text)
+    .replace(/[\u201c\u201d\u2018\u2019]/g, '')
+    .replace(/[^0-9A-Za-z가-힣·\s]/g, ' ');
+  const parts = cleaned.split(/\s+/).map(normalizeWord).filter(Boolean);
+  const result = [];
+  for (const part of parts){
+    if (!part || part.length < 2) continue;
+    const hasHangul = containsHangul(part);
+    const lower = part.toLowerCase();
+    if (hasHangul && STOPWORDS_KO.has(part)) continue;
+    if (!hasHangul && STOPWORDS_EN.has(lower)) continue;
+    result.push({ token: part, locale: hasHangul ? 'ko' : 'en' });
+  }
+  return result;
+}
+
+function extractKeywordPhrases(text){
+  if (!text) return [];
+  const words = splitMeaningfulWords(text);
+  const phrases = [];
+  const seen = new Set();
+  for (let i = 0; i < words.length; i++){
+    const slice = [];
+    for (let len = 1; len <= 3 && i + len <= words.length; len++){
+      slice.push(words[i + len - 1]);
+      if (!slice.length) continue;
+      const phrase = slice.map(it => it.token).join(' ');
+      if (!phrase || phrase.length < 3) continue;
+      if (phrase.split(' ').length === 1) continue;
+      const locales = new Set(slice.map(it => it.locale));
+      const locale = locales.has('ko') ? 'ko' : 'en';
+      const hasMeaningful = slice.some(it => {
+        if (containsHangul(it.token)) return !STOPWORDS_KO.has(it.token);
+        return !STOPWORDS_EN.has(it.token.toLowerCase());
+      });
+      if (!hasMeaningful) continue;
+      const key = `${locale}:${phrase.toLowerCase()}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      phrases.push({ token: phrase, locale });
+    }
+  }
+  return phrases;
+}
+
 function addKeywordCandidate(map, key, info){
   if (!key) return;
   const norm = key.toLowerCase();
@@ -377,7 +424,8 @@ function buildKeywordSummary(articles){
     const text = `${article.title || ''} ${article.description || ''}`;
     const english = extractEnglishKeywords(text);
     const korean  = extractKoreanKeywords(text);
-    const tokens = [...english, ...korean];
+    const phrases = extractKeywordPhrases(text);
+    const tokens = [...phrases, ...english, ...korean];
     for (const { token, locale } of tokens) {
       if (!token) continue;
       addKeywordCandidate(map, token, {


### PR DESCRIPTION
## Summary
- extract multi-word market keyword phrases so generated topics include richer Korean and English content and bilingual Google search URLs
- refresh the sample `newsKeywords.json` snapshot with representative bilingual keywords, metadata, and search links

## Testing
- node tests/apple_association.test.js

------
https://chatgpt.com/codex/tasks/task_b_68db13078abc832a9dd682b597088267