### PR TITLE
Ignore vendored Plotly bundle in secret-scan guard

### DIFF
--- a/.github/workflows/stock-recs.yml
+++ b/.github/workflows/stock-recs.yml
@@ -107,7 +107,14 @@ jobs:
           set -Euo pipefail
           secret_pattern='(api[_-]?key|token|secret)[[:space:]]*[:=][[:space:]]*["'"'"'][A-Za-z0-9_./+=-]{12,}["'"'"']'
           echo_pattern='echo[[:space:]]+(\$\{?(FINNHUB_API_KEY|TWELVEDATA_API_KEY|ALPHA_VANTAGE_KEY|FMP_KEY|SERP_API_KEY)\}?|%(FINNHUB_API_KEY|TWELVEDATA_API_KEY|ALPHA_VANTAGE_KEY|FMP_KEY|SERP_API_KEY)%)'
-          exclusions=( ':!README.md' ':!.github/workflows/**' ':!**/*.yml' ':!**/*.yaml' ':!**/*.md' )
+          exclusions=(
+            ':!README.md'
+            ':!.github/workflows/**'
+            ':!**/*.yml'
+            ':!**/*.yaml'
+            ':!**/*.md'
+            ':!Linear_Transformation_Lab/plotly-latest.min.js'
+          )
 
           run_guard() {
             local label="$1" pattern="$2"


### PR DESCRIPTION
### Motivation
- The stock-recs workflow's regex-based secret guard was failing on a minified third-party bundle (`Linear_Transformation_Lab/plotly-latest.min.js`) and the change prevents that false positive so CI can proceed.

### Description
- Added `Linear_Transformation_Lab/plotly-latest.min.js` to the `exclusions` array in `.github/workflows/stock-recs.yml` so the guard skips the vendored Plotly file while keeping all other checks unchanged.

### Testing
- Ran the repository test `node tests/apple_association.test.js` which completed successfully and printed `All tests passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f939b22a388331849f4aef3040b72b)