### PR TITLE
ci: force JavaScript actions to Node 24 in stock workflow

### DIFF
--- a/.github/workflows/stock-recs.yml
+++ b/.github/workflows/stock-recs.yml
@@ -25,6 +25,7 @@ jobs:
     env:
       TZ: Asia/Seoul
       NODE_OPTIONS: --dns-result-order=ipv4first
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
       # keep deprecation warnings visible
       # Keep the run under typical 60s shells; script respects this.
       HARD_DEADLINE_MS: "55000"           # news deadline (now enforced)


### PR DESCRIPTION
### Motivation
- Address the GitHub Actions deprecation warning for Node.js 20 by ensuring JavaScript-based actions run on Node 24 to avoid breakage for actions such as `peaceiris/actions-gh-pages`.

### Description
- Added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"` to the `build-publish` job `env` block in `.github/workflows/stock-recs.yml` so JS actions are opted into Node 24 immediately.

### Testing
- Ran the repository test `node tests/apple_association.test.js`, which printed `All tests passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69eed01447e083318e2e88bd5c530c1f)