### PR TITLE
Fix DeepL auth flow and bump GitHub Actions to Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
       - name: Install
         run: |

--- a/.github/workflows/daily-build.yml
+++ b/.github/workflows/daily-build.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
       - name: Install
         run: |

--- a/.github/workflows/pools-test.yml
+++ b/.github/workflows/pools-test.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Install deps
         run: |

--- a/.github/workflows/stock-recs.yml
+++ b/.github/workflows/stock-recs.yml
@@ -139,7 +139,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
           cache-dependency-path: '**/package-lock.json'  # keep this for multi-package repos
 

--- a/src/news/marketKeywords.cjs
+++ b/src/news/marketKeywords.cjs
@@ -39,12 +39,18 @@ async function callDeepLTranslate(text, { targetLang = 'KO', sourceLang } = {}) 
   }
 
   const params = new URLSearchParams();
-  params.append('auth_key', DEEPL_API_KEY);
   params.append('text', normalized);
   if (targetLang) params.append('target_lang', targetLang);
   if (sourceLang) params.append('source_lang', sourceLang);
 
-  const res = await fetch(DEEPL_API_URL, { method: 'POST', body: params });
+  const res = await fetch(DEEPL_API_URL, {
+    method: 'POST',
+    headers: {
+      'Authorization': `DeepL-Auth-Key ${DEEPL_API_KEY}`,
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: params,
+  });
   if (!res.ok) {
     const errText = await res.text().catch(() => '');
     throw new Error(`DeepL error ${res.status}: ${errText}`);


### PR DESCRIPTION
### Motivation
- DeepL translations were failing with 403 due to deprecated form-body `auth_key` authentication, causing keyword/translation pipelines to break and produce incomplete `tags.json`/`finance_keywords.json` data. 
- GitHub Actions workflows referenced Node 20 which is deprecated and risks future CI breakage. 
- Updating auth to the header-based pattern and moving workflows to Node 24 prevents translation failures and reduces CI churn.

### Description
- Changed DeepL calls in `src/news/marketKeywords.cjs` to send `Authorization: DeepL-Auth-Key <KEY>` in request headers and removed the deprecated `auth_key` form field while keeping form-urlencoded body fields. 
- Updated Node versions from `20` to `24` in the workflow files `/.github/workflows/ci.yml`, `/.github/workflows/daily-build.yml`, `/.github/workflows/pools-test.yml`, and `/.github/workflows/stock-recs.yml`. 
- Kept the existing form encoding (`application/x-www-form-urlencoded`) and preserved existing translation fallback behavior to avoid breaking the pipeline when the API key is absent.

### Testing
- Ran the repository test script `node tests/apple_association.test.js` and it completed successfully (`All tests passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69faa313a2348331824236077f968f58)