### PR TITLE
Fix market keyword require path in fetchByTicker

### DIFF
--- a/src/news/fetchByTicker.js
+++ b/src/news/fetchByTicker.js
@@ -136,7 +136,7 @@ const {
   lookupKoFromMap,
   primeTranslationCacheFromSnapshot,
   naverSearch,
-} = require('./marketKeywords.js');
+} = require('./marketKeywords.cjs');
 
 export {
   collectKoreanFirstKeywords,


### PR DESCRIPTION
## Summary
- update `fetchByTicker.js` to require the CommonJS market keywords module
- remove lingering references to the deprecated `.js` filename

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68e67cd0bfd4832a91e498dde93093ba