### PR TITLE
Sync keyword highlights and template layout

### DIFF
--- a/newsKeywords.json
+++ b/newsKeywords.json
@@ -1,0 +1,116 @@
+{
+  "generatedAt": "2025-10-03T04:49:55.640Z",
+  "updatedAt": {
+    "en": "Updated Oct 3, 2025, 10:56 AM KST (5 hours)",
+    "ko": "2025. 10. 3. 오전 10:56 기준 업데이트 (5 hours)"
+  },
+  "timezone": "Asia/Seoul",
+  "keywords": [
+    {
+      "term": "조선 업 호황",
+      "term_ko": "조선 업 호황",
+      "score": 0.85,
+      "mentions": 5,
+      "search": {
+        "ko": "https://www.google.com/search?q=%EC%A1%B0%EC%84%A0%20%EC%97%85%20%ED%98%B8%ED%99%A9&tbm=nws&hl=ko&gl=KR&ceid=KR%3Ako",
+        "en": "https://www.google.com/search?q=%EC%A1%B0%EC%84%A0%20%EC%97%85%20%ED%98%B8%ED%99%A9&tbm=nws&hl=en&gl=US&ceid=US%3Aen"
+      }
+    },
+    {
+      "term": "의 수출 증가",
+      "term_ko": "의 수출 증가",
+      "score": 0.69,
+      "mentions": 3,
+      "search": {
+        "ko": "https://www.google.com/search?q=%EC%9D%98%20%EC%88%98%EC%B6%9C%20%EC%A6%9D%EA%B0%80&tbm=nws&hl=ko&gl=KR&ceid=KR%3Ako",
+        "en": "https://www.google.com/search?q=%EC%9D%98%20%EC%88%98%EC%B6%9C%20%EC%A6%9D%EA%B0%80&tbm=nws&hl=en&gl=US&ceid=US%3Aen"
+      }
+    },
+    {
+      "term": "수출 증가 까지",
+      "term_ko": "수출 증가 까지",
+      "score": 0.69,
+      "mentions": 3,
+      "search": {
+        "ko": "https://www.google.com/search?q=%EC%88%98%EC%B6%9C%20%EC%A6%9D%EA%B0%80%20%EA%B9%8C%EC%A7%80&tbm=nws&hl=ko&gl=KR&ceid=KR%3Ako",
+        "en": "https://www.google.com/search?q=%EC%88%98%EC%B6%9C%20%EC%A6%9D%EA%B0%80%20%EA%B9%8C%EC%A7%80&tbm=nws&hl=en&gl=US&ceid=US%3Aen"
+      }
+    },
+    {
+      "term": "정책 환율 재상승은",
+      "term_ko": "정책 환율 재상승은",
+      "score": 0.65,
+      "mentions": 1,
+      "search": {
+        "ko": "https://www.google.com/search?q=%EC%A0%95%EC%B1%85%20%ED%99%98%EC%9C%A8%20%EC%9E%AC%EC%83%81%EC%8A%B9%EC%9D%80&tbm=nws&hl=ko&gl=KR&ceid=KR%3Ako",
+        "en": "https://www.google.com/search?q=%EC%A0%95%EC%B1%85%20%ED%99%98%EC%9C%A8%20%EC%9E%AC%EC%83%81%EC%8A%B9%EC%9D%80&tbm=nws&hl=en&gl=US&ceid=US%3Aen"
+      }
+    },
+    {
+      "term": "상승 AI 반도체주",
+      "term_ko": "상승 AI 반도체주",
+      "score": 0.62,
+      "mentions": 1,
+      "search": {
+        "ko": "https://www.google.com/search?q=%EC%83%81%EC%8A%B9%20AI%20%EB%B0%98%EB%8F%84%EC%B2%B4%EC%A3%BC&tbm=nws&hl=ko&gl=KR&ceid=KR%3Ako",
+        "en": "https://www.google.com/search?q=%EC%83%81%EC%8A%B9%20AI%20%EB%B0%98%EB%8F%84%EC%B2%B4%EC%A3%BC&tbm=nws&hl=en&gl=US&ceid=US%3Aen"
+      }
+    },
+    {
+      "term": "반도체 호황 수출",
+      "term_ko": "반도체 호황 수출",
+      "score": 0.62,
+      "mentions": 1,
+      "search": {
+        "ko": "https://www.google.com/search?q=%EB%B0%98%EB%8F%84%EC%B2%B4%20%ED%98%B8%ED%99%A9%20%EC%88%98%EC%B6%9C&tbm=nws&hl=ko&gl=KR&ceid=KR%3Ako",
+        "en": "https://www.google.com/search?q=%EB%B0%98%EB%8F%84%EC%B2%B4%20%ED%98%B8%ED%99%A9%20%EC%88%98%EC%B6%9C&tbm=nws&hl=en&gl=US&ceid=US%3Aen"
+      }
+    },
+    {
+      "term": "금융사 규제 완화",
+      "term_ko": "금융사 규제 완화",
+      "score": 0.59,
+      "mentions": 1,
+      "search": {
+        "ko": "https://www.google.com/search?q=%EA%B8%88%EC%9C%B5%EC%82%AC%20%EA%B7%9C%EC%A0%9C%20%EC%99%84%ED%99%94&tbm=nws&hl=ko&gl=KR&ceid=KR%3Ako",
+        "en": "https://www.google.com/search?q=%EA%B8%88%EC%9C%B5%EC%82%AC%20%EA%B7%9C%EC%A0%9C%20%EC%99%84%ED%99%94&tbm=nws&hl=en&gl=US&ceid=US%3Aen"
+      }
+    },
+    {
+      "term": "확대 이는 조선",
+      "term_ko": "확대 이는 조선",
+      "score": 0.53,
+      "mentions": 1,
+      "search": {
+        "ko": "https://www.google.com/search?q=%ED%99%95%EB%8C%80%20%EC%9D%B4%EB%8A%94%20%EC%A1%B0%EC%84%A0&tbm=nws&hl=ko&gl=KR&ceid=KR%3Ako",
+        "en": "https://www.google.com/search?q=%ED%99%95%EB%8C%80%20%EC%9D%B4%EB%8A%94%20%EC%A1%B0%EC%84%A0&tbm=nws&hl=en&gl=US&ceid=US%3Aen"
+      }
+    },
+    {
+      "term": "호황 수출 호조",
+      "term_ko": "호황 수출 호조",
+      "score": 0.53,
+      "mentions": 1,
+      "search": {
+        "ko": "https://www.google.com/search?q=%ED%98%B8%ED%99%A9%20%EC%88%98%EC%B6%9C%20%ED%98%B8%EC%A1%B0&tbm=nws&hl=ko&gl=KR&ceid=KR%3Ako",
+        "en": "https://www.google.com/search?q=%ED%98%B8%ED%99%A9%20%EC%88%98%EC%B6%9C%20%ED%98%B8%EC%A1%B0&tbm=nws&hl=en&gl=US&ceid=US%3Aen"
+      }
+    },
+    {
+      "term": "투자로 반도체 호황",
+      "term_ko": "투자로 반도체 호황",
+      "score": 0.53,
+      "mentions": 1,
+      "search": {
+        "ko": "https://www.google.com/search?q=%ED%88%AC%EC%9E%90%EB%A1%9C%20%EB%B0%98%EB%8F%84%EC%B2%B4%20%ED%98%B8%ED%99%A9&tbm=nws&hl=ko&gl=KR&ceid=KR%3Ako",
+        "en": "https://www.google.com/search?q=%ED%88%AC%EC%9E%90%EB%A1%9C%20%EB%B0%98%EB%8F%84%EC%B2%B4%20%ED%98%B8%ED%99%A9&tbm=nws&hl=en&gl=US&ceid=US%3Aen"
+      }
+    }
+  ],
+  "tagMeta": {
+    "source": "stocks/data/tags.json",
+    "date": "2025-10-03",
+    "window": "5_hours",
+    "generatedAt": "2025-10-03T01:56:35.516Z"
+  }
+}

