### PR TITLE
Add DeepL translations for market keyword exports

### DIFF
--- a/.github/workflows/stock-recs.yml
+++ b/.github/workflows/stock-recs.yml
@@ -65,6 +65,7 @@ jobs:
       POLYGON_API_KEY: ${{ secrets.POLYGON_API_KEY }}
       NASDAQ_API_KEY: ${{ secrets.NASDAQ_API_KEY }}
       DEEPS_API_KEY: ${{ secrets.DEEPS_API_KEY }}
+      DEEP_API_KEY: ${{ secrets.DEEP_API_KEY }}
       COINDESK_API: ${{ secrets.COINDESK_API }}
       # Optional tuning for this module
       NEWS_CONCURRENCY: 2        # your code already defaults to 2; keep it small for SerpApi quotas

--- a/src/news/fetchByTicker.js
+++ b/src/news/fetchByTicker.js
@@ -34,6 +34,7 @@ const polygonRest = POLYGON_API_KEY ? restClient(POLYGON_API_KEY) : null;
 const DEEPS_API_KEY = process.env.DEEPS_API_KEY || '';
 const DEEPS_US_EXCHANGE = process.env.DEEPS_US_EXCHANGE || 'NASDAQ';
 const NEWSDATA_API_KEY = process.env.NEWSDATA_API_KEY || '';
+const DEEP_API_KEY = (process.env.DEEP_API_KEY || '').trim();
 
 const NAVER_WEIGHT = Number(process.env.NAVER_WEIGHT || 1.6);
 const OTHER_NEWS_WEIGHT = Number(process.env.OTHER_NEWS_WEIGHT || 1.0);
