### PR TITLE
feat: add Korean-first keyword collection

### DIFF
--- a/src/news/fetchByTicker.js
+++ b/src/news/fetchByTicker.js
@@ -5,6 +5,7 @@ import { spawn } from 'child_process';
 import { restClient } from '@polygon.io/client-js';
 import { fileURLToPath } from 'url';
 import { createRequire } from 'module';
+import { parse } from 'node-html-parser';
 import { fetchKotraRecent } from "./kotraOverseas.js";
 import { getCompanyNameByYahooSymbol } from "../data/krxDirectory.js";
 import { tokenBucket, circuitBreaker } from "./helpers/rate.js";
@@ -123,7 +124,6 @@ const KEYWORD_MARKET_QUERIES = [
 ];
 
 const TAG_OUTPUT_FILE = process.env.MARKET_TAG_FILE || 'tags.json';
-const TAG_TARGET_COUNT = Number(process.env.MARKET_TAG_TARGET || 10_000);
 const TAG_COLLECTION_WINDOW_DAYS = Number(process.env.TAG_COLLECTION_LOOKBACK_DAYS || 14);
 const TAG_COLLECTION_PAGE_LIMIT = Number(process.env.TAG_COLLECTION_PAGE_LIMIT || 5);
 const TAG_COLLECTION_PAGE_SIZE = Number(process.env.TAG_COLLECTION_PAGE_SIZE || 40);
@@ -1724,227 +1724,320 @@ async function fetchNaverDatalabTrendingKeywords({ limit = 20 } = {}) {
     .slice(0, limit);
 }
 