--- a/src/template.html
+++ b/src/template.html
@@ -22,27 +22,111 @@
   <style>
   .fx-ticker {
     background-color: #000;
-    color: yellow;
+    color: #f6ff00;
     font-weight: bold;
     font-size: 1.0em;
     height: 1.5em;
     line-height: 1.1em;
-    overflow: hidden;
-    position: relative;
+    overflow-x: auto;
+    white-space: nowrap;
+    scrollbar-width: none;
     box-sizing: border-box;
     margin: 0.5rem 0;
   }
-  .fx-ticker .fx-track {
+  .fx-ticker::-webkit-scrollbar {
+    display: none;
+  }
+  .fx-track {
     display: inline-block;
     white-space: nowrap;
     line-height: inherit;
-    animation: ticker-loop 30s linear infinite;
+    color: inherit;
+    text-decoration: underline;
+    cursor: pointer;
   }
   .fx-item { margin: 0 .6rem; }
   .fx-time { opacity: .75; margin-left: .85rem; font-size: .9em; }
-  @keyframes ticker-loop {
-    0%   { transform: translateX(50%); }
-    100% { transform: translateX(-100%); }
+  .keyword-box {
+    border: 1px solid #e0e0e0;
+    border-radius: 8px;
+    padding: 1rem;
+    margin: 1.5rem 0;
+    background: #fafafa;
+  }
+  .keyword-box h3 {
+    margin-top: 0;
+    margin-bottom: 0.75rem;
+    font-size: 1.3rem;
+  }
+  .keyword-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 0.5rem;
+  }
+  .keyword-list li {
+    padding: 0.65rem 0.75rem;
+    border-radius: 6px;
+    background: #fff;
+    box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+  .keyword-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+  .keyword-text {
+    font-weight: 600;
+    font-size: 1rem;
+    color: #2c3e50;
+  }
+  .keyword-actions {
+    display: inline-flex;
+    gap: 0.4rem;
+    flex-wrap: wrap;
+  }
+  .keyword-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.25rem 0.65rem;
+    border-radius: 4px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    text-decoration: none;
+    color: #fff;
+    background: #2563eb;
+    border: 1px solid #1d4ed8;
+    transition: background-color 0.2s ease, box-shadow 0.2s ease;
+  }
+  .keyword-btn:hover,
+  .keyword-btn:focus-visible {
+    background: #1e40af;
+    box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.25);
+  }
+  .keyword-btn[data-lang="ko"] {
+    background: #0f766e;
+    border-color: #0f5e55;
+  }
+  .keyword-btn[data-lang="ko"]:hover,
+  .keyword-btn[data-lang="ko"]:focus-visible {
+    background: #0d5f59;
+    box-shadow: 0 0 0 2px rgba(15, 118, 110, 0.25);
+  }
+  .keyword-markets {
+    font-size: 0.85rem;
+    color: #576574;
+  }
+  @media (min-width: 768px) {
+    .keyword-list {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
   }
   </style>
 </head>
@@ -79,6 +163,13 @@
       <div id="newsUpdated" class="last-updated"></div>
     </section>
 
+    <section id="keywordHighlights" class="keyword-box" aria-labelledby="keywordTitle">
+      <h3 id="keywordTitle" data-i18n="keywordTitle">오늘의 키워드</h3>
+      <div id="keywordUpdated" class="last-updated"></div>
+      <ul id="keywordList" class="keyword-list"></ul>
+      <div id="keywordError" class="error" role="alert" style="display:none;"></div>
+    </section>
+
   <section id="portfolioRecommendations">
     <h2 data-i18n="portfolioRecs">포트폴리오 추천</h2>
     <div id="loading" class="loading" style="display:none">
@@ -102,8 +193,13 @@
         nasdaqDesc: '나스닥 상장 비금융 대형주 100종목으로 기술주 비중 높음',
         disclaimer: '본 페이지의 정보는 투자 참고용이며, 제공된 데이터의 정확성을 보장하지 않습니다. 투자 판단의 책임은 이용자에게 있습니다.',
         marketNews: '최신 마켓 뉴스',
+        keywordTitle: '오늘의 키워드',
+        keywordError: '키워드를 불러오지 못했습니다.',
+        keywordMarkets: '적용 시장',
         portfolioRecs: '포트폴리오 추천',
         dashboardLink: '👉 주식 시장 요약 대시보드',
+        refreshing: '새로고침 중...',
+        refreshData: '데이터 새로고침',
         marketDataError: '마켓 데이터를 불러오지 못했습니다.',
         newsError: '뉴스를 불러오지 못했습니다.',
         recsError: '추천 데이터를 불러오지 못했습니다.',
@@ -126,8 +222,13 @@
         nasdaqDesc: 'Tech-heavy index of 100 non-financial NASDAQ stocks',
         disclaimer: 'Information on this page is for reference only and accuracy is not guaranteed. Investment decisions are your responsibility.',
         marketNews: 'Latest Market News',
+        keywordTitle: "Today's Keyword",
+        keywordError: 'Failed to load keywords.',
+        keywordMarkets: 'Markets',
         portfolioRecs: 'Portfolio Recommendations',
         dashboardLink: '👉 Stock News Summary Dashboard',
+        refreshing: 'Refreshing...',
+        refreshData: 'Refresh Data',
         marketDataError: 'Failed to load market data.',
         newsError: 'Failed to load news.',
         recsError: 'Failed to load recommendations.',
@@ -143,6 +244,114 @@
 
     let currentLang = (navigator.language || 'en').startsWith('ko') ? 'ko' : 'en';
     let visitData = null;
+    let keywordSnapshot = null;
+    let keywordLoadFailed = false;
+    let tagKoLookup = null;
+    let tagKoLookupPromise = null;
+
+    function escapeHtml(str) {
+      return String(str || '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+    }
+
+    function normalizeTermKey(term) {
+      return String(term || '').trim().toLowerCase();
+    }
+
+    function buildTagKoLookup(snapshot) {
+      const map = new Map();
+      if (!snapshot || typeof snapshot !== 'object') {
+        return map;
+      }
+      const add = (en, ko) => {
+        const key = normalizeTermKey(en);
+        const value = String(ko || '').trim();
+        if (!key || !value) return;
+        map.set(key, value);
+      };
+      if (Array.isArray(snapshot.discovered_keywords)) {
+        snapshot.discovered_keywords.forEach(item => {
+          const en = item?.term || '';
+          const ko = item?.term_ko || '';
+          add(en, ko);
+        });
+      }
+      if (Array.isArray(snapshot.keywords)) {
+        snapshot.keywords.forEach(item => {
+          const en = item?.term || '';
+          const ko = item?.term_ko || '';
+          add(en, ko);
+        });
+      }
+      if (snapshot.translations && typeof snapshot.translations === 'object') {
+        for (const [en, value] of Object.entries(snapshot.translations)) {
+          if (!value) continue;
+          if (typeof value === 'string') {
+            add(en, value);
+          } else {
+            add(en, value.ko || value.en || '');
+          }
+        }
+      }
+      return map;
+    }
+
+    async function loadTagKoLookup() {
+      if (tagKoLookup) return tagKoLookup;
+      if (tagKoLookupPromise) return tagKoLookupPromise;
+      const url = 'stocks/data/tags.json?_=' + Date.now();
+      tagKoLookupPromise = fetch(url, { cache: 'no-store' })
+        .then(res => {
+          if (!res.ok) throw new Error('HTTP ' + res.status);
+          return res.json();
+        })
+        .then(data => {
+          tagKoLookup = buildTagKoLookup(data);
+          return tagKoLookup;
+        })
+        .catch(err => {
+          console.warn('tags.json load failed', err);
+          tagKoLookup = new Map();
+          return tagKoLookup;
+        })
+        .finally(() => {
+          tagKoLookupPromise = null;
+          renderKeywordBox();
+        });
+      return tagKoLookupPromise;
+    }
+
+    function lookupKoTerm(term) {
+      const key = normalizeTermKey(term);
+      if (!key) return '';
+      if (tagKoLookup && tagKoLookup.has(key)) {
+        return tagKoLookup.get(key);
+      }
+      return '';
+    }
+
+    function getKoTermForEntry(entry) {
+      if (!entry) return '';
+      const direct = typeof entry.term_ko === 'string' ? entry.term_ko.trim() : '';
+      if (direct) return direct;
+      const enSource = typeof entry.term === 'string' ? entry.term.trim() : '';
+      const lookup = lookupKoTerm(enSource);
+      if (lookup) return lookup;
+      return '';
+    }
+
+    function buildNewsSearchUrl(term, lang = 'en') {
+      const query = String(term || '').trim();
+      if (!query) return '';
+      const hl = lang === 'ko' ? 'ko' : 'en';
+      const gl = lang === 'ko' ? 'KR' : 'US';
+      const ceid = `${gl}:${hl}`;
+      return `https://www.google.com/search?q=${encodeURIComponent(query)}&tbm=nws&hl=${hl}&gl=${gl}&ceid=${encodeURIComponent(ceid)}`;
+    }
 
     function applyTranslations() {
       const t = translations[currentLang];
@@ -156,6 +365,7 @@
           el.textContent = t[key];
         }
       });
+      renderKeywordBox();
     }
 
     function toggleDebug() {
@@ -312,6 +522,66 @@
       }
   }
 
