### PR TITLE
Add translation support to news keyword snapshot generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@polygon.io/client-js": "^8.2.0",
+        "@vitalets/google-translate-api": "^9.2.0",
         "cheerio": "^1.0.0",
         "compromise": "^14.14.2",
         "fast-xml-parser": "^5.2.5",
@@ -39,6 +40,46 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-1.8.2.tgz",
+      "integrity": "sha512-EqX+YQxINb+MeXaIqYDASb6U6FCHbWjkj4a1CKDBks3d/QiB2+PqBLyO72vLDgAO1wUI4O+9gweRcQK11bTL/w==",
+      "license": "MIT"
+    },
+    "node_modules/@vitalets/google-translate-api": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@vitalets/google-translate-api/-/google-translate-api-9.2.1.tgz",
+      "integrity": "sha512-zlwQWSjXUZhbZQ6qwtIQ7GdYXFQmJ4wYqzcrYJUxtvzQQwUP+uKUb/SRJaBOQuBntjBjzcdcJoLFrpCKUbIkOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "^1.8.2",
+        "http-errors": "^2.0.0",
+        "node-fetch": "^2.6.7"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@vitalets/google-translate-api/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/ajv": {
@@ -437,6 +478,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/dom-serializer": {
@@ -1055,6 +1105,22 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -1099,8 +1165,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/is-typedarray": {
       "version": "1.0.0",
@@ -1551,6 +1616,12 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
     "node_modules/sntp": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
