### PR TITLE
Fix staging path for tags snapshot in stock recs workflow

### DIFF
--- a/.github/workflows/stock-recs.yml
+++ b/.github/workflows/stock-recs.yml
@@ -466,7 +466,7 @@ jobs:
             stocks/fx_rates/fx_rates.json
             stocks/fx_rates/fx_history*.json
             stocks/fx_rates/index.html
-            stocks/data/tags.json
+            data/tags.json
             data/keyword_trends.csv
             stocks/keywords.html
           )


### PR DESCRIPTION
## Summary
- update the stock recommendations workflow to stage data/tags.json so tag updates are included in automated commits

## Testing
- node tests/apple_association.test.js

------
https://chatgpt.com/codex/tasks/task_b_68e6694e4240832aaf3f621f92032f31