-async function collectTagCorpus({ targetCount = TAG_TARGET_COUNT, fallbackSnapshot = null } = {}) {
-  const stats = new Map();
-  const collected = [];
-  const actualTarget = Math.min(targetCount, 100); // Cap at 100
+// ============= KOREAN-FIRST COLLECTION FUNCTIONS =============
 
-  console.log(`[keywords] collecting up to ${actualTarget} keywords from multiple sources`);
+const KO_DOMAIN_BOOST = new Set([
+  '반도체', 'AI', '인공지능', '2차전지', '배터리', '전기차', '조선', '해운',
+  '바이오', '제약', '방산', '원자력', 'SMR', '수소', '클라우드', '로봇',
+  '디스플레이', '철강', '자동차', '금리', '환율', '원달러', '연준', 'CPI',
+  '인플레이션', '경기침체', '수출', '무역', 'LNG', '에너지', '친환경',
+  '헬스케어', '메타버스', '블록체인', 'HBM', '파운드리', '메모리'
+]);
 
-  // ===== 1. Naver DataLab existing keywords (most reliable) =====
-  console.log('[keywords] fetching Naver DataLab for predefined keywords...');
-  const datalabEntries = await buildDatalabKeywordEntries();
-  for (const entry of datalabEntries) {
-    const koTerm = entry?.text?.ko || '';
-    const enTerm = entry?.text?.en || '';
-    if (!koTerm) continue;
+async function scrapeDaumRealtimeTrends() {
+  try {
+    const text = await fetchTextWithFallback([
+      { url: 'https://www.daum.net/', headers: { Accept: 'text/html' } }
+    ], { timeoutMs: 8000, label: 'Daum trends' });
 
-    const key = koTerm.toLowerCase();
-    const statEntry = stats.get(key) || {
-      key,
-      forms: new Set([koTerm]),
-      display: koTerm,
-      count: 0,
-      markets: new Set(entry.markets || []),
-      sources: new Set(['naver-datalab']),
-      headlines: [],
-      headlineKeys: new Set()
-    };
+    if (!text) return [];
 
-    const scoreBoost = Number(entry?.score || 0);
-    statEntry.count += scoreBoost * 100;
-    statEntry.forms.add(koTerm);
-    if (enTerm) statEntry.forms.add(enTerm);
-    if (Array.isArray(entry.markets)) {
-      for (const market of entry.markets) statEntry.markets.add(market);
-    }
-    if (Array.isArray(entry.sources)) {
-      for (const source of entry.sources) statEntry.sources.add(source);
-    }
-    statEntry.sources.add('naver-datalab');
-    if (!statEntry.display || koTerm.length > statEntry.display.length) {
-      statEntry.display = koTerm;
-    }
-    if (Array.isArray(entry.sampleHeadlines)) {
-      for (const headline of entry.sampleHeadlines) {
-        const title = headline?.title || '';
-        const url = headline?.url || '';
-        if (!title && !url) continue;
-        const keyStr = `${title}__${url}`;
-        if (!statEntry.headlineKeys.has(keyStr)) {
-          statEntry.headlineKeys.add(keyStr);
-          statEntry.headlines.push(headline);
+    const root = parse(text);
+    const keywords = [];
+    const selectors = ['.link_favorsch', '.link_txt', '.tit_g'];
+
+    for (const selector of selectors) {
+      const links = root.querySelectorAll(selector);
+      for (const link of links) {
+        const txt = link.text.trim().replace(/^\d+\.?\s*/, '');
+        if (txt && txt.length > 1 && containsHangul(txt) && !STOPWORDS_KO.has(txt)) {
+          keywords.push({
+            term_ko: txt,
+            source: 'daum',
+            score: 20 - keywords.length
+          });
         }
+        if (keywords.length >= 20) break;
       }
+      if (keywords.length >= 20) break;
     }
 
-    stats.set(key, statEntry);
+    console.log(`[Daum] collected ${keywords.length} keywords`);
+    return keywords;
+  } catch (err) {
+    console.warn('[Daum] scrape failed:', err.message);
+    return [];
   }
-  console.log(`[keywords] collected ${datalabEntries.length} from Naver DataLab (predefined)`);
+}
 
-  // ===== 2. Naver DataLab trending seeds =====
-  console.log('[keywords] fetching Naver DataLab trending seeds...');
-  const naverTrends = await fetchNaverDatalabTrendingKeywords({ limit: 30 });
-  for (const item of naverTrends) {
-    const key = item.term_ko.toLowerCase();
-    const entry = stats.get(key) || {
-      key,
-      forms: new Set([item.term_ko]),
-      display: item.term_ko,
-      count: 0,
-      markets: new Set(['KOSPI', 'KOSDAQ']),
-      sources: new Set(['naver-datalab']),
-      headlines: [],
-      headlineKeys: new Set()
-    };
-    entry.count += item.score;
-    entry.forms.add(item.term_ko);
-    entry.sources.add('naver-datalab');
-    entry.markets.add('KOSPI');
-    entry.markets.add('KOSDAQ');
-    if (!entry.display || item.term_ko.length > entry.display.length) {
-      entry.display = item.term_ko;
+async function scrapeNateIssueTrends() {
+  try {
+    const text = await fetchTextWithFallback([
+      { url: 'https://news.nate.com/', headers: { Accept: 'text/html' } }
+    ], { timeoutMs: 8000, label: 'Nate trends' });
+
+    if (!text) return [];
+
+    const root = parse(text);
+    const keywords = [];
+    const selectors = ['.mlt01 a', '.ranking a', '.issue a'];
+
+    for (const selector of selectors) {
+      const items = root.querySelectorAll(selector);
+      for (const item of items) {
+        const txt = item.text.trim().replace(/^\d+\.?\s*/, '');
+        if (txt && txt.length > 1 && containsHangul(txt) && !STOPWORDS_KO.has(txt)) {
+          keywords.push({
+            term_ko: txt,
+            source: 'nate',
+            score: 15 - keywords.length
+          });
+        }
+        if (keywords.length >= 15) break;
+      }
+      if (keywords.length >= 15) break;
     }
-    stats.set(key, entry);
+
+    console.log(`[Nate] collected ${keywords.length} keywords`);
+    return keywords;
+  } catch (err) {
+    console.warn('[Nate] scrape failed:', err.message);
+    return [];
   }
-  console.log(`[keywords] collected ${naverTrends.length} from Naver DataLab (trending)`);
+}
 
-  // ===== 3. Yahoo Finance (free, no API key) =====
-  console.log('[keywords] fetching Yahoo Finance topics...');
-  const yahooTopics = await fetchYahooFinanceTopics();
-  for (const topic of yahooTopics) {
-    const normalized = normalizeTagCandidate(topic);
-    if (!normalized) continue;
+async function extractNaverNewsKeywords() {
+  if (!NAVER_CLIENT_ID || !NAVER_CLIENT_SECRET || SKIP_NAVER) return [];
 
-    const key = normalized.toLowerCase();
-    const entry = stats.get(key) || {
-      key,
-      forms: new Set([normalized]),
-      display: normalized,
-      count: 0,
-      markets: new Set(['NASDAQ 100', 'S&P 500']),
-      sources: new Set(['yahoo-finance']),
-      headlines: [],
-      headlineKeys: new Set()
-    };
-    entry.count += 5; // Fixed weight
-    entry.forms.add(normalized);
-    entry.sources.add('yahoo-finance');
-    entry.markets.add('NASDAQ 100');
-    entry.markets.add('S&P 500');
-    if (!entry.display || normalized.length > entry.display.length) {
-      entry.display = normalized;
-    }
-    stats.set(key, entry);
-  }
-  console.log(`[keywords] collected ${yahooTopics.length} from Yahoo Finance`);
+  const queries = ['증시 동향', '경제 뉴스', '반도체 산업', '2차전지', '금리 전망'];
+  const keywordMap = new Map();
 
-  // ===== 4. Google News RSS (free, no API key) =====
-  console.log('[keywords] fetching Google News topics...');
-  const googleTopics = await fetchGoogleNewsTopics();
-  for (const topic of googleTopics) {
-    const normalized = normalizeTagCandidate(topic);
-    if (!normalized) continue;
+  for (const query of queries) {
+    try {
+      const res = await naverSearch({ query, NAVER_ID: NAVER_CLIENT_ID, NAVER_SECRET: NAVER_CLIENT_SECRET });
 
-    const key = normalized.toLowerCase();
-    const entry = stats.get(key) || {
-      key,
-      forms: new Set([normalized]),
-      display: normalized,
-      count: 0,
-      markets: new Set(['GLOBAL']),
-      sources: new Set(['google-news']),
-      headlines: [],
-      headlineKeys: new Set()
-    };
-    entry.count += 3; // Lower weight than Yahoo
-    entry.forms.add(normalized);
-    entry.sources.add('google-news');
-    entry.markets.add('GLOBAL');
-    if (!entry.display || normalized.length > entry.display.length) {
-      entry.display = normalized;
-    }
-    stats.set(key, entry);
-  }
-  console.log(`[keywords] collected ${googleTopics.length} from Google News RSS`);
+      for (const item of res?.items || []) {
+        const title = stripHtml(item.title);
+        const desc = stripHtml(item.description);
+        const text = `${title} ${desc}`;
 
-  // ===== 5. Optional: NewsData supplement (only if under quota) =====
-  if (NEWSDATA_API_KEY && stats.size < actualTarget) {
-    console.log('[keywords] supplementing with NewsData (limited queries)...');
-    const topQueries = ['AI', 'semiconductor', 'stock market']
-      .slice(0, 3); // Only 3 queries to stay under quota
+        const matches = text.match(/[가-힣]{2,4}/g) || [];
 
-    for (const query of topQueries) {
-      if (stats.size >= actualTarget) break;
+        for (const match of matches) {
+          if (STOPWORDS_KO.has(match) || match.length < 2) continue;
 
-      try {
-        const articles = await newsdataArchiveFetch({
-          q: query,
-          languages: ['en'],
-          fromDate: daysAgo(7),
-          toDate: daysAgo(0),
-          size: 10,
-          pageLimit: 1
-        });
-
-        for (const article of articles) {
-          const tags = Array.isArray(article?.tags) ? article.tags : [];
-          for (const rawTag of tags) {
-            recordTagStat({
-              stats,
-              tag: rawTag,
-              article,
-              markets: ['GLOBAL'],
-              sourceLabel: 'newsdata',
-              collected: [],
-              targetCount: actualTarget
+          const key = match.toLowerCase();
+          const existing = keywordMap.get(key);
+          if (existing) {
+            existing.score += 1;
+          } else {
+            keywordMap.set(key, {
+              term_ko: match,
+              source: 'naver-news',
+              score: 1
             });
           }
         }
-      } catch (err) {
-        console.warn(`[keywords] NewsData query "${query}" failed:`, err.message);
-        break; // Stop on first failure to avoid rate limits
       }
+    } catch (err) {
+      console.warn(`[Naver News] query "${query}" failed:`, err.message);
     }
   }
 
-  // ===== 5. Build final list =====
-  const entries = [...stats.values()]
-    .sort((a, b) => (b.count - a.count) || chooseTagDisplay(a).localeCompare(chooseTagDisplay(b)));
+  const results = Array.from(keywordMap.values())
+    .filter(k => k.score >= 3)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 30);
 
-  for (const entry of entries) {
-    if (collected.length >= actualTarget) break;
-    collected.push(chooseTagDisplay(entry));
+  console.log(`[Naver News] extracted ${results.length} keywords from ${keywordMap.size} unique terms`);
+  return results;
+}
+
+async function aggregateKoreanKeywords(allKeywords) {
+  const aggregated = new Map();
+
+  for (const kw of allKeywords) {
+    const koTerm = String(kw.term_ko || kw.term || '').trim();
+    if (!koTerm || !containsHangul(koTerm)) continue;
+
+    const key = koTerm.toLowerCase();
+    const existing = aggregated.get(key);
+
+    if (existing) {
+      existing.count += 1;
+      existing.score += Number(kw.score || 1);
+      existing.sources.add(kw.source || 'unknown');
+    } else {
+      aggregated.set(key, {
+        term_ko: koTerm,
+        count: 1,
+        score: Number(kw.score || 1),
+        sources: new Set([kw.source || 'unknown'])
+      });
+    }
   }
 
-  console.log(`[keywords] final collection: ${collected.length} tags from ${stats.size} unique terms`);
+  let results = Array.from(aggregated.values()).map(item => {
+    const domainBoost = KO_DOMAIN_BOOST.has(item.term_ko) ? 1.5 : 1.0;
+    const diversityBonus = Math.min(item.sources.size, 3) * 0.2;
 
-  // Fallback if still empty
-  if (!collected.length && fallbackSnapshot) {
-    const fallbackTags = extractTagTermsFromSnapshot(fallbackSnapshot);
-    if (fallbackTags.length) {
-      console.warn('[keywords] using fallback snapshot');
-      return {
-        tags: fallbackTags.slice(0, actualTarget),
-        stats: rebuildTagStatsFromSnapshot(fallbackSnapshot),
-        fallbackUsed: true,
-        articleTexts: [],
-        articleCount: 0,
-        asOfDate: daysAgo(0)
+    return {
+      ...item,
+      sources: Array.from(item.sources),
+      originalScore: item.score,
+      score: item.score * domainBoost * (1 + diversityBonus)
+    };
+  });
+
+  results.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    if (b.count !== a.count) return b.count - a.count;
+    return a.term_ko.localeCompare(b.term_ko, 'ko');
+  });
+
+  return results.slice(0, 50);
+}
+
+async function translateKoreanKeywordToEnglish(koTerm) {
+  const dictResult = translateTagToKo(koTerm);
+  if (dictResult && dictResult !== koTerm) return dictResult;
+
+  const cached = TRANSLATION_CACHE.get(koTerm.toLowerCase());
+  if (cached && cached !== koTerm) return cached;
+
+  if (DEEPL_API_KEY) {
+    try {
+      const deepl = await translateWithDeepL(koTerm, { sourceLang: 'KO', targetLang: 'EN' });
+      if (deepl && deepl !== koTerm) {
+        setTranslationCache(deepl, koTerm);
+        return deepl;
+      }
+    } catch (err) {
+      console.warn(`[DeepL] translation failed for "${koTerm}":`, err.message);
+    }
+  }
+
+  if (NAVER_CLIENT_ID && NAVER_CLIENT_SECRET) {
+    try {
+      const papago = await translateWithNaverPapago(koTerm, { sourceLang: 'ko', targetLang: 'en' });
+      if (papago && papago !== koTerm) {
+        setTranslationCache(papago, koTerm);
+        return papago;
+      }
+    } catch (err) {
+      console.warn(`[Papago] translation failed for "${koTerm}":`, err.message);
+    }
+  }
+
+  return koTerm;
+}
+
+export async function collectKoreanFirstKeywords({ targetCount = 30 } = {}) {
+  console.log('[Korean-First] Starting keyword collection...');
+
+  const allKeywords = [];
+
+  const collectors = [
+    scrapeDaumRealtimeTrends(),
+    scrapeNateIssueTrends(),
+    extractNaverNewsKeywords(),
+    fetchInvestZumIssueKeywords({ maxEntries: 40 }),
+    fetchEIECEconomyKeywords({ maxEntries: 60 }),
+  ];
+
+  const results = await Promise.allSettled(collectors);
+
+  for (const result of results) {
+    if (result.status === 'fulfilled' && Array.isArray(result.value)) {
+      allKeywords.push(...result.value);
+    } else if (result.status === 'rejected') {
+      console.warn('[Korean-First] collector failed:', result.reason?.message);
+    }
+  }
+
+  console.log(`[Korean-First] collected ${allKeywords.length} raw keywords`);
+
+  const aggregated = await aggregateKoreanKeywords(allKeywords);
+  console.log(`[Korean-First] aggregated to ${aggregated.length} unique keywords`);
+
+  const topKeywords = aggregated.slice(0, targetCount);
+
+  console.log('[Korean-First] translating to English...');
+  const translatedKeywords = [];
+
+  for (const kw of topKeywords) {
+    const enTerm = await translateKoreanKeywordToEnglish(kw.term_ko);
+    translatedKeywords.push({
+      term: enTerm,
+      term_ko: kw.term_ko,
+      score: kw.score,
+      count: kw.count,
+      sources: kw.sources
+    });
+
+    await new Promise(r => setTimeout(r, 50));
+  }
+
+  console.log(`[Korean-First] completed with ${translatedKeywords.length} keywords`);
+
+  return {
+    keywords: translatedKeywords,
+    totalRaw: allKeywords.length,
+    uniqueTerms: aggregated.length
+  };
+}
+
+export async function writeKoreanFirstTagsJson({ outputPath = TAG_OUTPUT_FILE, preCollected = null } = {}) {
+  const existingSnapshot = readJsonSafe(outputPath) || null;
+
+  primeTranslationCacheFromSnapshot(existingSnapshot);
+
+  const { keywords, totalRaw, uniqueTerms } = preCollected || await collectKoreanFirstKeywords({ targetCount: 30 });
+
+  if (!keywords.length) {
+    console.warn('[Korean-First] no keywords collected, using fallback');
+    if (existingSnapshot) return existingSnapshot;
+    return null;
+  }
+
+  const translations = {};
+  for (const kw of keywords) {
+    if (kw.term && kw.term_ko) {
+      translations[kw.term] = {
+        en: kw.term,
+        ko: kw.term_ko,
+        translator: DEEPL_API_KEY ? 'deepl' : (NAVER_CLIENT_ID ? 'papago' : 'dictionary')
       };
     }
   }
 
-  return {
-    tags: collected.slice(0, actualTarget),
-    stats,
-    fallbackUsed: false,
-    articleTexts: [],
-    articleCount: stats.size,
-    asOfDate: daysAgo(0)
+  const now = new Date();
+  const payload = {
+    date: now.toISOString().slice(0, 10),
+    window: '5_hours',
+    total_articles: totalRaw,
+    discovered_keywords: keywords.map(kw => ({
+      term: kw.term,
+      term_ko: kw.term_ko
+    })),
+    translations,
+    metadata: {
+      collection_method: 'korean_first',
+      unique_terms: uniqueTerms,
+      sources_used: Array.from(new Set(keywords.flatMap(k => k.sources))),
+      domain_keywords: keywords.filter(k => KO_DOMAIN_BOOST.has(k.term_ko)).length,
+      generated_at: now.toISOString()
+    }
   };
-}
 
+  ensureDirFor(outputPath);
+  await fsp.writeFile(outputPath, JSON.stringify(payload, null, 2));
+
+  console.log(`[Korean-First] wrote ${outputPath} with ${keywords.length} keywords`);
+  console.log(`[Korean-First] sources: ${payload.metadata.sources_used.join(', ')}`);
+
+  return payload;
+}
 function buildDiscoveredKeywordsFromStats(tagStats, { limit = 50 } = {}) {
   if (!tagStats || typeof tagStats.size !== 'number' || tagStats.size === 0) return [];
   const entries = [];
@@ -2370,62 +2463,53 @@ export async function buildMarketKeywordSnapshot({ outputPath = KEYWORD_OUTPUT_F
   const existingSnapshot = readJsonSafe(outputPath) || {};
   const existingTagSnapshot = readJsonSafe(TAG_OUTPUT_FILE) || null;
 
-  const { tags: tagCorpus, stats: tagStats, fallbackUsed, articleTexts, articleCount, asOfDate } = await collectTagCorpus({
-    targetCount: TAG_TARGET_COUNT,
-    fallbackSnapshot: existingTagSnapshot
-  });
-  const tagSnapshot = await writeTagsJsonFile(tagCorpus, tagStats, {
-    fallbackSnapshot: existingTagSnapshot,
-    fallbackUsed,
-    articleTexts,
-    articleCount,
-    asOfDate
-  });
-
-  const termKoLookup = buildTermKoLookup(tagSnapshot);
-
-  let keywords = await buildNewsKeywordsFromTagSnapshot(tagSnapshot, tagStats, { limit: 10, koLookup: termKoLookup });
-  if (!keywords.length) {
-    keywords = await buildKeywordsFromTagStats(tagStats, { limit: 10, koLookup: termKoLookup });
+  let collectionResult = { keywords: [], totalRaw: 0, uniqueTerms: 0 };
+  try {
+    collectionResult = await collectKoreanFirstKeywords({ targetCount: 30 });
+  } catch (err) {
+    console.warn('[Korean-First] collection failed:', err.message);
   }
-  if (!keywords.length && Array.isArray(existingSnapshot?.keywords) && existingSnapshot.keywords.length) {
-    console.warn('[keywords] falling back to previous keyword snapshot');
-    const localizedFallback = [];
-    for (const entry of existingSnapshot.keywords) {
-      if (!entry || typeof entry !== 'object') continue;
-      const koTerm = String(entry?.term_ko || '').trim();
-      if (!koTerm || !hasHangulText(koTerm)) continue;
-      const enTerm = formatTagDisplay(entry?.term || '');
-      if (enTerm) {
-        setTranslationCache(enTerm, koTerm);
-      }
-      localizedFallback.push({ term: enTerm || '', term_ko: koTerm });
-      if (localizedFallback.length >= 10) break;
+
+  let tagSnapshot = existingTagSnapshot;
+  try {
+    const snapshot = await writeKoreanFirstTagsJson({ outputPath: TAG_OUTPUT_FILE, preCollected: collectionResult });
+    if (snapshot) {
+      tagSnapshot = snapshot;
     }
-    keywords = localizedFallback;
+  } catch (err) {
+    console.warn('[Korean-First] failed to write tags snapshot:', err.message);
   }
 
-  if (Array.isArray(keywords)) {
-    const deduped = [];
+  const dedupeKeywords = (list = []) => {
+    const out = [];
     const seen = new Set();
-    for (const entry of keywords) {
+    for (const entry of list) {
       if (!entry || typeof entry !== 'object') continue;
-      const koTerm = String(entry.term_ko || '').trim();
-      const key = (koTerm || String(entry.term || '').trim()).toLowerCase();
+      const term = formatTagDisplay(entry.term || '');
+      const termKo = String(entry.term_ko || '').trim();
+      const key = (termKo || term).toLowerCase();
       if (!key || seen.has(key)) continue;
       seen.add(key);
-      deduped.push({ term: String(entry.term || '').trim(), term_ko: koTerm });
-      if (deduped.length >= 10) break;
+      out.push({ term, term_ko: termKo });
+      if (out.length >= 10) break;
     }
-    keywords = deduped;
+    return out;
+  };
+
+  let keywords = dedupeKeywords(collectionResult.keywords);
+
+  if (!keywords.length && Array.isArray(tagSnapshot?.discovered_keywords)) {
+    keywords = dedupeKeywords(tagSnapshot.discovered_keywords);
   }
 
-  const marketSet = new Set();
-  if (tagStats && typeof tagStats.values === 'function') {
-    for (const entry of tagStats.values()) {
-      for (const market of entry.markets || []) {
-        if (market) marketSet.add(market);
-      }
+  if (!keywords.length && Array.isArray(existingSnapshot?.keywords)) {
+    console.warn('[keywords] falling back to previous keyword snapshot');
+    keywords = dedupeKeywords(existingSnapshot.keywords);
+  }
+
+  for (const entry of keywords) {
+    if (entry.term && entry.term_ko) {
+      setTranslationCache(entry.term, entry.term_ko);
     }
   }
 
@@ -2434,10 +2518,7 @@ export async function buildMarketKeywordSnapshot({ outputPath = KEYWORD_OUTPUT_F
   const updatedKo = now.toLocaleString('ko-KR', { timeZone: tz, hour12: false });
   const updatedEn = now.toLocaleString('en-US', { timeZone: tz });
 
-  const derivedMarkets = Array.from(marketSet).sort();
-  const markets = derivedMarkets.length
-    ? derivedMarkets
-    : (Array.isArray(existingSnapshot?.markets) ? existingSnapshot.markets : []);
+  const markets = Array.isArray(existingSnapshot?.markets) ? existingSnapshot.markets : [];
 
   const payload = {
     generatedAt: now.toISOString(),
@@ -4341,6 +4422,8 @@ export async function buildNewsCachesCli() {
 if (import.meta.url === `file://${process.argv[1]}`) {
   if (process.argv.includes('--build-caches')) {
     buildNewsCachesCli().catch(e => { console.error(e); process.exit(1); });
+  } else if (process.argv.includes('--korean-first-keywords')) {
+    writeKoreanFirstTagsJson().catch(e => { console.error(e); process.exit(1); });
   } else if (process.argv.includes('--build-keywords')) {
     buildMarketKeywordSnapshot().catch(e => { console.error(e); process.exit(1); });
   }


### PR DESCRIPTION
## Summary
- add a Korean-first keyword aggregation pipeline that scrapes Daum, Nate, and Naver sources before translating to English
- update the market keyword snapshot workflow to use the new collector and expose a CLI flag for generating Korean-first tags

## Testing
- node tests/apple_association.test.js

------
https://chatgpt.com/codex/tasks/task_b_68de4396aab0832ab4484ef4633323d9