@@ -1600,6 +1671,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/strict-uri-encode": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
@@ -1633,6 +1713,15 @@
       "resolved": "https://registry.npmjs.org/suffix-thumb/-/suffix-thumb-5.0.2.tgz",
       "integrity": "sha512-I5PWXAFKx3FYnI9a+dQMWNqTxoRt6vdBdb0O+BJ1sxXCWtSoQCusc13E58f+9p4MYx/qCnEMkD5jac6K2j3dgA==",
       "license": "MIT"
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
     },
     "node_modules/tough-cookie": {
       "version": "2.3.4",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@polygon.io/client-js": "^8.2.0",
+    "@vitalets/google-translate-api": "^9.2.0",
     "cheerio": "^1.0.0",
     "compromise": "^14.14.2",
     "fast-xml-parser": "^5.2.5",

--- a/src/news/fetchByTicker.js
+++ b/src/news/fetchByTicker.js
@@ -42,6 +42,8 @@ const NAVER_REP_BONUS = Number(process.env.NAVER_REP_BONUS || 1.1);
 const NAVER_KO_WEIGHT = Number(process.env.NAVER_KO_WEIGHT || 1.3);
 const NAVER_EN_WEIGHT = Number(process.env.NAVER_EN_WEIGHT || 1.0);
 
+const HANGUL_REGEX = /[\u3131-\u318E\uAC00-\uD7A3]/;
+
 const POS_KR = /(호조|개선|확대|수주|계약|제휴|승인|허가|인증|증설|증대|흑자전환|사상 최대|서프라이즈|상향)/i;
 const NEG_KR = /(부진|감소|하락|급락|적자|적자전환|소송|제재|벌금|과징금|리콜|해킹|유출|파업|중단|연기|취소|하향|정지)/i;
 
@@ -862,6 +864,63 @@ function translateTagToKo(tag) {
   return text;
 }
 
+const TRANSLATION_CACHE = new Map();
+let translationModulePromise = null;
+
+function hasHangulText(value) {
+  return HANGUL_REGEX.test(String(value || ''));
+}
+
+async function ensureTranslationModule() {
+  if (!translationModulePromise) {
+    translationModulePromise = import('@vitalets/google-translate-api')
+      .then(mod => mod?.default ?? mod)
+      .catch(err => {
+        console.warn('[keywords] failed to load translation module:', err?.message || err);
+        return null;
+      });
+  }
+  return translationModulePromise;
+}
+
+async function getLocalizedKeywordTexts(enText) {
+  const en = String(enText || '').trim();
+  if (!en) return { en: '', ko: '' };
+
+  const dictionaryKo = translateTagToKo(en);
+  if (dictionaryKo && hasHangulText(dictionaryKo)) {
+    const finalKo = dictionaryKo.trim();
+    TRANSLATION_CACHE.set(en.toLowerCase(), finalKo);
+    return { en, ko: finalKo };
+  }
+
+  const cacheKey = en.toLowerCase();
+  if (TRANSLATION_CACHE.has(cacheKey)) {
+    return { en, ko: TRANSLATION_CACHE.get(cacheKey) };
+  }
+
+  let ko = dictionaryKo && dictionaryKo.trim() ? dictionaryKo.trim() : '';
+  const translator = await ensureTranslationModule();
+  if (translator) {
+    try {
+      const result = await translator(en, { from: 'en', to: 'ko' });
+      const translated = String(result?.text || '').trim();
+      if (translated) {
+        ko = translated;
+      }
+    } catch (err) {
+      console.warn(`[keywords] failed to translate "${en}":`, err?.message || err);
+    }
+  }
+
+  if (!ko) {
+    ko = en;
+  }
+
+  TRANSLATION_CACHE.set(cacheKey, ko);
+  return { en, ko };
+}
+
 function chooseTagDisplay(entry) {
   if (!entry) return '';
   const forms = Array.from(entry.forms || []);
@@ -1250,7 +1309,7 @@ function buildSearchUrlPair(enText, koText) {
   return urls;
 }
 
-function buildKeywordsFromTagStats(tagStats, { limit = 10 } = {}) {
+async function buildKeywordsFromTagStats(tagStats, { limit = 10 } = {}) {
   if (!tagStats || !tagStats.size) return [];
   const entries = [];
   for (const entry of tagStats.values()) {
@@ -1269,19 +1328,24 @@ function buildKeywordsFromTagStats(tagStats, { limit = 10 } = {}) {
 
   const maxCount = entries[0]?.count || 1;
 
-  return entries.slice(0, limit).map(item => {
+  const results = [];
+  for (const item of entries.slice(0, limit)) {
     const enText = formatTagDisplay(item.display);
-    const koText = translateTagToKo(enText) || enText;
-    return {
-      text: { ko: koText, en: enText },
+    if (!enText) continue;
+    const localized = await getLocalizedKeywordTexts(enText);
+    const koText = localized.ko || enText;
+    results.push({
+      text: { ko: koText, en: localized.en || enText },
       markets: item.markets,
       sources: item.sources,
       mentions: item.count,
       score: Number((item.count / maxCount).toFixed(3)),
       sampleHeadlines: item.headlines,
-      searchUrl: buildSearchUrlPair(enText, koText)
-    };
-  }).filter(entry => entry.text.en);
+      searchUrl: buildSearchUrlPair(localized.en || enText, koText)
+    });
+  }
+
+  return results.filter(entry => entry.text.en);
 }
 
 function mergeKeywordLists(primary = [], secondary = [], limit = 10) {
@@ -1299,7 +1363,7 @@ function mergeKeywordLists(primary = [], secondary = [], limit = 10) {
   return out.slice(0, limit);
 }
 
-function buildNewsKeywordsFromTagSnapshot(snapshot, tagStats, { limit = 10 } = {}) {
+async function buildNewsKeywordsFromTagSnapshot(snapshot, tagStats, { limit = 10 } = {}) {
   if (!snapshot) return [];
   const discovered = Array.isArray(snapshot?.discovered_keywords) ? snapshot.discovered_keywords : [];
   if (!discovered.length) return [];
@@ -1331,13 +1395,14 @@ function buildNewsKeywordsFromTagSnapshot(snapshot, tagStats, { limit = 10 } = {
     const mentions = mentionsFromSnapshot || Number(statEntry?.count || 0);
     const scoreBase = item?.score != null ? Number(item.score) : (maxCount > 0 ? mentions / maxCount : 0);
     const normalizedScore = Number(to01(scoreBase).toFixed(3));
-    const koText = translateTagToKo(enText) || enText;
+    const localized = await getLocalizedKeywordTexts(enText);
+    const koText = localized.ko || enText;
     const markets = statEntry ? Array.from(statEntry.markets || []) : [];
     const sources = statEntry ? Array.from(statEntry.sources || []) : [];
     const sampleHeadlines = statEntry ? statEntry.headlines.slice(0, 3) : [];
-    const searchUrl = buildSearchUrlPair(enText, koText);
+    const searchUrl = buildSearchUrlPair(localized.en || enText, koText);
     out.push({
-      text: { ko: koText, en: enText },
+      text: { ko: koText, en: localized.en || enText },
       markets,
       sources,
       mentions,
@@ -1366,13 +1431,27 @@ export async function buildMarketKeywordSnapshot({ outputPath = KEYWORD_OUTPUT_F
     asOfDate
   });
 
-  let keywords = buildNewsKeywordsFromTagSnapshot(tagSnapshot, tagStats, { limit: 10 });
+  let keywords = await buildNewsKeywordsFromTagSnapshot(tagSnapshot, tagStats, { limit: 10 });
   if (!keywords.length) {
-    keywords = buildKeywordsFromTagStats(tagStats, { limit: 10 });
+    keywords = await buildKeywordsFromTagStats(tagStats, { limit: 10 });
   }
   if (!keywords.length && Array.isArray(existingSnapshot?.keywords) && existingSnapshot.keywords.length) {
     console.warn('[keywords] falling back to previous keyword snapshot');
-    keywords = existingSnapshot.keywords;
+    const localizedFallback = [];
+    for (const entry of existingSnapshot.keywords) {
+      if (!entry || typeof entry !== 'object') continue;
+      const enSource = entry?.text?.en || entry?.text?.ko || entry?.text || '';
+      const enText = formatTagDisplay(enSource);
+      if (!enText) continue;
+      const localized = await getLocalizedKeywordTexts(enText);
+      const koText = localized.ko || enText;
+      localizedFallback.push({
+        ...entry,
+        text: { ko: koText, en: localized.en || enText },
+        searchUrl: buildSearchUrlPair(localized.en || enText, koText)
+      });
+    }
+    keywords = localizedFallback;
   }
 
   const marketSet = new Set();


### PR DESCRIPTION
## Summary
- add Google Translate API dependency so market keyword snapshots can be localized
- translate English tag names into Korean when generating `newsKeywords.json`, including fallbacks
- keep search URLs aligned with each keyword’s language while reusing prior snapshots when necessary

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68dca69c7480832aa9a35aed236dae4c