### PR TITLE
Refine ticker keyword extraction with linguistic tokenizers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,15 @@
       "dependencies": {
         "@polygon.io/client-js": "^8.2.0",
         "cheerio": "^1.0.0",
+        "compromise": "^14.14.2",
         "fast-xml-parser": "^5.2.5",
         "node-fetch": "^3.3.2"
       },
       "engines": {
         "node": ">=18"
+      },
+      "optionalDependencies": {
+        "open-korean-text-node": "^2.2.0"
       }
     },
     "node_modules/@polygon.io/client-js": {
@@ -36,11 +40,71 @@
         "node": ">=16"
       }
     },
+    "node_modules/ajv": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha512-Ajr4IcMXq/2QmMkEmSvxqfLN5zGmJ92gHXAeOXq1OekoH2rfDNsgdDoL2f7QaRCy7G/E6TpxBVdRuNraMztGHw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
+      }
+    },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "node_modules/assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/async": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+      "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "lodash": "^4.14.0"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
+    },
+    "node_modules/aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/aws4": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
+      "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/axios": {
       "version": "1.11.0",
@@ -53,11 +117,53 @@
         "proxy-from-env": "^1.1.0"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "license": "ISC"
+    },
+    "node_modules/boom": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+      "integrity": "sha512-FA8ZqcHBLjyFCPns8EsFTWxARi8iKzLfl3vXS1n1O6mlUpZvjXg9E+0Ys8mh7k/s8mHVpROgeoUmz4HadhPhAQ==",
+      "deprecated": "This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "hoek": "4.x.x"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
     },
     "node_modules/bufferutil": {
       "version": "4.0.9",
@@ -84,6 +190,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
+      "license": "Apache-2.0",
+      "optional": true
     },
     "node_modules/cheerio": {
       "version": "1.1.2",
@@ -127,6 +240,17 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -138,6 +262,34 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/compromise": {
+      "version": "14.14.4",
+      "resolved": "https://registry.npmjs.org/compromise/-/compromise-14.14.4.tgz",
+      "integrity": "sha512-QdbJwronwxeqb7a5KFK/+Y5YieZ4PE1f7ai0vU58Pp4jih+soDCBMuKVbhDEPQ+6+vI3vSiG4UAAjTAXLJw1Qw==",
+      "license": "MIT",
+      "dependencies": {
+        "efrt": "2.7.0",
+        "grad-school": "0.0.5",
+        "suffix-thumb": "5.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/cross-fetch": {
       "version": "3.2.0",
@@ -166,6 +318,34 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/cryptiles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.2.1.tgz",
+      "integrity": "sha512-eeYcSehTunKcMIspjiIzRI+dk447ncZXlHNRPUKQxvC6y9MvsELVnA1bbMdUgrY9KsVT1weZTcfPxSoafUTkYQ==",
+      "deprecated": "This module has moved and is now available at @hapi/cryptiles. Please update your dependencies as this version is no longer maintained and may contain bugs and security issues.",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "dependencies": {
+        "boom": "5.x.x"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/cryptiles/node_modules/boom": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-5.3.3.tgz",
+      "integrity": "sha512-UdzFI5w5zxU56pCAhV1ToNnYh7TxO7R0cp1X0qLrjyCJHJNYWos8XMtIx4LLXwfPHbPV1E3FD0kxA6od98P7ng==",
+      "deprecated": "This module has moved and is now available at @hapi/boom. Please update your dependencies as this version is no longer maintained and may contain bugs and security issues.",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "dependencies": {
+        "hoek": "4.x.x"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/css-select": {
@@ -207,6 +387,19 @@
       },
       "engines": {
         "node": ">=0.12"
+      }
+    },
+    "node_modules/dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/data-uri-to-buffer": {
@@ -314,6 +507,26 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "node_modules/efrt": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/efrt/-/efrt-2.7.0.tgz",
+      "integrity": "sha512-/RInbCy1d4P6Zdfa+TMVsf/ufZVotat5hCw3QXmWtjU+3pFEOvOQ7ibo3aIxyCJw2leIeAMjmPj+1SLJiCpdrQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/encoding-sniffer": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
@@ -411,6 +624,13 @@
         "es6-symbol": "^3.1.1"
       }
     },
+    "node_modules/es6-promisify": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-6.1.1.tgz",
+      "integrity": "sha512-HBL8I3mIki5C1Cc9QjKUenHtnG0A5/xA8Q/AllRcfiwl2CZFXGK7ddBiCoRwAix4i2KxcQfjtIVcrVbB3vbmwg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/es6-symbol": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.4.tgz",
@@ -457,6 +677,37 @@
       "dependencies": {
         "type": "^2.7.2"
       }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha512-fueX787WZKCV0Is4/T2cyAdM4+x1S3MXXOAhavE1ys/W42SHAPacLTQhucja22QBYrfGw50M2sRiXPtTGv9Ymw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fast-xml-parser": {
       "version": "5.2.5",
@@ -508,6 +759,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/find-java-home": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/find-java-home/-/find-java-home-0.2.0.tgz",
+      "integrity": "sha512-nq5PFOHxE1VSEbdDVkLoA2bAcRnG4ETqJO8ipFq3glIWA52hdWCXYX3emuUyMAQfaqFU4Ea85gqcgaPmOApEPA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "which": "~1.0.5",
+        "winreg": "~1.2.2"
+      }
+    },
     "node_modules/follow-redirects": {
       "version": "1.15.11",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
@@ -526,6 +788,16 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/form-data": {
@@ -555,6 +827,13 @@
       "engines": {
         "node": ">=12.20.0"
       }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -602,6 +881,35 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -612,6 +920,40 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/grad-school": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/grad-school/-/grad-school-0.0.5.tgz",
+      "integrity": "sha512-rXunEHF9M9EkMydTBux7+IryYXEZinRk6g8OBOGDBzo/qWJjhTxy86i5q7lQYpCLHN8Sqv1XX3OIOc7ka2gtvQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/har-validator": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+      "integrity": "sha512-r7LZkP7Z6WMxj5zARzB9dSpIKu/sp0NfHIgtj6kmQXhEArNctjB5FEv/L2XfLdWqIocPT2QVt0LFOlEUioTBtQ==",
+      "deprecated": "this library is no longer supported",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "ajv": "^5.1.0",
+        "har-schema": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/has-symbols": {
@@ -653,6 +995,34 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hawk": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+      "deprecated": "This module moved to @hapi/hawk. Please make sure to switch over as this distribution is no longer supported and may contain bugs and critical security issues.",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "boom": "4.x.x",
+        "cryptiles": "3.x.x",
+        "hoek": "4.x.x",
+        "sntp": "2.x.x"
+      },
+      "engines": {
+        "node": ">=4.5.0"
+      }
+    },
+    "node_modules/hoek": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.3.1.tgz",
+      "integrity": "sha512-v7E+yIjcHECn973i0xHm4kJkEpv3C8sbYS4344WXbzYqRyiDD7rjnnKo4hsJkejQBAFdRMUGNHySeSPKSH9Rqw==",
+      "deprecated": "This module has moved and is now available at @hapi/hoek. Please update your dependencies as this version is no longer maintained an may contain bugs and security issues.",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/htmlparser2": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
@@ -684,6 +1054,22 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      },
+      "engines": {
+        "node": ">=0.8",
+        "npm": ">=1.3.7"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -696,11 +1082,106 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC",
+      "optional": true
+    },
     "node_modules/is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
       "license": "MIT"
