### PR TITLE
Improve stock rec tag commit step resilience

### DIFF
--- a/.github/workflows/stock-recs.yml
+++ b/.github/workflows/stock-recs.yml
@@ -244,7 +244,9 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git fetch origin "$branch"
-          git pull --rebase origin "$branch"
+          git stash --include-untracked
+          git pull --rebase origin "$branch" || git pull --no-rebase origin "$branch"
+          git stash pop || true
           git add "${files[@]}"
           git commit -m "chore: update market tags and keyword trends"
           git push origin "HEAD:$branch"


### PR DESCRIPTION
## Summary
- add stashing around the tag corpus commit step before pulling the branch
- fall back to a non-rebase pull when the rebase attempt fails and restore stashed changes afterwards

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e67fd913e8832aa7aab41f0f103baf