### PR TITLE
Add price context to stock recommendations

### DIFF
--- a/fetchStockInfo.js
+++ b/fetchStockInfo.js
@@ -91,6 +91,10 @@ const NAVER_ENABLED = Boolean(NAVER_CLIENT_ID && NAVER_CLIENT_SECRET);
 const NEWS_TTL_MS = Number(process.env.NEWS_TTL_MS || 12 * 60 * 60 * 1000);
 
 const sleep = ms => new Promise(r => setTimeout(r, ms));
+const DAY_MS = 24 * 60 * 60 * 1000;
+const PRICE_LOOKBACK_DAYS = Number(process.env.PRICE_LOOKBACK_DAYS || 365);
+const PRICE_WINDOW_DAYS = Number(process.env.PRICE_WINDOW_DAYS || 10);
+const PRICE_HISTORY_CONCURRENCY = Number(process.env.PRICE_HISTORY_CONCURRENCY || 3);
 
 // 429-aware delay
 let consecutive429 = 0;
@@ -130,6 +134,142 @@ function noteStatus(err) {
     }
   } else {
     consecutive429 = 0;
+  }
+}
+
+async function fetchHistoricalPriceYahoo(ticker, targetDate) {
+  const targetMs = targetDate.getTime();
+  const period1 = Math.floor((targetMs - PRICE_WINDOW_DAYS * DAY_MS) / 1000);
+  const period2 = Math.floor((targetMs + PRICE_WINDOW_DAYS * DAY_MS) / 1000);
+  if (!(Number.isFinite(period1) && Number.isFinite(period2) && period2 > period1)) {
+    throw new Error('invalid period for historical price');
+  }
+
+  const url = `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(ticker)}?interval=1d&period1=${period1}&period2=${period2}`;
+  const res = await fetchWithRetry(url, { headers: HEADERS_JSON });
+  const json = await res.json();
+  if (json?.chart?.error) {
+    throw new Error(json.chart.error?.description || 'yahoo chart error');
+  }
+  const result = json?.chart?.result?.[0];
+  if (!result) throw new Error('missing chart result');
+  const timestamps = Array.isArray(result.timestamp) ? result.timestamp : [];
+  const closes = Array.isArray(result.indicators?.quote?.[0]?.close)
+    ? result.indicators.quote[0].close
+    : [];
+  if (!timestamps.length || !closes.length) throw new Error('empty historical data');
+  const targetSec = Math.floor(targetMs / 1000);
+  let bestIdx = -1;
+  let bestDiff = Infinity;
+  for (let i = 0; i < timestamps.length; i++) {
+    const price = Number(closes[i]);
+    if (!Number.isFinite(price)) continue;
+    const diff = Math.abs(timestamps[i] - targetSec);
+    if (diff < bestDiff) {
+      bestDiff = diff;
+      bestIdx = i;
+    }
+  }
+  if (bestIdx === -1) throw new Error('no valid historical price');
+  return { price: Number(closes[bestIdx]), timestamp: timestamps[bestIdx] * 1000 };
+}
+
+async function fetchHistoricalPricesBatch(tickers, targetDate) {
+  const unique = [...new Set((tickers || []).filter(Boolean))];
+  if (!unique.length) return {};
+  const queue = unique.slice();
+  const out = {};
+  const workers = Math.min(Math.max(1, PRICE_HISTORY_CONCURRENCY), queue.length);
+
+  async function worker() {
+    while (true) {
+      const sym = queue.shift();
+      if (!sym) break;
+      try {
+        const hist = await fetchHistoricalPriceYahoo(sym, targetDate);
+        if (hist) out[sym] = hist;
+      } catch (e) {
+        console.warn(`[PRICE] ${sym} 1y lookup failed: ${e.message}`);
+      }
+      await sleep(150);
+    }
+  }
+
+  await Promise.all(Array.from({ length: workers }, worker));
+  return out;
+}
+
+function deriveCurrency(ticker) {
+  if (/\.K[QS]$/i.test(ticker || '')) return 'KRW';
+  return 'USD';
+}
+
+async function attachPrices(data) {
+  const tickers = new Set();
+  for (const market of Object.keys(data || {})) {
+    for (const bucket of ['safe', 'aggressive']) {
+      const entries = data[market]?.[bucket];
+      if (!Array.isArray(entries)) continue;
+      for (const entry of entries) {
+        if (entry?.ticker) tickers.add(entry.ticker);
+      }
+    }
+  }
+  const list = [...tickers].filter(Boolean);
+  if (!list.length) return;
+
+  const now = new Date();
+  let quotes = [];
+  try {
+    quotes = await fetchByTickers(list);
+  } catch (e) {
+    console.warn('[PRICE] failed to fetch quotes:', e.message || e);
+  }
+  const priceMap = {};
+  for (const q of quotes) {
+    if (!q?.symbol) continue;
+    const symbol = q.symbol;
+    const current = Number.isFinite(q.regularMarketPrice)
+      ? Number(q.regularMarketPrice)
+      : (Number.isFinite(q.regularMarketPreviousClose) ? Number(q.regularMarketPreviousClose) : null);
+    const prevClose = Number.isFinite(q.regularMarketPreviousClose)
+      ? Number(q.regularMarketPreviousClose)
+      : null;
+    priceMap[symbol] = {
+      currentPrice: current,
+      previousClose: prevClose,
+      priceAsOf: now.toISOString(),
+      currency: deriveCurrency(symbol)
+    };
+  }
+
+  const targetDate = new Date(now.getTime() - PRICE_LOOKBACK_DAYS * DAY_MS);
+  const historical = await fetchHistoricalPricesBatch(list, targetDate);
+  for (const [symbol, info] of Object.entries(historical)) {
+    if (!info) continue;
+    if (!priceMap[symbol]) {
+      priceMap[symbol] = { priceAsOf: now.toISOString(), currency: deriveCurrency(symbol) };
+    }
+    if (Number.isFinite(info.price)) priceMap[symbol].price1yAgo = Number(info.price);
+    if (Number.isFinite(info.timestamp)) priceMap[symbol].price1yDate = new Date(info.timestamp).toISOString();
+  }
+
+  for (const market of Object.keys(data || {})) {
+    for (const bucket of ['safe', 'aggressive']) {
+      const entries = data[market]?.[bucket];
+      if (!Array.isArray(entries)) continue;
+      for (const entry of entries) {
+        const symbol = entry?.ticker;
+        const info = symbol ? priceMap[symbol] : null;
+        if (!info) continue;
+        if (Number.isFinite(info.currentPrice)) entry.currentPrice = info.currentPrice;
+        else if (Number.isFinite(info.previousClose)) entry.currentPrice = info.previousClose;
+        if (Number.isFinite(info.price1yAgo)) entry.price1yAgo = info.price1yAgo;
+        if (info.price1yDate) entry.price1yDate = info.price1yDate;
+        if (info.priceAsOf) entry.priceAsOf = info.priceAsOf;
+        if (info.currency) entry.priceCurrency = info.currency;
+      }
+    }
   }
 }
 