+    },
+    "node_modules/isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/java": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/java/-/java-0.9.1.tgz",
+      "integrity": "sha512-n2+ljvwSoZ/DgNr9HM4Dsx0dEsFA41perfeEFjuDJVkAfDbVjEarMiSaTtCV2qR1BPgQNi4SdSABbk3nrck4gQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "async": "2.6.0",
+        "find-java-home": "0.2.0",
+        "glob": "7.1.2",
+        "lodash": "4.17.5",
+        "nan": "2.9.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)",
+      "optional": true
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha512-4JD/Ivzg7PoW8NzdrBSr3UFwC9mHgvI7Z6z3QGBsSHgKaRTUDmyZAAKJo2UbG1kUVfS9WS8bi36N49U1xw43DA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/jsprim": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.4.0",
+        "verror": "1.10.0"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.5",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -732,11 +1213,31 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
+    },
+    "node_modules/nan": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.9.2.tgz",
+      "integrity": "sha512-ltW65co7f3PQWBDbqVvaU1WtFJUsNW7sWWm4HINhbMQIyVyzIeyZ8toX5TC5eeooE6piZoaEh4cZkueSKG3KYw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/next-tick": {
       "version": "1.1.0",
@@ -793,6 +1294,22 @@
         "node-gyp-build-test": "build-test.js"
       }
     },