+    function renderKeywordBox() {
+      const listEl = document.getElementById('keywordList');
+      const errorEl = document.getElementById('keywordError');
+      const updatedEl = document.getElementById('keywordUpdated');
+      if (!listEl || !errorEl) return;
+
+      if (!keywordSnapshot) {
+        listEl.innerHTML = '';
+        if (keywordLoadFailed) {
+          errorEl.textContent = translations[currentLang].keywordError;
+          errorEl.style.display = 'block';
+        } else {
+          errorEl.style.display = 'none';
+        }
+        if (updatedEl) updatedEl.textContent = '';
+        return;
+      }
+
+      const keywords = Array.isArray(keywordSnapshot.keywords)
+        ? keywordSnapshot.keywords.slice(0, 10)
+        : [];
+      if (!keywords.length) {
+        listEl.innerHTML = `<li class="empty">${translations[currentLang].keywordError}</li>`;
+        errorEl.style.display = 'none';
+      } else {
+        const items = keywords.map(entry => {
+          const enTerm = typeof entry?.term === 'string' ? entry.term.trim() : '';
+          const koTerm = String(getKoTermForEntry(entry) || '').trim();
+          const display = currentLang === 'ko'
+            ? (koTerm || enTerm)
+            : (enTerm || koTerm);
+          const label = escapeHtml(display || '');
+          const koQuery = koTerm || enTerm;
+          const enQuery = enTerm || koTerm;
+          const koUrl = entry?.search?.ko || (koQuery ? buildNewsSearchUrl(koQuery, 'ko') : '');
+          const enUrl = entry?.search?.en || (enQuery ? buildNewsSearchUrl(enQuery, 'en') : '');
+          const buttons = [];
+          if (koUrl) {
+            buttons.push(`<a class="keyword-btn" data-lang="ko" href="${escapeHtml(koUrl)}" target="_blank" rel="noopener noreferrer">한국어</a>`);
+          }
+          if (enUrl) {
+            buttons.push(`<a class="keyword-btn" data-lang="en" href="${escapeHtml(enUrl)}" target="_blank" rel="noopener noreferrer">English</a>`);
+          }
+          const actionsHtml = buttons.length ? `<div class="keyword-actions">${buttons.join('')}</div>` : '';
+          return `<li><div class="keyword-header"><span class="keyword-text">${label}</span>${actionsHtml}</div></li>`;
+        }).join('');
+        listEl.innerHTML = items || `<li class="empty">${translations[currentLang].keywordError}</li>`;
+        errorEl.style.display = 'none';
+      }
+
+      if (updatedEl) {
+        const localized = currentLang === 'ko'
+          ? (keywordSnapshot.updatedAt?.ko || keywordSnapshot.updatedAt?.en || '')
+          : (keywordSnapshot.updatedAt?.en || keywordSnapshot.updatedAt?.ko || '');
+        updatedEl.textContent = localized
+          ? translations[currentLang].updated + localized
+          : '';
+      }
+    }
+
   async function loadMarketNews() {
       let data = null;
       try {
@@ -346,6 +616,26 @@
       }
       renderNewsUpdated();
   }
