### PR TITLE
Enhance stopword learning and fix workflow script indentation

### DIFF
--- a/.github/workflows/stock-recs.yml
+++ b/.github/workflows/stock-recs.yml
@@ -397,17 +397,17 @@ jobs:
           find data/articles -name "*.json" -mtime +0 -delete 2>/dev/null || true
           # Generate fresh keywords
           node <<'NODE'
-const { createRequire } = require('module');
-const req = createRequire(process.cwd() + '/');
-const fetchShim = (...args) => {
-  if (typeof globalThis.fetch === 'function') {
-    return globalThis.fetch(...args);
-  }
-  return import('node-fetch').then(mod => mod.default(...args));
-};
-req.cache[req.resolve('node-fetch')] = { exports: fetchShim };
-req('./stocks/stockKeywords.js');
-NODE
+          const { createRequire } = require('module');
+          const req = createRequire(process.cwd() + '/');
+          const fetchShim = (...args) => {
+            if (typeof globalThis.fetch === 'function') {
+              return globalThis.fetch(...args);
+            }
+            return import('node-fetch').then(mod => mod.default(...args));
+          };
+          req.cache[req.resolve('node-fetch')] = { exports: fetchShim };
+          req('./stocks/stockKeywords.js');
+          NODE
           test -s data/tags.json
 
       - name: Verify market tag snapshot

--- a/stocks/stockKeywords.js
+++ b/stocks/stockKeywords.js
@@ -13,6 +13,8 @@ const NAVER_CLIENT_SECRET = process.env.NAVER_CLIENT_SECRET;
 const OUTPUT_PATH = "./data/tags.json";
 const FINANCE_DICT_PATH = "./data/finance_keywords.json";
 const STOPWORDS_PATH = "./data/stopwords.txt";
+const STOPWORD_STATS_PATH = "./data/stopword_stats.json";
+const PRUNE_INTERVAL = 10; // every 10 runs
 const ARTICLE_DIRS = ["./news", "./articles"];
 const LOOKBACK_HOURS = 12;
 const KEYWORD_LIMIT = 30;
@@ -39,6 +41,21 @@ function loadStopwords() {
   ]);
 }
 const STOPWORDS = loadStopwords();
+
+function loadStopwordStats() {
+  if (fs.existsSync(STOPWORD_STATS_PATH)) {
+    try {
+      return JSON.parse(fs.readFileSync(STOPWORD_STATS_PATH, "utf8"));
+    } catch {
+      return { runs: 0, counts: {} };
+    }
+  }
+  return { runs: 0, counts: {} };
+}
+
+function saveStopwordStats(stats) {
+  fs.writeFileSync(STOPWORD_STATS_PATH, JSON.stringify(stats, null, 2));
+}
 
 function cosineSimilarity(a, b) {
   const dot = a.reduce((s, v, i) => s + v * b[i], 0);
@@ -121,6 +138,7 @@ function collectArticles() {
 
 function computeTfIdfPhrases(texts, topN = 100) {
   const tf = {}, df = {};
+  const tokenFreq = {};
   texts.forEach((text) => {
     const phrases = extractPhrasesFromText(text);
     const seen = new Set();
@@ -131,6 +149,14 @@ function computeTfIdfPhrases(texts, topN = 100) {
         seen.add(p);
       }
     });
+    const tokens = text
+      .replace(/[^\p{L}\p{N}\s]/gu, " ")
+      .toLowerCase()
+      .split(/\s+/)
+      .filter((t) => t.length > 1);
+    tokens.forEach((token) => {
+      tokenFreq[token] = (tokenFreq[token] || 0) + 1;
+    });
   });
   const N = texts.length || 1;
   const scores = Object.entries(tf).map(([phrase, freq]) => {
@@ -138,6 +164,46 @@ function computeTfIdfPhrases(texts, topN = 100) {
     return [phrase, freq * idf];
   });
   scores.sort((a, b) => b[1] - a[1]);
+
+  // --- Learn new stopwords and maintain stats ---
+  const stats = loadStopwordStats();
+  stats.runs += 1;
+
+  // count token frequency for this run
+  Object.entries(tokenFreq).forEach(([t, f]) => {
+    stats.counts[t] = (stats.counts[t] || 0) + f;
+  });
+
+  // detect frequent new tokens
+  const avgFreq =
+    Object.values(tokenFreq).reduce((a, b) => a + b, 0) /
+    Object.keys(tokenFreq).length;
+  const frequent = Object.entries(tokenFreq)
+    .filter(([_, f]) => f > avgFreq * 3)
+    .map(([t]) => t)
+    .filter((t) => !STOPWORDS.has(t));
+
+  if (frequent.length > 0) {
+    console.log(`🧠 Learned ${frequent.length} new stopwords`);
+    fs.appendFileSync(STOPWORDS_PATH, "\n" + frequent.join("\n"));
+    frequent.forEach((t) => STOPWORDS.add(t));
+  }
+
+  // prune rarely used stopwords every N runs
+  if (stats.runs % PRUNE_INTERVAL === 0) {
+    const threshold = 2;
+    const surviving = [...STOPWORDS].filter((t) => (stats.counts[t] || 0) >= threshold);
+    fs.writeFileSync(STOPWORDS_PATH, surviving.join("\n"));
+    console.log(`✂️ Pruned stopwords: ${STOPWORDS.size - surviving.length}`);
+    STOPWORDS.clear();
+    surviving.forEach((t) => STOPWORDS.add(t));
+    // reset stats for next cycle
+    stats.runs = 0;
+    stats.counts = {};
+  }
+
+  saveStopwordStats(stats);
+
   return scores.slice(0, topN).map(([term, score]) => ({
     term,
     term_ko: term,


### PR DESCRIPTION
## Summary
- add persistent stopword statistics and pruning helpers to the TF-IDF keyword generator
- track per-run token frequencies to learn and prune stopwords automatically
- fix indentation in the stock recommendations workflow inline node script to avoid YAML parsing issues

## Testing
- node tests/apple_association.test.js

------
https://chatgpt.com/codex/tasks/task_b_68e6126d4fd8832ab906aa8f15f8c711