+    "node_modules/node-wget": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/node-wget/-/node-wget-0.4.3.tgz",
+      "integrity": "sha512-sltt/nc4NJeI4CuncyBFZZ7W4Wz3Q1oM8h27mYEbj5OihXMsuqJpplPl0WUZTSpXy8AyGczT08jIBsXHxdCtgg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "request": "~2.85.0"
+      },
+      "bin": {
+        "wget": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.8.6"
+      }
+    },
     "node_modules/nth-check": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
@@ -803,6 +1320,42 @@
       },
       "funding": {
         "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/oauth-sign": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha512-VlF07iu3VV3+BTXj43Nmp6Irt/G7j/NgEctUS6IweH1RGhURjjCc2NWtzXFPXXWWfc7hgbXQdtiQu2LGp6MxUg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/open-korean-text-node": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/open-korean-text-node/-/open-korean-text-node-2.2.0.tgz",
+      "integrity": "sha512-i6BY72j4Jq1xzJCBJfZB6OAfNqCerc5rGtisLLXxQGDW+7f36cHsNLPPOsPFObdpbVx6eM5uMd9GRbNDJkFalw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "es6-promisify": "^6.0.0",
+        "java": "^0.9.0",
+        "node-wget": "^0.4.2"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/parse5": {
@@ -854,11 +1407,45 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
+    },
+    "node_modules/punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/qs": {
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.6"
+      }
     },
     "node_modules/query-string": {
       "version": "7.1.3",
@@ -878,11 +1465,96 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/request": {
+      "version": "2.85.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
+      "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
+      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.6.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.1",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.1",
+        "har-validator": "~5.0.3",
+        "hawk": "~6.0.2",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.17",
+        "oauth-sign": "~0.8.2",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.1",
+        "safe-buffer": "^5.1.1",
+        "stringstream": "~0.0.5",
+        "tough-cookie": "~2.3.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.1.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/request/node_modules/form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/sntp": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+      "deprecated": "This module moved to @hapi/sntp. Please make sure to switch over as this distribution is no longer supported and may contain bugs and critical security issues.",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "hoek": "4.x.x"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
     },
     "node_modules/split-on-first": {
       "version": "1.1.0",
@@ -893,6 +1565,32 @@
         "node": ">=6"
       }
     },
+    "node_modules/sshpk": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
+      "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/strict-uri-encode": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
@@ -901,6 +1599,13 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/stringstream": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
+      "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/strnum": {
       "version": "2.1.1",
@@ -914,11 +1619,50 @@
       ],
       "license": "MIT"
     },
+    "node_modules/suffix-thumb": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/suffix-thumb/-/suffix-thumb-5.0.2.tgz",
+      "integrity": "sha512-I5PWXAFKx3FYnI9a+dQMWNqTxoRt6vdBdb0O+BJ1sxXCWtSoQCusc13E58f+9p4MYx/qCnEMkD5jac6K2j3dgA==",
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "punycode": "^1.4.1"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+      "license": "Unlicense",
+      "optional": true
     },
     "node_modules/type": {
       "version": "2.7.3",
@@ -955,6 +1699,32 @@
       },
       "engines": {
         "node": ">=6.14.2"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
+    "node_modules/verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
       }
     },
     "node_modules/web-streams-polyfill": {
@@ -1019,6 +1789,30 @@
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
       }
+    },
+    "node_modules/which": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
+      "integrity": "sha512-E87fdQ/eRJr9W1X4wTPejNy9zTW3FI2vpCZSJ/HAY+TkjKVC0TUm1jk6vn2Z7qay0DQy0+RBGdXxj+RmmiGZKQ==",
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/winreg": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/winreg/-/winreg-1.2.5.tgz",
+      "integrity": "sha512-uf7tHf+tw0B1y+x+mKTLHkykBgK2KMs3g+KlzmyMbLvICSHQyB/xOFjTT8qZ3oeTFyU7Bbj4FzXitGG6jvKhYw==",
+      "license": "BSD-2-Clause",
+      "optional": true
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/yaeti": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,11 @@
   "dependencies": {
     "@polygon.io/client-js": "^8.2.0",
     "cheerio": "^1.0.0",
+    "compromise": "^14.14.2",
     "fast-xml-parser": "^5.2.5",
     "node-fetch": "^3.3.2"
+  },
+  "optionalDependencies": {
+    "open-korean-text-node": "^2.2.0"
   }
 }

--- a/src/news/fetchByTicker.js
+++ b/src/news/fetchByTicker.js
@@ -3,6 +3,7 @@ import fsp from 'fs/promises';
 import path from 'path';
 import { restClient } from '@polygon.io/client-js';
 import { fileURLToPath } from 'url';
