### PR TITLE
Default stocks page to Korean

### DIFF
--- a/stocks.html
+++ b/stocks.html
@@ -243,7 +243,7 @@
       }
     };
 
-    let currentLang = (navigator.language || 'en').startsWith('ko') ? 'ko' : 'en';
+    let currentLang = 'ko';
     let visitData = null;
     let keywordSnapshot = null;
     let keywordLoadFailed = false;


### PR DESCRIPTION
## Summary
- force the stocks page to initialize in Korean rather than auto-detecting browser language

## Testing
- node tests/apple_association.test.js

------
https://chatgpt.com/codex/tasks/task_b_68e12035b314832aa3dd21f4c40e91f4