### PR TITLE
Harden stock-recs workflow and make cache building resilient to provider failures

### DIFF
--- a/.github/workflows/stock-recs.yml
+++ b/.github/workflows/stock-recs.yml
@@ -200,7 +200,7 @@ jobs:
         shell: bash
         run: |
           node --version
-          node --test tests/*.test.js || echo "No tests or tests failed — continuing"
+          node --test tests/*.test.js
 
       - name: Build index ticker maps
         run: node tools/updateIndexMaps.mjs
@@ -225,7 +225,7 @@ jobs:
           NEWSDATA_SIZE: ${{ env.NEWSDATA_SIZE }}
           NEWSAPI_KEY: ${{ secrets.NEWSAPI_KEY }}
           POLYGON_API_KEY: ${{ secrets.POLYGON_API_KEY }}
-          DEEPS_API_KEY: ${{ secrets.DEEPS_API_KEY }}
+          DEEPS_API_KEY: ${{ secrets.DEEPSEARCH_API_KEY }}
         run: |
           set -euo pipefail
           export SKIP_NAVER=${SKIP_NAVER:-0}
@@ -436,8 +436,6 @@ jobs:
             echo "❌ CEREBRAS_API_KEY is not available in the workflow environment"
             exit 1
           fi
-          # Clear stale caches to force fresh data collection
-          rm -rf cache/news-*.json
           find data/articles -name "*.json" -mtime +0 -delete 2>/dev/null || true
           # Generate fresh keywords
           node stocks/stockKeywords.cjs
@@ -652,7 +650,7 @@ jobs:
 
       - name: Deploy to GitHub Pages
         if: always()
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e  # v4
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "axios": "^1.16.0",
         "cheerio": "^1.2.0",
         "compromise": "^14.15.0",
-        "fast-xml-parser": "^5.7.2",
+        "fast-xml-parser": "^5.7.3",
         "keyword-extractor": "^0.0.28",
         "natural": "^8.1.1",
         "node-fetch": "^3.3.2",
@@ -933,9 +933,9 @@
       "optional": true
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.8.tgz",
+      "integrity": "sha512-sDVBc2gg8pSKvcbE8rBmOyjSGQf0AdsbqvHeIOv3D/uYNoV4eCReQXyDF8Pdv8+m1FHazACypSz2hR7O2S1LLw==",
       "funding": [
         {
           "type": "github",
@@ -948,9 +948,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
-      "integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
       "funding": [
         {
           "type": "github",
@@ -960,7 +960,7 @@
       "license": "MIT",
       "dependencies": {
         "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.1.5",
+        "fast-xml-builder": "^1.1.7",
         "path-expression-matcher": "^1.5.0",
         "strnum": "^2.2.3"
       },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "axios": "^1.16.0",
     "cheerio": "^1.2.0",
     "compromise": "^14.15.0",
-    "fast-xml-parser": "^5.7.2",
+    "fast-xml-parser": "^5.7.3",
     "keyword-extractor": "^0.0.28",
     "natural": "^8.1.1",
     "node-fetch": "^3.3.2",

--- a/src/news/fetchByTicker.js
+++ b/src/news/fetchByTicker.js
@@ -44,7 +44,7 @@ const NEWS_FEATURES_FILE = path.join('data', 'news-features.json');
 const NAVER_TRENDS_FILE  = path.join('data', 'naver-trends.json');
 const POLYGON_API_KEY = process.env.POLYGON_API_KEY || '';
 const polygonRest = POLYGON_API_KEY ? restClient(POLYGON_API_KEY) : null;
-const DEEPS_API_KEY = process.env.DEEPS_API_KEY || '';
+const DEEPS_API_KEY = process.env.DEEPSEARCH_API_KEY || process.env.DEEPS_API_KEY || '';
 const DEEPS_US_EXCHANGE = process.env.DEEPS_US_EXCHANGE || 'NASDAQ';
 const NEWSDATA_API_KEY = process.env.NEWSDATA_API_KEY || '';
 const DEEPL_API_KEY = (process.env.DEEPL_API_KEY || '').trim();
@@ -1018,6 +1018,7 @@ async function withRetry(fn,{max=2,baseMs=600,onError}={}){
     catch(e){
       last=e;
       const msg=String(e);
+      if (/\bHTTP 404\b/i.test(msg)) throw e;
       const ra=Number((e?.responseHeaders?.['retry-after'])||0);
       const is429=/HTTP 429/.test(msg);
       const wait=typeof onError==='function' ? (onError(e)||0) : 0;
@@ -1160,7 +1161,9 @@ async function newsFromGNews(sym, q, GNEWS_API){
 
   // Keep it simple and quota-friendly. You can add date filters later if needed.
   // Docs: https://gnews.io/api/v4/search?q=...&lang=...&max=...&apikey=KEY
-  const url = `https://gnews.io/api/v4/search?q=${encodeURIComponent(q)}&lang=${lang}&max=10&apikey=${GNEWS_API}`;
+  const params = new URLSearchParams({ q, lang, max: '10' });
+  console.log(`[gnews] request params: ${params.toString()}`);
+  const url = `https://gnews.io/api/v4/search?${params.toString()}&apikey=${GNEWS_API}`;
 
   // Cache ~20 min; allow stale like others
   const j = await withRetry(
@@ -1595,7 +1598,7 @@ export async function buildNewsFeatures(symbols, opts={}){
   if (deepKey && deepKeyLooksValid) console.log('[deepsearch] enabled (7d window)');
   if (deepKey && !deepKeyLooksValid) {
     providerDisabled.add('deepsearch');
-    warnOnce('deepsearch-key', '[deepsearch] DEEPS_API_KEY format looks invalid; provider disabled');
+    warnOnce('deepsearch-key', '[deepsearch] DEEPSEARCH_API_KEY format looks invalid; provider disabled');
   }
 
   await mapLimit(uniq, NEWS_CONCURRENCY, async (sym)=>{
@@ -2332,7 +2335,12 @@ export async function buildNewsCachesCli() {
   // 1) News features (counts/sentiment/reputation etc.)
   const collectedArticles = {};
   const features = await buildNewsFeatures(symbols, { symbolToName, collectArticles: collectedArticles });
-  await fsp.writeFile(NEWS_FEATURES_FILE, JSON.stringify(features, null, 2));
+  const previousFeatures = readJsonSafe(NEWS_FEATURES_FILE) || {};
+  const nextFeatures = Object.keys(features || {}).length ? features : previousFeatures;
+  if (!Object.keys(features || {}).length) {
+    console.warn('[news-caches] providers failed or returned empty features; keeping previous cache');
+  }
+  await fsp.writeFile(NEWS_FEATURES_FILE, JSON.stringify(nextFeatures, null, 2));
 
   // 2) Naver trends (use company names in keyword builder & baskets)
   const KEYWORDS = await buildKeywordDict({
@@ -2356,9 +2364,15 @@ export async function buildNewsCachesCli() {
   if (!naverResult) {
     console.warn('[news-caches] skipping Naver trends write due to missing results');
   }
+  const previousTrends = readJsonSafe(NAVER_TRENDS_FILE) || {};
   const perSymbol = naverResult?.perSymbol || {};
   const rawMeta = naverResult?.raw ? Object.keys(naverResult.raw) : [];
-  await fsp.writeFile(NAVER_TRENDS_FILE, JSON.stringify({ perSymbol, rawMeta }, null, 2));
+  const hasFreshTrends = Object.keys(perSymbol).length > 0;
+  const nextTrends = hasFreshTrends ? { perSymbol, rawMeta } : previousTrends;
+  if (!hasFreshTrends) {
+    console.warn('[news-caches] trend providers failed or returned empty trends; keeping previous cache');
+  }
+  await fsp.writeFile(NAVER_TRENDS_FILE, JSON.stringify(nextTrends, null, 2));
   console.log(`[news-caches] wrote ${NEWS_FEATURES_FILE} and ${NAVER_TRENDS_FILE}`);
 
   // 3) Ticker keyword snapshot merged into tags.json


### PR DESCRIPTION
### Motivation
- The data-fetching pipeline was fragile: provider failures or non-retryable errors could overwrite caches with empty outputs or hide failing smoke tests.
- Secret wiring for DeepSearch was inconsistent between workflow and code, and GNews logs risked exposing secrets or noisy retries on 404s.
- Some npm packages were slightly out-of-date and the GitHub Pages deploy action used a commit SHA pin that can be simplified.

### Description
- Removed the non-blocking smoke-test fallback so `node --test tests/*.test.js` fails loudly instead of masking failures. (`.github/workflows/stock-recs.yml`)
- Switched workflow env wiring to `DEEPSEARCH_API_KEY` and made the code load `DEEPSEARCH_API_KEY` with a backward-compatible fallback to legacy `DEEPS_API_KEY`, and updated the invalid-key warning text. (`.github/workflows/stock-recs.yml`, `src/news/fetchByTicker.js`)
- Added GNews request-parameter construction with `URLSearchParams` and a log of the request params (query/lang/max) to avoid logging API secrets. (`src/news/fetchByTicker.js`)
- Stopped retrying HTTP 404 responses in the shared retry helper by rethrowing 404 errors immediately to avoid wasted retries. (`src/news/fetchByTicker.js`)
- Made the CLI cache builder resilient: when providers fail or return empty results the builder keeps the previous `data/news-features.json` and `data/naver-trends.json` instead of overwriting with empty data. (`src/news/fetchByTicker.js`)
- Preserved existing provider caches by removing the forced `rm -rf cache/news-*.json` deletion during the keywords build step in the workflow. (`.github/workflows/stock-recs.yml`)
- Bumped `fast-xml-parser` to a newer compatible patch (`^5.7.3`) to address a reported outdated package. (`package.json`, `package-lock.json`)
- Simplified the GitHub Pages deploy action reference to `peaceiris/actions-gh-pages@v4`. (`.github/workflows/stock-recs.yml`)

### Testing
- Ran repository test: `node tests/apple_association.test.js` → `All tests passed`.
- Checked for outdated packages with `npm outdated --json` and upgraded `fast-xml-parser` via `npm install fast-xml-parser@^5.7.3`, which completed successfully.
- Verified that the modified build/cache code writes the cache files (`data/news-features.json`, `data/naver-trends.json`) and that the workflow changes containing secret env names and action pin were applied locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f98b099d5883319e74f515f844edf4)