+import { createRequire } from 'module';
 import { fetchKotraRecent } from "./kotraOverseas.js";
 import { getCompanyNameByYahooSymbol } from "../data/krxDirectory.js";
 import { tokenBucket, circuitBreaker } from "./helpers/rate.js";
@@ -520,12 +521,34 @@ export async function buildMarketKeywordSnapshot({ outputPath = KEYWORD_OUTPUT_F
 }
 
 // --- Ticker-level keyword builder (domain-aware tokenizer) ---
+const require = createRequire(import.meta.url);
+
+let okt = null;
+try {
+  const mod = require('open-korean-text-node');
+  okt = (mod && mod.default) ? mod.default : mod;
+} catch (e) {
+  okt = null;
+}
+
+let nlp = null;
+try {
+  const mod = require('compromise');
+  nlp = (mod && mod.default) ? mod.default : mod;
+} catch (e) {
+  nlp = null;
+}
+
 const DOMAIN_LEXICON = new Set([
   '2차전지','전고체 배터리','배터리','조선해양','조선','해운','반도체','HBM','AI','클라우드','로봇',
   '방산','원자력','SMR','바이오','제약','철강','자동차','전장','디스플레이','석유화학','정유',
   '부동산','리츠','건설','물류','원자재','구리','금','환율','달러','유가','수출','수입','무역수지',
   '금리','기준금리','연준','연방준비제도','소비','고용','실업','임금','경기','경기침체','연착륙',
-  '소프트랜딩','테슬라','엔비디아','삼성전자','하이닉스','현대차','LG에너지솔루션'
+  '소프트랜딩','테슬라','엔비디아','삼성전자','하이닉스','현대차','LG에너지솔루션','LNG',
+  'semiconductor','semiconductors','battery','batteries','chip','chips','ai','cloud','robotics','defense',
+  'nuclear','smr','lng','biotech','pharma','pharmaceuticals','steel','automotive','mobility','display','petrochemical',
+  'oil','energy','gas','refining','logistics','export','exports','import','imports','currency','forex','fx',
+  'inflation','recession','growth','earnings','guidance','orders','backlog','naver','kakao'
 ]);
 
 const CANONICAL_MAP = new Map([
@@ -535,32 +558,31 @@ const CANONICAL_MAP = new Map([
   ['전고체배터리','전고체 배터리'],
   ['배터리','2차전지'],
   ['조선','조선해양'],
+  ['조선 해양','조선해양'],
   ['해양','조선해양'],
   ['조선업','조선해양'],
   ['해운','조선해양'],
-  ['HBM3','HBM'], ['HBM3e','HBM'], ['HBM2e','HBM'],
+  ['HBM3','HBM'], ['HBM3e','HBM'], ['HBM3E','HBM'], ['HBM2e','HBM'],
   ['메모리','반도체'], ['파운드리','반도체'], ['칩','반도체'],
   ['연방준비제도','연준'],
   ['soft landing','연착륙'], ['소프트랜딩','연착륙'],
   ['전기차','자동차'],
   ['전장화','전장'],
+  ['semiconductors','semiconductor'],
+  ['batteries','battery'],
+  ['chips','chip'],
+  ['markets','market'],
+  ['exports','export'],
+  ['imports','import'],
+  ['interest rates','rates'],
+  ['electric vehicles','electric vehicle'],
+  ['electric vehicle','자동차'],
 ]);
 
-const STOP_KO = new Set(['은','는','이','가','을','를','에','에서','으로','와','과','및','또한','등','대한','관련','부분','대해','통한','지난','올해','이번','최근']);
-const STOP_EN = new Set(['the','a','an','and','or','for','to','of','in','on','with','by','as','from','at','this','that','these','those','is','are','was','were']);
-const BLACKLIST_KO = new Set([
-  '최소','최대','전문','속보','종합','단독','사진','영상','라디오','프로그램',
-  '오늘','어제','내일','현재','최근','지난','이번','올해','관련','대해','부분','경우',
-  '발언','인터뷰','코멘트','분석','전망','영향','상승','하락','변동','폭','수준',
-  '연합뉴스','YTN','KBS','SBS','MBN','JTBC','머니투데이','한국경제','매일경제','서울경제'
-]);
-
-const ECON_SUFFIXES = [
-  '산업','업','업체','기업','시장','수요','공급','가격','지수','수출','수입','무역수지',
-  '금리','환율','물가','채권','유가','원자재','설비','수주','발주','실적','가이던스',
-  '배터리','전지','조선','해양','반도체','자동차','전장','디스플레이','철강','정유','석유화학',
-  '방산','바이오','제약','로봇','원자력','SMR','LNG','데이터센터'
-];
+const BLACKLIST = new Set(['최소','최대','속보','종합','오늘','어제','내일','최근','전문','사진','영상']);
+const ECON_SUFFIXES = ['산업','업','시장','수출','수입','무역수지','금리','환율','물가','지수','채권','유가','원자재',
+  '실적','가이던스','수주','발주','배터리','전지','조선','해양','반도체','자동차','전장','디스플레이','철강','정유','석유화학','방산','바이오','제약','로봇','원자력','SMR','LNG',
+  'market','markets','exports','imports','earnings','revenue','revenues','guidance','sales','demand','supply','inflation','rates','rate','yields','yield','forex','currency','currencies','sector','sectors','industry','industries','index','indices','production','manufacturing','chip','chips','battery','batteries','semiconductor','semiconductors','automotive'];
 
 const MACRO_WHITELIST = new Set([
   'CPI','PPI','PCE','FOMC','GDP','NFP','PMI','ISM','QT','QE',
@@ -568,55 +590,99 @@ const MACRO_WHITELIST = new Set([
   '2차전지','조선해양','반도체','HBM','AI','LNG'
 ]);
 
-function looksEconomic(term) {
-  if (DOMAIN_LEXICON.has(term) || MACRO_WHITELIST.has(term)) return true;
+const KEYWORD_WHITELIST = new Set([...DOMAIN_LEXICON, ...MACRO_WHITELIST]);
 
-  for (const suf of ECON_SUFFIXES) {
-    if (term.endsWith(suf)) return true;
+const isHangulTerm = (str) => /[\u3131-\u318E\uAC00-\uD7A3]/.test(str || '');
+
+function isWhitelisted(term, lexicon = KEYWORD_WHITELIST) {
+  const t = String(term || '').trim();
+  if (!t) return false;
+  const collapsed = t.replace(/\s+/g, '');
+  const lower = t.toLowerCase();
+  const lowerCollapsed = collapsed.toLowerCase();
+  return (
+    lexicon.has(t) ||
+    lexicon.has(collapsed) ||
+    lexicon.has(lower) ||
+    lexicon.has(lowerCollapsed)
+  );
+}
+
+function canon(term) {
+  const t = term.trim();
+  if (CANONICAL_MAP.has(t)) return CANONICAL_MAP.get(t);
+  const collapsed = t.replace(/\s+/g, '');
+  if (CANONICAL_MAP.has(collapsed)) return CANONICAL_MAP.get(collapsed);
+  return t;
+}
+
+function looksContenty(token) {
+  const raw = String(token || '').trim();
+  if (!raw) return false;
+  if (BLACKLIST.has(raw)) return false;
+  const collapsed = raw.replace(/\s+/g, '');
+  if (!/^[\u3131-\u318E\uAC00-\uD7A3A-Za-z0-9-]+$/.test(collapsed)) return false;
+  if (/^\d+([.,]\d+)?%?$/.test(collapsed)) return false;
+  if (/^\d+(분기|월|일|년)$/.test(collapsed)) return false;
+  if (/^\d+$/.test(collapsed)) return false;
+
+  if (isWhitelisted(raw)) {
+    return true;
   }
 
-  if (/^[A-Z]{3,6}$/.test(term)) return true;
+  if (/^[A-Z]{3,6}$/.test(collapsed)) return true;
 
-  if (/^\d+([.,]\d+)?%?$/.test(term)) return false;
-  if (/^\d+(분기|월|일|년)$/.test(term)) return false;
+  if (isHangulTerm(raw)) {
+    if (collapsed.length < 2) return false;
+    return ECON_SUFFIXES.some(suf => raw.endsWith(suf));
+  }
+
+  if (collapsed.length < 3) return false;
+
+  const lower = collapsed.toLowerCase();
+  if (ECON_SUFFIXES.some(suf => lower.endsWith(suf.toLowerCase()))) return true;
 
   return false;
 }
 
-const isHangul = (s) => /^[\u1100-\u11FF\u3130-\u318F\uAC00-\uD7A3]+$/.test(s);
-const isAlphaNum = (s) => /^[a-z0-9\-]+$/.test(s);
-const normalizeTokenText = (text = '') =>
-  text
-    .replace(/[\u200B-\u200D\uFEFF]/g, '')
-    .replace(/[“”‘’"”“]/g, ' ')
-    .replace(/[(){}\[\],.:;!?/\\]+/g, ' ')
-    .replace(/\s+/g, ' ')
-    .trim();
-
-function tokenizeKR(text) {
-  const toks = normalizeTokenText(text).split(' ');
-  return toks.filter(t => {
-    if (!t) return false;
-    if (STOP_KO.has(t)) return false;
-    if (t.length <= 2 && !DOMAIN_LEXICON.has(t) && !MACRO_WHITELIST.has(t)) return false;
-    if (/[한]$/.test(t) || /(적|적인)$/.test(t)) return false;
-    if (isHangul(t)) return true;
-    if (DOMAIN_LEXICON.has(t) || MACRO_WHITELIST.has(t)) return true;
-    return false;
-  });
+function koNouns(text) {
+  if (!text) return [];
+  const str = String(text);
+  if (okt && typeof okt.normalizeSync === 'function' && typeof okt.posSync === 'function') {
+    try {
+      const norm = okt.normalizeSync(str);
+      const pos = okt.posSync(norm);
+      return pos
+        .filter(([w, tag]) => tag === 'Noun')
+        .map(([w]) => w.trim())
+        .filter(w => looksContenty(w) || isWhitelisted(w));
+    } catch {}
+  }
+  return (str.match(/[\uAC00-\uD7A3]{2,}/g) || [])
+    .map(w => w.trim())
+    .filter(w => looksContenty(w) || isWhitelisted(w));
 }
 
-function tokenizeEN(text) {
-  const toks = normalizeTokenText(text.toLowerCase()).split(' ');
-  return toks.filter(t => {
-    if (!t) return false;
-    if (STOP_EN.has(t)) return false;
-    if (isAlphaNum(t)) return t.length > 2;
-    return false;
-  });
+function enNouns(text) {
+  if (!text) return [];
+  const str = String(text);
+  if (nlp) {
+    try {
+      const doc = nlp(str);
+      return [
+        ...doc.nouns().out('array'),
+        ...doc.match('#Acronym').out('array'),
+      ]
+        .map(t => t.trim())
+        .filter(t => looksContenty(t) || isWhitelisted(t));
+    } catch {}
+  }
+  return (str.match(/[A-Za-z][A-Za-z0-9\-]{2,}/g) || [])
+    .map(t => t.trim())
+    .filter(t => looksContenty(t) || isWhitelisted(t));
 }
 
-function ngrams(tokens, n) {
+function ngrams(tokens, n = 2) {
   const out = [];
   for (let i = 0; i <= tokens.length - n; i++) {
     out.push(tokens.slice(i, i + n).join(' '));
@@ -624,111 +690,125 @@ function ngrams(tokens, n) {
   return out;
 }
 
-function candidatePhrases({ title, summary, body }) {
-  const textKR = [title, summary, body].filter(Boolean).join(' ');
-  const textEN = textKR;
-
-  const ko = tokenizeKR(textKR);
-  const en = tokenizeEN(textEN);
-
-  const singles = [...ko, ...en];
-  const bigrams = [...ngrams(ko, 2), ...ngrams(en, 2)];
-  const trigrams = [...ngrams(ko, 3), ...ngrams(en, 3)];
-
-  const all = [...singles, ...bigrams, ...trigrams]
-    .map(s => s.trim())
-    .filter(s => s && s.length >= 2);
-
-  return all;
+function addCollocations(docs, addTerm) {
+  docs.forEach(({ text, url }) => {
+    const ko = koNouns(text);
+    const en = enNouns(text);
+    const grams = [...ngrams(ko, 2), ...ngrams(en, 2)];
+    grams.forEach(g => {
+      const collapsed = g.replace(/\s+/g, '');
+      if (looksContenty(collapsed) || isWhitelisted(g) || isWhitelisted(collapsed)) {
+        addTerm(g, url);
+      }
+    });
+  });
 }
 
-export function canonicalize(term) {
-  const t = term.trim();
-  if (CANONICAL_MAP.has(t)) return CANONICAL_MAP.get(t);
-  if (t === '조선 해양') return '조선해양';
-  return t;
-}
-
-export function buildKeywordScores(articles) {
-  const docs = articles.map(a => ({
-    text: candidatePhrases(a),
-    titleText: new Set(candidatePhrases({ title: a.title || '', summary: '', body: '' })),
-    url: a.url
-  }));
-
-  const df = new Map();
+function scoreTerms(docs, domainLexicon = new Set()) {
   const tf = [];
-  for (const d of docs) {
+  const df = new Map();
+
+  docs.forEach((doc, idx) => {
+    const tokens = [...koNouns(doc.text), ...enNouns(doc.text)];
+    const titleTokens = new Set([...koNouns(doc.title || ''), ...enNouns(doc.title || '')]);
     const tfMap = new Map();
-    for (const raw of d.text) {
-      const term = canonicalize(raw);
-      tfMap.set(term, (tfMap.get(term) || 0) + 1);
-    }
-    tf.push(tfMap);
-    const uniqueTerms = new Set([...tfMap.keys()]);
-    for (const term of uniqueTerms) {
-      df.set(term, (df.get(term) || 0) + 1);
-    }
-  }
+
+    tokens.forEach(t => {
+      const key = t.trim();
+      if (!key) return;
+      tfMap.set(key, (tfMap.get(key) || 0) + 1);
+    });
+
+    tf.push({ tfMap, titleTokens, url: doc.url || `doc_${idx}`, text: doc.text });
+    const unique = new Set(tfMap.keys());
+    unique.forEach(term => df.set(term, (df.get(term) || 0) + 1));
+  });
 
   const N = docs.length || 1;
   const scores = new Map();
-  tf.forEach((tfMap, i) => {
-    const d = docs[i];
+
+  tf.forEach(({ tfMap, titleTokens, url }) => {
     for (const [term, freq] of tfMap.entries()) {
       const idf = Math.log((N + 1) / ((df.get(term) || 0) + 1)) + 1;
       let s = freq * idf;
-
-      if (DOMAIN_LEXICON.has(term)) s *= 1.6;
-      if (d.titleText.has(term)) s *= 1.4;
+      if (titleTokens.has(term)) s *= 1.4;
+      if (isWhitelisted(term, domainLexicon)) s *= 1.6;
 
       const cur = scores.get(term) || { score: 0, sources: new Set() };
       cur.score += s;
-      cur.sources.add(docs[i].url || `doc_${i}`);
+      cur.sources.add(url);
       scores.set(term, cur);
     }
   });
 
-  for (const [term, obj] of scores.entries()) {
-    const multi = Math.min(obj.sources.size, 5);
-    obj.score *= (1 + (multi - 1) * 0.2);
+  addCollocations(tf.map(({ text, url }, i) => ({ text, url: url || `doc_${i}` })), (term, url) => {
+    const clean = term.trim();
+    if (!clean) return;
+    const cur = scores.get(clean) || { score: 0, sources: new Set() };
+    cur.score += 0.5;
+    if (url) cur.sources.add(url);
+    scores.set(clean, cur);
+  });
+
+  for (const [, info] of scores.entries()) {
+    const src = Math.min(info.sources.size, 5);
+    info.score *= 1 + (src - 1) * 0.2;
   }
 
   return scores;
 }
 
-export function filterAndRank(scores) {
-  const MIN_LEN = 2;
+function pickKeywords(scores, domainLexicon) {
   const MIN_SCORE = 1.6;
   const MIN_SOURCES = 2;
-  const out = [];
+  const arr = [];
 
   for (const [term, { score, sources }] of scores.entries()) {
-    const srcCount = sources.size || sources.length || 0;
+    const canonicalTerm = canon(term);
+    const collapsed = canonicalTerm.replace(/\s+/g, '');
+    if (!looksContenty(collapsed) && !domainLexicon.has(canonicalTerm) && !domainLexicon.has(collapsed)) continue;
 
-    if (!term || term.length < MIN_LEN) continue;
-    if (BLACKLIST_KO.has(term)) continue;
-    if (/^\d+$/.test(term)) continue;
-    if (STOP_KO.has(term) || STOP_EN.has(term)) continue;
+    const srcCount = sources.size;
+    const whitelisted = isWhitelisted(canonicalTerm, domainLexicon) || isWhitelisted(collapsed, domainLexicon);
 
-    if (!looksEconomic(term)) continue;
-
-    if (srcCount < MIN_SOURCES && !DOMAIN_LEXICON.has(term)) continue;
-
-    const keep = score >= MIN_SCORE || DOMAIN_LEXICON.has(term);
-    if (!keep) continue;
-
-    out.push({ term, score: Number(score.toFixed(3)), sources: [...sources].slice(0, 5) });
+    if ((srcCount >= MIN_SOURCES && score >= MIN_SCORE) || whitelisted) {
+      arr.push({ term: canonicalTerm, score: Number(score.toFixed(3)), sources: [...sources].slice(0, 5) });
+    }
   }
 
-  const seen = new Map();
-  for (const k of out) {
-    const t = canonicalize(k.term);
-    const prev = seen.get(t);
-    if (!prev || k.score > prev.score) seen.set(t, { ...k, term: t });
+  const deduped = new Map();
+  for (const item of arr) {
+    const key = item.term;
+    const prev = deduped.get(key);
+    if (!prev || item.score > prev.score) {
+      deduped.set(key, item);
+    }
   }
 
-  return [...seen.values()].sort((a, b) => b.score - a.score).slice(0, 10);
+  return [...deduped.values()].sort((a, b) => b.score - a.score).slice(0, 20);
+}
+
+function extractKeywords(articles, domainLexicon) {
+  const docs = articles.map(a => ({
+    title: a.title || '',
+    url: a.url || '',
+    text: [a.title, a.summary, a.body].filter(Boolean).join(' ')
+  }));
+
+  const scores = scoreTerms(docs, domainLexicon);
+
+  for (const [term, value] of [...scores.entries()]) {
+    const c = canon(term);
+    if (c !== term) {
+      const cur = scores.get(c) || { score: 0, sources: new Set() };
+      cur.score += value.score;
+      value.sources.forEach(src => cur.sources.add(src));
+      scores.set(c, cur);
+      scores.delete(term);
+    }
+  }
+
+  return pickKeywords(scores, domainLexicon);
 }
 
 export function buildNewsKeywords(articlesByTicker) {
@@ -740,8 +820,7 @@ export function buildNewsKeywords(articlesByTicker) {
 
   for (const [ticker, articles] of Object.entries(articlesByTicker || {})) {
     if (!Array.isArray(articles) || !articles.length) continue;
-    const scores = buildKeywordScores(articles);
-    const keywords = filterAndRank(scores).slice(0, 10);
+    const keywords = extractKeywords(articles, KEYWORD_WHITELIST).slice(0, 10);
     if (keywords.length) {
       output.tickers[ticker] = { keywords };
     }
@@ -2103,18 +2182,19 @@ export async function buildNewsCachesCli() {
   if (tickerCount) {
     await fsp.mkdir(path.dirname(NEWS_KEYWORDS_FILE), { recursive: true }).catch(()=>{});
     const existing = readJsonSafe(NEWS_KEYWORDS_FILE) || {};
-    const merged = { ...existing };
-    if (!Array.isArray(merged.keywords)) merged.keywords = Array.isArray(existing?.keywords) ? existing.keywords : [];
-    if (merged.updatedAt == null && existing?.updatedAt == null) merged.updatedAt = existing?.updatedAt || {};
-    if (!Array.isArray(merged.markets) && Array.isArray(existing?.markets)) {
-      merged.markets = existing.markets;
-    }
-    merged.tickerKeywords = keywordPayload.tickers;
-    merged.tickerKeywordsMeta = {
-      generatedAt: keywordPayload.generated_at,
-      version: keywordPayload.version,
+    const fresh = {
+      generatedAt: existing?.generatedAt || keywordPayload.generated_at,
+      timezone: existing?.timezone || 'Asia/Seoul',
+      updatedAt: existing?.updatedAt || {},
+      keywords: Array.isArray(existing?.keywords) ? existing.keywords : [],
+      markets: Array.isArray(existing?.markets) ? existing.markets : KEYWORD_MARKET_QUERIES.map(m => m.market),
+      tickerKeywords: keywordPayload.tickers,
+      tickerKeywordsMeta: {
+        generatedAt: keywordPayload.generated_at,
+        version: keywordPayload.version,
+      }
     };
-    await fsp.writeFile(NEWS_KEYWORDS_FILE, JSON.stringify(merged, null, 2));
+    await fsp.writeFile(NEWS_KEYWORDS_FILE, JSON.stringify(fresh, null, 2));
     console.log(`[news-caches] updated ${NEWS_KEYWORDS_FILE} with ${tickerCount} ticker keyword sets`);
   } else {
     console.log('[news-caches] no ticker keywords derived from collected articles');


### PR DESCRIPTION
## Summary
- incorporate open-korean-text (with graceful fallback) and compromise-based noun extraction to build bilingual TF-IDF scores with collocation boosts
- expand the economic domain lexicon, canonical mappings, and keyword filtering to favor content-rich multi-source terms for ticker news keywords
- refresh newsKeywords.json during cache builds and register the new tokenizer dependencies (open-korean-text-node optional, compromise required)

## Testing
- node tests/apple_association.test.js

------
https://chatgpt.com/codex/tasks/task_b_68db3eebe680832abafdb60dd068b8ef