+
+    async function loadKeywordHighlights() {
+      keywordLoadFailed = false;
+      try {
+        const res = await fetch('newsKeywords.json?_=' + Date.now(), { cache: 'no-store' });
+        if (!res.ok) throw new Error('HTTP ' + res.status);
+        keywordSnapshot = await res.json();
+        keywordLoadFailed = false;
+      } catch (err) {
+        console.warn('newsKeywords.json load failed', err);
+        keywordSnapshot = null;
+        keywordLoadFailed = true;
+      }
+      try {
+        await loadTagKoLookup();
+      } catch (e) {
+        console.warn('Unable to load tag translations', e);
+      }
+      renderKeywordBox();
+    }
 
     // 추천 종목 로드
     const FULL_NAME_MAP = {
@@ -469,7 +759,7 @@
         button.disabled = true;
         button.textContent = translations[currentLang].refreshing;
       }
-      Promise.all([loadMarketData(), fetchRecs(), loadMarketNews()]).finally(() => {
+      Promise.all([loadMarketData(), fetchRecs(), loadMarketNews(), loadKeywordHighlights()]).finally(() => {
         if (button) {
           button.disabled = false;
           button.textContent = translations[currentLang].refreshData;
@@ -483,6 +773,7 @@
       updateCurrentDate();
       console.log('📊 데일리 주식 리포트 페이지 로드 완료');
       // 페이지가 초기화되면 자동으로 데이터를 새로 불러옵니다.
+      loadTagKoLookup().catch(() => {});
       refreshAllData();
 
       document.getElementById('btnKo').addEventListener('click', function() {
@@ -490,6 +781,7 @@
         applyTranslations();
         updateCurrentDate();
         renderNewsUpdated();
+        renderKeywordBox();
         if (lastRecommendations) render(lastRecommendations);
         updateVisitCounts();
       });
@@ -498,6 +790,7 @@
         applyTranslations();
         updateCurrentDate();
         renderNewsUpdated();
+        renderKeywordBox();
         if (lastRecommendations) render(lastRecommendations);
         updateVisitCounts();
       });
@@ -536,7 +829,7 @@
   <div id="visitCounts" style="text-align:center;margin-top:20px;font-size:0.8rem;color:#64748b;"></div>
   <!-- FX ticker (below view count) -->
   <div id="fx-ticker" class="fx-ticker">
-    <div id="fx-line" class="fx-track"></div>
+    <a id="fx-line" class="fx-track" href="stocks/fx_rates/index.html"></a>
   </div>
   <script>
     (async function() {
@@ -567,12 +860,7 @@
         });
         const stamp = `<span class="fx-time">업데이트 ${String(data.lastUpdated).replace('T',' ').replace('+09:00',' KST')}</span>`;
         line.innerHTML = parts.join(' • ') + ' • ' + stamp;
-        const afterFonts = (document.fonts && document.fonts.ready) ? document.fonts.ready : Promise.resolve();
-        line.style.animation = 'none';
-        afterFonts.then(() => {
-          void line.offsetWidth;
-          line.style.animation = 'ticker-loop 30s linear infinite';
-        });
+        wrap.scrollLeft = 0;
       });
   }
   if (document.readyState === 'loading') {
@@ -583,6 +871,95 @@
     (document.fonts && document.fonts.ready ? document.fonts.ready : Promise.resolve()).then(start);
   }
 })();