@@ -867,8 +868,49 @@ function translateTagToKo(tag) {
 const TRANSLATION_CACHE = new Map();
 let translationModulePromise = null;
 
+function setTranslationCache(en, ko) {
+  const enText = String(en || '').trim();
+  const koText = String(ko || '').trim();
+  if (!enText || !koText) return;
+  TRANSLATION_CACHE.set(enText.toLowerCase(), koText);
+}
+
 function hasHangulText(value) {
   return HANGUL_REGEX.test(String(value || ''));
+}
+
+async function translateWithDeepL(text, { targetLang = 'KO', sourceLang = 'EN' } = {}) {
+  if (!DEEP_API_KEY) return null;
+  const raw = String(text || '').trim();
+  if (!raw) return null;
+  try {
+    const res = await fetch('https://api.deepl.com/v2/translate', {
+      method: 'POST',
+      headers: {
+        'Authorization': `DeepL-Auth-Key ${DEEP_API_KEY}`,
+        'Content-Type': 'application/json',
+        'User-Agent': 'stock-recs/1.2 (+github-actions)'
+      },
+      body: JSON.stringify({
+        text: [raw],
+        target_lang: String(targetLang || 'KO').toUpperCase(),
+        source_lang: String(sourceLang || 'EN').toUpperCase()
+      })
+    });
+    if (!res.ok) {
+      const errText = await res.text().catch(() => res.statusText);
+      console.warn(`[keywords] DeepL translation failed (${res.status}):`, errText);
+      return null;
+    }
+    const data = await res.json().catch(() => null);
+    const translated = data?.translations?.[0]?.text;
+    if (translated) {
+      return String(translated).trim();
+    }
+  } catch (err) {
+    console.warn(`[keywords] DeepL request failed for "${raw}":`, err?.message || err);
+  }
+  return null;
 }
 
 async function ensureTranslationModule() {
@@ -890,7 +932,7 @@ async function getLocalizedKeywordTexts(enText) {
   const dictionaryKo = translateTagToKo(en);
   if (dictionaryKo && hasHangulText(dictionaryKo)) {
     const finalKo = dictionaryKo.trim();
-    TRANSLATION_CACHE.set(en.toLowerCase(), finalKo);
+    setTranslationCache(en, finalKo);
     return { en, ko: finalKo };
   }
 
@@ -900,16 +942,26 @@ async function getLocalizedKeywordTexts(enText) {
   }
 
   let ko = dictionaryKo && dictionaryKo.trim() ? dictionaryKo.trim() : '';
-  const translator = await ensureTranslationModule();
-  if (translator) {
-    try {
-      const result = await translator(en, { from: 'en', to: 'ko' });
-      const translated = String(result?.text || '').trim();
-      if (translated) {
-        ko = translated;
+
+  if (!ko) {
+    const deeplResult = await translateWithDeepL(en, { sourceLang: 'EN', targetLang: 'KO' });
+    if (deeplResult) {
+      ko = deeplResult;
+    }
+  }
+
+  if (!ko) {
+    const translator = await ensureTranslationModule();
+    if (translator) {
+      try {
+        const result = await translator(en, { from: 'en', to: 'ko' });
+        const translated = String(result?.text || '').trim();
+        if (translated) {
+          ko = translated;
+        }
+      } catch (err) {
+        console.warn(`[keywords] failed to translate "${en}":`, err?.message || err);
       }
-    } catch (err) {
-      console.warn(`[keywords] failed to translate "${en}":`, err?.message || err);
     }
   }
 
@@ -917,7 +969,7 @@ async function getLocalizedKeywordTexts(enText) {
     ko = en;
   }
 
-  TRANSLATION_CACHE.set(cacheKey, ko);
+  setTranslationCache(en, ko);
   return { en, ko };
 }
 
@@ -1243,6 +1295,29 @@ function normalizeDiscoveredKeywordList(entries = []) {
   });
 }
 
+function primeTranslationCacheFromSnapshot(snapshot) {
+  if (!snapshot || typeof snapshot !== 'object') return;
+  if (snapshot?.translations && typeof snapshot.translations === 'object') {
+    for (const [key, value] of Object.entries(snapshot.translations)) {
+      if (!value) continue;
+      const enText = String(value?.en || key || '').trim();
+      const koText = String(value?.ko || value || '').trim();
+      if (enText && koText) {
+        setTranslationCache(enText, koText);
+      }
+    }
+  }
+  if (Array.isArray(snapshot?.discovered_keywords)) {
+    for (const item of snapshot.discovered_keywords) {
+      const enText = String(item?.text?.en || item?.term || item?.text || '').trim();
+      const koText = String(item?.text?.ko || '').trim();
+      if (enText && koText) {
+        setTranslationCache(enText, koText);
+      }
+    }
+  }
+}
+
 function extractTagTermsFromSnapshot(snapshot) {
   if (!snapshot) return [];
   if (Array.isArray(snapshot?.tags)) {
@@ -1263,6 +1338,8 @@ async function writeTagsJsonFile(tags, stats = new Map(), {
   articleCount = 0,
   asOfDate = daysAgo(0)
 } = {}) {
+  primeTranslationCacheFromSnapshot(fallbackSnapshot);
+
   const normalizedTags = Array.isArray(tags) ? tags.map(formatTagDisplay).filter(Boolean) : [];
   let discovered = buildDiscoveredKeywordsFromStats(stats, { limit: Math.max(normalizedTags.length, 50) });
   let derivedArticleCount = Number(articleCount) || 0;
@@ -1285,11 +1362,26 @@ async function writeTagsJsonFile(tags, stats = new Map(), {
     return null;
   }
 
+  const translations = {};
+  const localizedDiscovered = [];
+  for (const item of discovered) {
+    const localized = await getLocalizedKeywordTexts(item.term);
+    const enText = localized.en || item.term;
+    const koText = localized.ko || enText;
+    translations[enText] = { en: enText, ko: koText };
+    localizedDiscovered.push({
+      ...item,
+      term: enText,
+      text: { en: enText, ko: koText }
+    });
+  }
+
   const payload = {
     date: asOfDate,
     window: `${TAG_COLLECTION_WINDOW_DAYS}_days`,
     total_articles: derivedArticleCount,
-    discovered_keywords: discovered
+    discovered_keywords: localizedDiscovered,
+    translations
   };
 
   ensureDirFor(TAG_OUTPUT_FILE);


### PR DESCRIPTION
## Summary
- expose the `DEEP_API_KEY` secret to the stock recommendation workflow
- translate collected market tags with DeepL and persist the localized text in `tags.json`
- reuse the stored translations when building localized news keywords and search links

## Testing
- node tests/apple_association.test.js

------
https://chatgpt.com/codex/tasks/task_b_68dd173a460c832a8194dcc16eb7720e