### PR TITLE
Fix YAML formatting in stock-recs workflow

### DIFF
--- a/.github/workflows/stock-recs.yml
+++ b/.github/workflows/stock-recs.yml
@@ -494,54 +494,54 @@ jobs:
           set -Eeuo pipefail
           mkdir -p stocks
           if [ ! -f stocks/keywords.html ]; then
-            cat > stocks/keywords.html <<'EOF'
-<!DOCTYPE html>
-<html lang="ko">
-<head>
-  <meta charset="UTF-8" />
-  <title>📈 Keyword Trends</title>
-  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-  <style>
-    body { font-family: sans-serif; margin: 20px; background: #fafafa; }
-    canvas { width: 100%; max-width: 900px; height: 450px; }
-  </style>
-</head>
-<body>
-  <h2>📊 Finance Keyword Trend Tracker</h2>
-  <canvas id="trendChart"></canvas>
-  <script>
-    async function drawChart() {
-      const resp = await fetch("../data/keyword_trends.csv");
-      const text = await resp.text();
-      const rows = text.trim().split("\n").slice(1).map(r => r.split(","));
-      const dates = [...new Set(rows.map(r => r[0]))];
-      const termGroups = {};
-      rows.forEach(([date, term, score]) => {
-        if (!termGroups[term]) termGroups[term] = {};
-        termGroups[term][date] = parseFloat(score);
-      });
-      const colors = ["#3366cc","#dc3912","#ff9900","#109618","#990099","#0099c6","#dd4477"];
-      const datasets = Object.keys(termGroups).slice(0,7).map((term,i)=>({
-        label: term,
-        data: dates.map(d=>termGroups[term][d]||null),
-        borderColor: colors[i%colors.length],
-        fill: false,
-        tension: 0.2
-      }));
-      new Chart(document.getElementById("trendChart"), {
-        type: "line",
-        data: { labels: dates, datasets },
-        options: {
-          scales: { y: { title: { display: true, text: "Score" } } },
-          plugins: { legend: { position: "bottom" } }
-        }
-      });
-    }
-    drawChart();
-  </script>
-</body>
-</html>
-EOF
+            python3 -c 'from pathlib import Path; from textwrap import dedent; Path("stocks/keywords.html").write_text(dedent("""\
+                <!DOCTYPE html>
+                <html lang="ko">
+                <head>
+                  <meta charset="UTF-8" />
+                  <title>📈 Keyword Trends</title>
+                  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+                  <style>
+                    body { font-family: sans-serif; margin: 20px; background: #fafafa; }
+                    canvas { width: 100%; max-width: 900px; height: 450px; }
+                  </style>
+                </head>
+                <body>
+                  <h2>📊 Finance Keyword Trend Tracker</h2>
+                  <canvas id="trendChart"></canvas>
+                  <script>
+                    async function drawChart() {
+                      const resp = await fetch("../data/keyword_trends.csv");
+                      const text = await resp.text();
+                      const rows = text.trim().split("\n").slice(1).map(r => r.split(","));
+                      const dates = [...new Set(rows.map(r => r[0]))];
+                      const termGroups = {};
+                      rows.forEach(([date, term, score]) => {
+                        if (!termGroups[term]) termGroups[term] = {};
+                        termGroups[term][date] = parseFloat(score);
+                      });
+                      const colors = ["#3366cc","#dc3912","#ff9900","#109618","#990099","#0099c6","#dd4477"];
+                      const datasets = Object.keys(termGroups).slice(0,7).map((term,i)=>({
+                        label: term,
+                        data: dates.map(d=>termGroups[term][d]||null),
+                        borderColor: colors[i%colors.length],
+                        fill: false,
+                        tension: 0.2
+                      }));
+                      new Chart(document.getElementById("trendChart"), {
+                        type: "line",
+                        data: { labels: dates, datasets },
+                        options: {
+                          scales: { y: { title: { display: true, text: "Score" } } },
+                          plugins: { legend: { position: "bottom" } }
+                        }
+                      });
+                    }
+                    drawChart();
+                  </script>
+                </body>
+                </html>
+            """), encoding="utf-8")'
             echo "✅ Created stocks/keywords.html"
           else
             echo "ℹ️ stocks/keywords.html already exists"


### PR DESCRIPTION
## Summary
- replace the heredoc block that created stocks/keywords.html with a Python command that preserves YAML indentation

## Testing
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/stock-recs.yml')"

------
https://chatgpt.com/codex/tasks/task_b_68e621f860a8832aaffdff3095238251