### PR TITLE
chore: refresh keyword snapshot caches

### DIFF
--- a/.github/workflows/stock-recs.yml
+++ b/.github/workflows/stock-recs.yml
@@ -385,8 +385,15 @@ jobs:
       - name: Build significance-based keyword snapshot
         env:
           MARKET_TAG_FILE: stocks/data/tags.json
+          KEYWORD_SIMILARITY_THRESHOLD: "0.6"
+          KEYWORDS_PER_CATEGORY: "4"
+          NEWS_TTL_MS: "600000"
         run: |
           set -Eeuo pipefail
+          # Clear stale caches to force fresh data collection
+          rm -rf cache/news-*.json
+          find data/articles -name "*.json" -mtime +0 -delete 2>/dev/null || true
+          # Generate fresh keywords
           node src/news/fetchByTicker.js --significant-phrases
           test -s stocks/data/tags.json
 


### PR DESCRIPTION
## Summary
- clear stale news caches and old article JSON before generating tags.json
- ensure keyword snapshot step sets similarity, category, and TTL overrides for fetchByTicker

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e222387e1c832a81e696b8f091c472