### PR TITLE
Ensure news cache build refreshes tags

### DIFF
--- a/src/news/fetchByTicker.js
+++ b/src/news/fetchByTicker.js
@@ -5569,7 +5569,20 @@ export async function buildNewsCachesCli() {
   console.log(`[news-caches] wrote ${NEWS_FEATURES_FILE} and ${NAVER_TRENDS_FILE}`);
 
   // 3) Ticker keyword snapshot merged into newsKeywords.json
-  const tagSnapshotForKeywords = readJsonSafe(TAG_OUTPUT_FILE) || null;
+  let tagSnapshotForKeywords = null;
+
+  try {
+    const latestTags = await writeSignificantPhrasesJson({ outputPath: TAG_OUTPUT_FILE });
+    if (latestTags) {
+      tagSnapshotForKeywords = latestTags;
+    }
+  } catch (err) {
+    console.warn('[news-caches] failed to build significant phrase tags:', err?.message || err);
+  }
+
+  if (!tagSnapshotForKeywords) {
+    tagSnapshotForKeywords = readJsonSafe(TAG_OUTPUT_FILE) || null;
+  }
   const keywordPayload = buildNewsKeywords(collectedArticles, { tagSnapshot: tagSnapshotForKeywords });
   const tickerCount = Object.keys(keywordPayload.tickers).length;
   if (tickerCount) {


### PR DESCRIPTION
## Summary
- trigger the significant phrase builder when running the news cache CLI so tags.json is refreshed
- fall back to the previous snapshot if tag generation fails

## Testing
- `npm test -- --runInBand`


------
https://chatgpt.com/codex/tasks/task_b_68e0c6f842e4832ab6f9cbe4cfbbaf42