+  </script>
+  <script>
+  (function enableFxTickerAutoScroll() {
+    const ticker = document.querySelector('.fx-ticker');
+    if (!ticker) return;
+
+    function autoScroll() {
+      if (ticker.scrollWidth <= ticker.clientWidth) return;
+      if (!ticker.matches(':hover') && !ticker.dataset.dragging) {
+        ticker.scrollLeft += 1;
+        if (ticker.scrollLeft >= ticker.scrollWidth - ticker.clientWidth) {
+          ticker.scrollLeft = 0;
+        }
+      }
+    }
+
+    setInterval(autoScroll, 30);
+
+    let isPointerDown = false;
+    let startX = 0;
+    let startScrollLeft = 0;
+    let pointerDragged = false;
+
+    function stopPointerDrag() {
+      if (!isPointerDown) return;
+      isPointerDown = false;
+      delete ticker.dataset.dragging;
+    }
+
+    ticker.addEventListener('mousedown', (event) => {
+      if (event.button !== 0) return;
+      isPointerDown = true;
+      pointerDragged = false;
+      startX = event.pageX;
+      startScrollLeft = ticker.scrollLeft;
+    });
+
+    document.addEventListener('mousemove', (event) => {
+      if (!isPointerDown) return;
+      const delta = event.pageX - startX;
+      if (!pointerDragged && Math.abs(delta) > 3) {
+        pointerDragged = true;
+        ticker.dataset.dragging = 'true';
+      }
+      if (pointerDragged) {
+        event.preventDefault();
+        ticker.scrollLeft = startScrollLeft - delta;
+      }
+    });
+
+    document.addEventListener('mouseup', stopPointerDrag);
+
+    ticker.addEventListener('touchstart', (event) => {
+      if (event.touches.length !== 1) return;
+      isPointerDown = true;
+      pointerDragged = false;
+      startX = event.touches[0].pageX;
+      startScrollLeft = ticker.scrollLeft;
+    }, { passive: true });
+
+    ticker.addEventListener('touchmove', (event) => {
+      if (!isPointerDown || event.touches.length !== 1) return;
+      const delta = event.touches[0].pageX - startX;
+      if (!pointerDragged && Math.abs(delta) > 6) {
+        pointerDragged = true;
+        ticker.dataset.dragging = 'true';
+      }
+      if (pointerDragged) {
+        ticker.scrollLeft = startScrollLeft - delta;
+        event.preventDefault();
+      }
+    }, { passive: false });
+
+    const resetTouchState = () => {
+      stopPointerDrag();
+    };
+
+    ticker.addEventListener('touchend', resetTouchState);
+    ticker.addEventListener('touchcancel', resetTouchState);
+    document.addEventListener('touchend', resetTouchState);
+    document.addEventListener('touchcancel', resetTouchState);
+
+    ticker.addEventListener('click', (event) => {
+      if (pointerDragged && event.detail !== 0) {
+        event.preventDefault();
+      }
+      pointerDragged = false;
+    });
+  })();
   </script>
 <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-3360521146359419" crossorigin="anonymous"></script>
 <!-- display_ad -->

--- a/stocks.html
+++ b/stocks.html
@@ -198,6 +198,7 @@
         keywordMarkets: '적용 시장',
         portfolioRecs: '포트폴리오 추천',
         dashboardLink: '👉 주식 시장 요약 대시보드',
+        marketDataError: '마켓 데이터를 불러오지 못했습니다.',
         refreshing: '새로고침 중...',
         refreshData: '데이터 새로고침',
         newsError: '뉴스를 불러오지 못했습니다.',
@@ -226,6 +227,7 @@
         keywordMarkets: 'Markets',
         portfolioRecs: 'Portfolio Recommendations',
         dashboardLink: '👉 Stock News Summary Dashboard',
+        marketDataError: 'Failed to load market data.',
         refreshing: 'Refreshing...',
         refreshData: 'Refresh Data',
         newsError: 'Failed to load news.',
@@ -429,7 +431,9 @@
         return;
       }
 
