### PR TITLE
Adjust stock recommendations workflow schedule

### DIFF
--- a/.github/workflows/stock-recs.yml
+++ b/.github/workflows/stock-recs.yml
@@ -5,8 +5,8 @@ name: Build & Publish Stock Recommendations
 on:
   workflow_dispatch:
   schedule:
-    # Every 5 hours (cron is UTC; cadence doesn't depend on timezone)
-    - cron: '0 */5 * * *'
+    # Every 6 hours (cron is UTC; runs 4 times daily)
+    - cron: '0 */6 * * *'
 
 jobs:
   build-publish:


### PR DESCRIPTION
## Summary
- update the stock recommendations workflow cron to run every six hours for four daily executions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dfe702bbc0832ab2960f28bcb7e916