@@ -911,6 +1051,12 @@ async function tryFetchAndEnrich() {
 
       data[market][group] = updated;
     }
+  }
+
+  try {
+    await attachPrices(data);
+  } catch (e) {
+    console.warn('[PRICE] Failed to enrich price data:', e?.message || e);
   }
 
   return { data, successCount };

--- a/src/template.html
+++ b/src/template.html
@@ -209,7 +209,9 @@
         updated: '업데이트: ',
         visitsToday: '오늘 방문: {daily} | 총 방문: {total}',
         noPicks: 'No picks available',
-        scoreSuffix: '매력점수'
+        scoreSuffix: '매력점수',
+        priceNow: '현재가',
+        priceYearAgo: '1년 전'
       },
       en: {
         title: 'Daily Stock Report Automation',
@@ -238,7 +240,9 @@
         updated: 'Updated: ',
         visitsToday: 'Visits today: {daily} | Total: {total}',
         noPicks: 'No picks available',
-        scoreSuffix: 'Attractiveness'
+        scoreSuffix: 'Attractiveness',
+        priceNow: 'Price',
+        priceYearAgo: '1Y Ago'
       }
     };
 
@@ -258,6 +262,50 @@
         .replace(/>/g, '&gt;')
         .replace(/"/g, '&quot;')
         .replace(/'/g, '&#39;');
+    }
+
+    function isKRTicker(ticker) {
+      return /\.K[QS]$/i.test(ticker || '');
+    }
+
+    function formatPriceValue(value, ticker) {
+      if (!Number.isFinite(value)) return null;
+      const isKR = isKRTicker(ticker);
+      const locale = isKR ? 'ko-KR' : 'en-US';
+      const currency = isKR ? 'KRW' : 'USD';
+      const options = {
+        style: 'currency',
+        currency,
+        maximumFractionDigits: isKR ? 0 : 2,
+        minimumFractionDigits: isKR ? 0 : 2
+      };
+      if (isKR) options.minimumFractionDigits = 0;
+      try {
+        return new Intl.NumberFormat(locale, options).format(value);
+      } catch {
+        return value.toLocaleString(locale);
+      }
+    }
+
+    function buildPriceText(item) {
+      if (!item) return '';
+      const now = formatPriceValue(item.currentPrice, item.ticker);
+      const past = formatPriceValue(item.price1yAgo, item.ticker);
+      const parts = [];
+      if (now) {
+        parts.push(`${translations[currentLang].priceNow} ${now}`);
+      }
+      if (past) {
+        let label = `${translations[currentLang].priceYearAgo} ${past}`;
+        if (item.price1yDate) {
+          try {
+            const locale = currentLang === 'ko' ? 'ko-KR' : 'en-US';
+            label += ` (${new Date(item.price1yDate).toLocaleDateString(locale)})`;
+          } catch {}
+        }
+        parts.push(label);
+      }
+      return parts.join(' / ');
     }
 
     function normalizeTermKey(term) {
@@ -796,7 +844,12 @@
             const name = FULL_NAME_MAP[item.name] || item.name;
             const link = item.searchUrl ? `<a href="${item.searchUrl}" target="_blank" rel="noopener">${name}</a>` : name;
             const sector = item.sector ? `<span class="sector">${item.sector}</span>` : '';
-            const score = item.score != null ? `<span class="score">${item.score}</span>` : '';
+            const priceText = buildPriceText(item);
+            const priceMarkup = priceText ? `<span class="price">${escapeHtml(priceText)}</span>` : '';
+            const metaParts = [];
+            if (item.score != null) metaParts.push(escapeHtml(String(item.score)));
+            if (priceMarkup) metaParts.push(priceMarkup);
+            const score = metaParts.length ? `<span class="score">${metaParts.join(' · ')}</span>` : '';
             return `<li>${link}${sector}${score}</li>`;
           });
           const list = itemsArr.length ? itemsArr.join('') : `<li class="empty">${translations[currentLang].noPicks}</li>`;