-      const keywords = Array.isArray(keywordSnapshot.keywords) ? keywordSnapshot.keywords : [];
+      const keywords = Array.isArray(keywordSnapshot.keywords)
+        ? keywordSnapshot.keywords.slice(0, 10)
+        : [];
       if (!keywords.length) {
         listEl.innerHTML = `<li class="empty">${translations[currentLang].keywordError}</li>`;
         errorEl.style.display = 'none';
@@ -443,12 +447,14 @@
           const label = escapeHtml(display || '');
           const koQuery = koTerm || enTerm;
           const enQuery = enTerm || koTerm;
+          const koUrl = entry?.search?.ko || (koQuery ? buildNewsSearchUrl(koQuery, 'ko') : '');
+          const enUrl = entry?.search?.en || (enQuery ? buildNewsSearchUrl(enQuery, 'en') : '');
           const buttons = [];
-          if (koQuery) {
-            buttons.push(`<a class="keyword-btn" data-lang="ko" href="${escapeHtml(buildNewsSearchUrl(koQuery, 'ko'))}" target="_blank" rel="noopener noreferrer">한국어</a>`);
+          if (koUrl) {
+            buttons.push(`<a class="keyword-btn" data-lang="ko" href="${escapeHtml(koUrl)}" target="_blank" rel="noopener noreferrer">한국어</a>`);
           }
-          if (enQuery) {
-            buttons.push(`<a class="keyword-btn" data-lang="en" href="${escapeHtml(buildNewsSearchUrl(enQuery, 'en'))}" target="_blank" rel="noopener noreferrer">English</a>`);
+          if (enUrl) {
+            buttons.push(`<a class="keyword-btn" data-lang="en" href="${escapeHtml(enUrl)}" target="_blank" rel="noopener noreferrer">English</a>`);
           }
           const actionsHtml = buttons.length ? `<div class="keyword-actions">${buttons.join('')}</div>` : '';
           return `<li><div class="keyword-header"><span class="keyword-text">${label}</span>${actionsHtml}</div></li>`;

--- a/tools/buildPoolsTrendy.js
+++ b/tools/buildPoolsTrendy.js
@@ -23,7 +23,7 @@ fs.mkdirSync('cache', { recursive: true });
 
 const CACHE_DIR = 'cache';
 const TTL_MS = 1000 * 60 * 60 * 12; // 12h default; can override per-call
-const TAG_FILE = process.env.MARKET_TAG_FILE || 'tags.json';
+let TAG_FILE = process.env.MARKET_TAG_FILE || 'tags.json';
 const TAG_WEIGHT_INPUT = Number(process.env.TAG_EVAL_WEIGHT);
 const TAG_FREQ_WEIGHT_INPUT = Number(process.env.TAG_FREQ_WEIGHT);
 
@@ -237,6 +237,187 @@ function normalizeKey(s) {
   return t.toUpperCase();
 }
 
+const TAG_FILE_CANDIDATES = Array.from(new Set([
+  TAG_FILE,
+  'tags.json',
+  'stocks/data/tags.json'
+].filter(Boolean)));
+const NEWS_KEYWORD_LIMIT = Math.max(1, Number(process.env.NEWS_KEYWORD_LIMIT || 10));
+let TAG_SOURCE_META = { date: '', window: '', generatedAt: '' };
+let TAG_SOURCE_PATH = null;
+
+function formatEnglishKeyword(str) {
+  const text = String(str || '').trim();
+  if (!text) return '';
+  const lower = text.toLowerCase();
+  if (text.length <= 3 && /[a-z]/i.test(text)) return text.toUpperCase();
+  if (text === lower) {
+    return lower
+      .split(' ')
+      .map(part => (part ? part[0].toUpperCase() + part.slice(1) : ''))
+      .join(' ');
+  }
+  return text;
+}
+
+function buildNewsSearchUrl(term, lang = 'en') {
+  const query = String(term || '').trim();
+  if (!query) return '';
+  const hl = lang === 'ko' ? 'ko' : 'en';
+  const gl = lang === 'ko' ? 'KR' : 'US';
+  const ceid = `${gl}:${hl}`;
+  return `https://www.google.com/search?q=${encodeURIComponent(query)}&tbm=nws&hl=${hl}&gl=${gl}&ceid=${encodeURIComponent(ceid)}`;
+}
+
+function enrichKeywordSnapshot(raw) {
+  if (!raw || typeof raw !== 'object') {
+    return { keywords: [], _matchers: [] };
+  }
+  const snapshot = { ...raw };
+  const list = Array.isArray(snapshot.keywords) ? snapshot.keywords : [];
+  snapshot.keywords = list;
+  snapshot._matchers = list.map(entry => {
+    const ko = String(entry?.term_ko || '').trim();
+    const en = String(entry?.term || '').trim();
+    const texts = [ko, en].filter(Boolean);
+    const lowered = texts.map(t => t.toLowerCase());
+    const regexes = texts
+      .filter(t => t && t.length >= 2)
+      .map(t => {
+        try { return new RegExp(esc(t), 'i'); }
+        catch { return null; }
+      })
+      .filter(Boolean);
+    return { entry, lowered, regexes };
+  });
+  return snapshot;
+}
+
+function formatTagUpdatedStrings(meta = {}) {
+  const iso = meta.generatedAt || meta.generated_at || (meta.metadata && meta.metadata.generated_at) || '';
+  const date = meta.date || '';
+  const window = meta.window || (meta.metadata && meta.metadata.window) || '';
+  const formatWindow = window ? window.replace(/_/g, ' ') : '';
+  const result = { en: '', ko: '' };
+  if (iso) {
+    const ts = new Date(iso);
+    if (!Number.isNaN(ts.valueOf())) {
+      try {
+        const fmtEn = new Intl.DateTimeFormat('en-US', {
+          dateStyle: 'medium',
+          timeStyle: 'short',
+          timeZone: 'Asia/Seoul'
+        }).format(ts);
+        result.en = `Updated ${fmtEn} KST`;
+      } catch {
+        result.en = `Updated ${iso}`;
+      }
+      try {
+        const fmtKo = new Intl.DateTimeFormat('ko-KR', {
+          dateStyle: 'medium',
+          timeStyle: 'short',
+          timeZone: 'Asia/Seoul'
+        }).format(ts);
+        result.ko = `${fmtKo} 기준 업데이트`;
+      } catch {
+        result.ko = `${iso} 기준 업데이트`;
+      }
+    }
+  }
+  if (!result.en && date) {
+    result.en = `As of ${date}`;
+  }
+  if (!result.ko && date) {
+    result.ko = `${date} 기준`;
+  }
+  if (formatWindow) {
+    result.en = result.en ? `${result.en} (${formatWindow})` : formatWindow;
+    result.ko = result.ko ? `${result.ko} (${formatWindow})` : formatWindow;
+  }
+  return result;
+}
+
+function sanitizeSearchMap(search) {
+  if (!search || typeof search !== 'object') return undefined;
+  const entries = Object.entries(search)
+    .filter(([_, url]) => typeof url === 'string' && url.trim());
+  if (!entries.length) return undefined;
+  return entries.reduce((acc, [lang, url]) => {
+    acc[lang] = url.trim();
+    return acc;
+  }, {});
+}
+
+function buildKeywordSnapshotFromTags({ limit = NEWS_KEYWORD_LIMIT } = {}) {
+  if (!Array.isArray(TAG_ENTRY_LIST) || !TAG_ENTRY_LIST.length) return null;
+  const sorted = [...TAG_ENTRY_LIST]
+    .sort((a, b) => {
+      if (b.combined !== a.combined) return b.combined - a.combined;
+      if (b.score !== a.score) return b.score - a.score;
+      return b.mentions - a.mentions;
+    });
+  const seen = new Set();
+  const keywords = [];
+  for (const entry of sorted) {
+    if (keywords.length >= limit) break;
+    const en = String(entry.termEn || entry.en || '').trim();
+    const ko = String(entry.termKo || entry.ko || '').trim();
+    const key = (ko || en).toLowerCase();
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    const primaryEn = formatEnglishKeyword(en || ko);
+    const primaryKo = ko || en;
+    const search = sanitizeSearchMap({
+      ko: primaryKo ? buildNewsSearchUrl(primaryKo, 'ko') : '',
+      en: primaryEn ? buildNewsSearchUrl(primaryEn, 'en') : ''
+    });
+    const record = {
+      term: primaryEn,
+      term_ko: primaryKo,
+      score: Number(entry.combined.toFixed(3)),
+      mentions: entry.mentions
+    };
+    if (search) record.search = search;
+    keywords.push(record);
+  }
+  if (!keywords.length) return null;
+  const updatedAt = formatTagUpdatedStrings(TAG_SOURCE_META);
+  return {
+    generatedAt: new Date().toISOString(),
+    updatedAt,
+    tagMeta: {
+      source: TAG_SOURCE_PATH || TAG_FILE,
+      date: TAG_SOURCE_META.date || '',
+      window: TAG_SOURCE_META.window || '',
+      generatedAt: TAG_SOURCE_META.generatedAt || ''
+    },
+    keywords
+  };
+}
+
+async function refreshKeywordSnapshotFromTags({ limit = NEWS_KEYWORD_LIMIT } = {}) {
+  const built = buildKeywordSnapshotFromTags({ limit });
+  if (!built) return null;
+  let existing = {};
+  try { existing = JSON.parse(fs.readFileSync(KEYWORD_SNAPSHOT_PATH, 'utf8')); }
+  catch {}
+  const merged = {
+    ...existing,
+    keywords: built.keywords,
+    updatedAt: { ...(existing?.updatedAt || {}), ...built.updatedAt },
+    generatedAt: built.generatedAt,
+    timezone: existing?.timezone || 'Asia/Seoul',
+    tagMeta: built.tagMeta
+  };
+  if (existing?.tickerKeywords) merged.tickerKeywords = existing.tickerKeywords;
+  if (existing?.tickerKeywordsMeta) merged.tickerKeywordsMeta = existing.tickerKeywordsMeta;
+  if (existing?.markets) merged.markets = existing.markets;
+  await fsp.mkdir(path.dirname(KEYWORD_SNAPSHOT_PATH), { recursive: true }).catch(() => {});
+  await writeAtomic(KEYWORD_SNAPSHOT_PATH, JSON.stringify(merged, null, 2));
+  NEWS_KEYWORD_SNAPSHOT = enrichKeywordSnapshot(merged);
+  return NEWS_KEYWORD_SNAPSHOT;
+}
+
 // Import index maps (S&P 500, Nasdaq-100, KOSPI 200, KOSDAQ 100)
 let INDEX_RAW = {};
 try {
@@ -382,25 +563,7 @@ function loadNewsKeywordSnapshot() {
   try {
     const raw = fs.readFileSync(KEYWORD_SNAPSHOT_PATH, 'utf8');
     const parsed = JSON.parse(raw);
-    if (Array.isArray(parsed?.keywords)) {
-      parsed._matchers = parsed.keywords.map(entry => {
-        const ko = String(entry?.term_ko || '').trim();
-        const en = String(entry?.term || '').trim();
-        const texts = [ko, en].filter(Boolean);
-        const lowered = texts.map(t => t.toLowerCase());
-        const regexes = texts
-          .filter(t => t && t.length >= 2)
-          .map(t => {
-            try { return new RegExp(esc(t), 'i'); }
-            catch { return null; }
-          })
-          .filter(Boolean);
-        return { entry, lowered, regexes };
-      });
-    } else {
-      parsed._matchers = [];
-    }
-    NEWS_KEYWORD_SNAPSHOT = parsed;
+    NEWS_KEYWORD_SNAPSHOT = enrichKeywordSnapshot(parsed);
   } catch {
     NEWS_KEYWORD_SNAPSHOT = { keywords: [], _matchers: [] };
   }
@@ -937,55 +1100,114 @@ let TAG_ENTRY_LIST = [];
 const TAG_SCORE_MAP = new Map();
 let TAG_NEUTRAL_SCORE = 0.5;
 
-try {
-  const rawTagData = await loadJson(TAG_FILE, null);
-  if (rawTagData) {
-    let entries = [];
-    if (Array.isArray(rawTagData?.discovered_keywords) && rawTagData.discovered_keywords.length) {
-      entries = rawTagData.discovered_keywords.map(item => ({
-        en: item?.term || '',
-        ko: item?.term_ko || '',
-        mentions: item?.count || 0,
-        score: item?.score || 0
-      }));
-    } else if (Array.isArray(rawTagData?.ranked) && rawTagData.ranked.length) {
-      entries = rawTagData.ranked.map(item => ({
-        en: item?.text?.en || item?.text || item?.term || '',
-        ko: item?.text?.ko || '',
-        mentions: item?.mentions || item?.count || 0,
-        score: item?.score || 0
-      }));
-    } else if (Array.isArray(rawTagData?.tags)) {
-      entries = rawTagData.tags.map(text => ({ en: text, ko: text, mentions: 0, score: 0 }));
+let rawTagData = null;
+let lastTagError = null;
+for (const candidate of TAG_FILE_CANDIDATES) {
+  try {
+    const txt = await fsp.readFile(candidate, 'utf8');
+    rawTagData = JSON.parse(txt);
+    TAG_FILE = candidate;
+    TAG_SOURCE_PATH = candidate;
+    break;
+  } catch (err) {
+    lastTagError = err;
+  }
+}
+
+if (!rawTagData) {
+  if (lastTagError) {
+    const joined = TAG_FILE_CANDIDATES.join(', ');
+    console.warn(`[tags] failed to load ${joined}:`, lastTagError?.message || lastTagError);
+  }
+} else {
+  TAG_SOURCE_META = {
+    date: rawTagData?.date || '',
+    window: rawTagData?.window || (rawTagData?.metadata?.window || ''),
+    generatedAt: rawTagData?.metadata?.generated_at
+      || rawTagData?.metadata?.generatedAt
+      || rawTagData?.generated_at
+      || rawTagData?.generatedAt
+      || '',
+    metadata: rawTagData?.metadata || {}
+  };
+
+  let entries = [];
+  if (Array.isArray(rawTagData?.discovered_keywords) && rawTagData.discovered_keywords.length) {
+    entries = rawTagData.discovered_keywords.map(item => ({
+      en: item?.term || '',
+      ko: item?.term_ko || '',
+      mentions: item?.mentions || item?.count || 0,
+      score: item?.score ?? item?.significance_score ?? item?.significance ?? 0
+    }));
+  } else if (Array.isArray(rawTagData?.ranked) && rawTagData.ranked.length) {
+    entries = rawTagData.ranked.map(item => ({
+      en: item?.text?.en || item?.text || item?.term || '',
+      ko: item?.text?.ko || '',
+      mentions: item?.mentions || item?.count || 0,
+      score: item?.score ?? item?.significance_score ?? item?.significance ?? 0
+    }));
+  } else if (Array.isArray(rawTagData?.tags)) {
+    entries = rawTagData.tags.map(text => ({ en: text, ko: text, mentions: 0, score: 0 }));
+  }
+
+  let maxMentions = 0;
+  entries.forEach(entry => {
+    const mentions = Number(entry?.mentions) || 0;
+    if (mentions > maxMentions) maxMentions = mentions;
+  });
+
+  TAG_ENTRY_LIST = entries.map(entry => {
+    const enRaw = String(entry?.en ?? entry?.term ?? '').trim();
+    const koRaw = String(entry?.ko ?? '').trim();
+    const en = formatEnglishKeyword(enRaw);
+    const ko = koRaw;
+    const keys = [...expandTagKeys(en || enRaw), ...expandTagKeys(ko)];
+    if (!keys.length) return null;
+    const mentions = Math.max(0, Number(entry?.mentions) || 0);
+    const rawScore = Number(entry?.score ?? 0);
+    let strength = Number.isFinite(rawScore) ? rawScore : 0;
+    if (strength > 1) strength = clamp01(strength / 100);
+    else strength = clamp01(strength);
+    const freqNorm = maxMentions > 0 ? clamp01(mentions / maxMentions) : strength;
+    const combined = clamp01((TAG_STRENGTH_WEIGHT * strength) + (TAG_FREQ_WEIGHT * freqNorm));
+    const tokens = [...new Set(keys.flatMap(k => k.split(' ').filter(part => part.length >= 4)))];
+    return {
+      keys,
+      mentions,
+      strength,
+      freqNorm,
+      combined,
+      norm: keys[0],
+      tokens,
+      termEn: en,
+      termKo: ko,
+      en,
+      ko,
+      score: strength,
+      rawScore
+    };
+  }).filter(Boolean);
+
+  TAG_ENTRY_LIST.forEach(item => {
+    for (const key of item.keys) {
+      if (!TAG_SCORE_MAP.has(key)) TAG_SCORE_MAP.set(key, item);
     }
-    let maxMentions = 0;
-    entries.forEach(entry => {
-      const mentions = Number(entry?.mentions) || 0;
-      if (mentions > maxMentions) maxMentions = mentions;
-    });
-    TAG_ENTRY_LIST = entries.map(entry => {
-      const en = String(entry?.en ?? entry?.term ?? '').trim();
-      const ko = String(entry?.ko ?? '').trim();
-      const keys = [...expandTagKeys(en), ...expandTagKeys(ko)];
-      if (!keys.length) return null;
-      const mentions = Math.max(0, Number(entry?.mentions) || 0);
-      const strength = clamp01(Number(entry?.score ?? 0));
-      const freqNorm = maxMentions > 0 ? clamp01(mentions / maxMentions) : strength;
-      const combined = clamp01((TAG_STRENGTH_WEIGHT * strength) + (TAG_FREQ_WEIGHT * freqNorm));
-      const tokens = [...new Set(keys.flatMap(k => k.split(' ').filter(part => part.length >= 4)))];
-      return { keys, mentions, strength, freqNorm, combined, norm: keys[0], tokens };
-    }).filter(Boolean);
-    TAG_ENTRY_LIST.forEach(item => {
-      for (const key of item.keys) {
-        if (!TAG_SCORE_MAP.has(key)) TAG_SCORE_MAP.set(key, item);
+  });
+  if (TAG_ENTRY_LIST.length) {
+    TAG_NEUTRAL_SCORE = TAG_ENTRY_LIST.reduce((sum, item) => sum + item.combined, 0) / TAG_ENTRY_LIST.length;
+  }
+
+  if (!DRY_RUN) {
+    try {
+      const snapshot = await refreshKeywordSnapshotFromTags({ limit: NEWS_KEYWORD_LIMIT });
+      if (snapshot?.keywords?.length) {
+        const rel = path.relative(process.cwd(), KEYWORD_SNAPSHOT_PATH) || KEYWORD_SNAPSHOT_PATH;
+        console.log(`[tags] wrote ${rel} (${snapshot.keywords.length} keywords)`);
       }
-    });
-    if (TAG_ENTRY_LIST.length) {
-      TAG_NEUTRAL_SCORE = TAG_ENTRY_LIST.reduce((sum, item) => sum + item.combined, 0) / TAG_ENTRY_LIST.length;
+    } catch (err) {
+      console.warn('[tags] failed to refresh newsKeywords.json:', err?.message || err);
     }
   }
-} catch (err) {
-  console.warn(`[tags] failed to load ${TAG_FILE}:`, err?.message || err);
 }
 
 function findTagMatch(normTerm) {


### PR DESCRIPTION
## Summary
- mirror the keyword highlight markup, translations, and client logic into src/template.html so future builds match the current stocks page
- cap the rendered news keyword list to the top 10 entries and keep translations in sync across languages
- refresh the FX ticker styling/scripts in the template to align with stocks.html, including the scrollable anchor behavior

## Testing
- node tests/apple_association.test.js

------
https://chatgpt.com/codex/tasks/task_b_68df54337550832a8acf4415fb0e81f1