### PR TITLE
Add optional finance keyword analysis step

### DIFF
--- a/.github/workflows/stock-recs.yml
+++ b/.github/workflows/stock-recs.yml
@@ -411,6 +411,19 @@ jobs:
           echo "tags.json total tags:"
           jq -r '.total_phrases // .total // (.discovered_keywords | length) // "missing"' stocks/data/tags.json
 
+      # Optional: run finance keyword analysis, but keep tags.json as the main output
+      - name: Analyze tags.json with finance dictionary (optional)
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          if [ ! -s stocks/data/tags.json ]; then
+            echo "❌ tags.json missing; skipping finance analysis"
+            exit 0
+          fi
+          echo "▶ Running extractKeywords.js for analysis (does not overwrite tags.json)"
+          node stocks/extractKeywords.js || echo "⚠️ extractKeywords.js failed (non-blocking)"
+
       - name: Prune cache directory
         env:
           CACHE_LIMIT: 1000


### PR DESCRIPTION
## Summary
- add a non-blocking workflow step to analyze tags.json with the finance dictionary for additional insights

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e39ed39fbc832a8e9e7fe468a94f33