--- a/stocks.css
+++ b/stocks.css
@@ -166,6 +166,11 @@ tr:hover {
   font-size: 0.85em;
 }
 
+.portfolio-group .score .price {
+  color: #1f2937;
+  font-weight: 500;
+}
+
 .portfolio-group .score-suffix {
   color: #6b7280;
   font-size: 0.85em;

--- a/stocks.html
+++ b/stocks.html
@@ -210,7 +210,9 @@
         updated: '업데이트: ',
         visitsToday: '오늘 방문: {daily} | 총 방문: {total}',
         noPicks: 'No picks available',
-        scoreSuffix: '매력점수'
+        scoreSuffix: '매력점수',
+        priceNow: '현재가',
+        priceYearAgo: '1년 전'
       },
       en: {
         title: 'Daily Stock Report Automation',
@@ -239,7 +241,9 @@
         updated: 'Updated: ',
         visitsToday: 'Visits today: {daily} | Total: {total}',
         noPicks: 'No picks available',
-        scoreSuffix: 'Attractiveness'
+        scoreSuffix: 'Attractiveness',
+        priceNow: 'Price',
+        priceYearAgo: '1Y Ago'
       }
     };
 
@@ -259,6 +263,50 @@
         .replace(/>/g, '&gt;')
         .replace(/"/g, '&quot;')
         .replace(/'/g, '&#39;');
+    }
+
+    function isKRTicker(ticker) {
+      return /\.K[QS]$/i.test(ticker || '');
+    }
+
+    function formatPriceValue(value, ticker) {
+      if (!Number.isFinite(value)) return null;
+      const isKR = isKRTicker(ticker);
+      const locale = isKR ? 'ko-KR' : 'en-US';
+      const currency = isKR ? 'KRW' : 'USD';
+      const options = {
+        style: 'currency',
+        currency,
+        maximumFractionDigits: isKR ? 0 : 2,
+        minimumFractionDigits: isKR ? 0 : 2
+      };
+      if (isKR) options.minimumFractionDigits = 0;
+      try {
+        return new Intl.NumberFormat(locale, options).format(value);
+      } catch {
+        return value.toLocaleString(locale);
+      }
+    }
+
+    function buildPriceText(item) {
+      if (!item) return '';
+      const now = formatPriceValue(item.currentPrice, item.ticker);
+      const past = formatPriceValue(item.price1yAgo, item.ticker);
+      const parts = [];
+      if (now) {
+        parts.push(`${translations[currentLang].priceNow} ${now}`);
+      }
+      if (past) {
+        let label = `${translations[currentLang].priceYearAgo} ${past}`;
+        if (item.price1yDate) {
+          try {
+            const locale = currentLang === 'ko' ? 'ko-KR' : 'en-US';
+            label += ` (${new Date(item.price1yDate).toLocaleDateString(locale)})`;
+          } catch {}
+        }
+        parts.push(label);
+      }
+      return parts.join(' / ');
     }
 
     function normalizeTermKey(term) {
@@ -837,7 +885,12 @@
             const name = FULL_NAME_MAP[item.name] || item.name;
             const link = item.searchUrl ? `<a href="${item.searchUrl}" target="_blank" rel="noopener">${name}</a>` : name;
             const sector = item.sector ? `<span class="sector">${item.sector}</span>` : '';
-            const score = item.score != null ? `<span class="score">${item.score}</span>` : '';
+            const priceText = buildPriceText(item);
+            const priceMarkup = priceText ? `<span class="price">${escapeHtml(priceText)}</span>` : '';
+            const metaParts = [];
+            if (item.score != null) metaParts.push(escapeHtml(String(item.score)));
+            if (priceMarkup) metaParts.push(priceMarkup);
+            const score = metaParts.length ? `<span class="score">${metaParts.join(' · ')}</span>` : '';
             return `<li>${link}${sector}${score}</li>`;
           });
           const list = itemsArr.length ? itemsArr.join('') : `<li class="empty">${translations[currentLang].noPicks}</li>`;


### PR DESCRIPTION
## Summary
- enrich `fetchStockInfo` with current and 1-year-ago pricing for recommended tickers when building `recommendations.json`
- display localized price information next to the attractiveness score in the stocks page and underlying template
- tweak styling to keep price text legible alongside the existing score badge

## Testing
- node tests/apple_association.test.js

------
https://chatgpt.com/codex/tasks/task_b_68e358608190832a97054b251ad0e4e6