### PR TITLE
Add keyword trend CSV export and link keywords page

### DIFF
--- a/.github/workflows/stock-recs.yml
+++ b/.github/workflows/stock-recs.yml
@@ -223,8 +223,13 @@ jobs:
             exit 0
           fi
 
-          if ! git status --short -- data/tags.json | grep -q 'data/tags.json'; then
-            echo "No tag updates detected"
+          files=(data/tags.json)
+          if [ -f data/keyword_trends.csv ]; then
+            files+=(data/keyword_trends.csv)
+          fi
+
+          if ! git status --short -- "${files[@]}" | grep -q '.'; then
+            echo "No tag or keyword trend updates detected"
             exit 0
           fi
 
@@ -235,8 +240,8 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git fetch origin "$branch"
           git pull --rebase origin "$branch"
-          git add data/tags.json
-          git commit -m "chore: update market tags"
+          git add "${files[@]}"
+          git commit -m "chore: update market tags and keyword trends"
           git push origin "HEAD:$branch"
 
       - name: "Preflight: DeepSearch"

--- a/stocks.html
+++ b/stocks.html
@@ -59,6 +59,14 @@
     margin-bottom: 0.75rem;
     font-size: 1.3rem;
   }
+  .keyword-box h3 a {
+    color: inherit;
+    text-decoration: none;
+  }
+  .keyword-box h3 a:hover,
+  .keyword-box h3 a:focus-visible {
+    text-decoration: underline;
+  }
   .keyword-list {
     list-style: none;
     padding: 0;
@@ -165,7 +173,7 @@
     </section>
 
     <section id="keywordHighlights" class="keyword-box" aria-labelledby="keywordTitle">
-      <h3 id="keywordTitle" data-i18n="keywordTitle">오늘의 키워드</h3>
+      <h3 id="keywordTitle"><a data-i18n="keywordTitle" href="stocks/keywords.html">오늘의 키워드</a></h3>
       <div id="keywordUpdated" class="last-updated"></div>
       <ul id="keywordList" class="keyword-list"></ul>
       <div id="keywordError" class="error" role="alert" style="display:none;"></div>

--- a/stocks/stockKeywords.js
+++ b/stocks/stockKeywords.js
@@ -338,6 +338,17 @@ async function generateKeywords() {
   if (trendLog.length > 10) trendLog = trendLog.slice(-10);
   fs.writeFileSync(TREND_LOG_PATH, JSON.stringify(trendLog, null, 2));
   console.log("🪄 Updated trend_log.json");
+
+  // --- Export to CSV ---
+  const CSV_PATH = "./data/keyword_trends.csv";
+  const csvLines = ["date,term,score"];
+  trendLog.forEach((entry) => {
+    entry.top_terms.forEach((t) => {
+      csvLines.push(`${entry.date},"${t.term}",${t.score}`);
+    });
+  });
+  fs.writeFileSync(CSV_PATH, csvLines.join("\n"));
+  console.log("📊 Exported keyword_trends.csv");
 }
 
 generateKeywords().catch((err) => console.error("❌ Generation failed:", err));


### PR DESCRIPTION
## Summary
- make the "Today's Keyword" header link to the keyword archive and adjust its styling
- export the keyword trend log to a CSV file when generating keywords
- update the stock recommendations workflow to commit the generated CSV with tag updates

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e61f5479f4832a96cac1676f614c47