### PR TITLE
Add missing node-html-parser dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "compromise": "^14.14.2",
         "fast-xml-parser": "^5.2.5",
         "keyword-extractor": "^0.0.28",
-        "node-fetch": "^3.3.2"
+        "node-fetch": "^3.3.2",
+        "node-html-parser": "^6.1.13"
       },
       "engines": {
         "node": ">=18"
@@ -1063,6 +1064,15 @@
         "node": ">=4.5.0"
       }
     },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
     "node_modules/hoek": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.3.1.tgz",
@@ -1366,6 +1376,16 @@
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
         "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/node-html-parser": {
+      "version": "6.1.13",
+      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-6.1.13.tgz",
+      "integrity": "sha512-qIsTMOY4C/dAa5Q5vsobRpOOvPfC4pB61UVW2uSwZNUp0QU/jCekTal1vMmbO0DgdHeLUJpv/ARmDqErVxA3Sg==",
+      "license": "MIT",
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "he": "1.2.0"
       }
     },
     "node_modules/node-wget": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "compromise": "^14.14.2",
     "fast-xml-parser": "^5.2.5",
     "keyword-extractor": "^0.0.28",
-    "node-fetch": "^3.3.2"
+    "node-fetch": "^3.3.2",
+    "node-html-parser": "^6.1.13"
   },
   "optionalDependencies": {
     "open-korean-text-node": "^2.2.0"


### PR DESCRIPTION
## Summary
- add node-html-parser to the project dependencies to satisfy runtime imports

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68de53b76144832aacb975c55b672627