### PR TITLE
Fix DeepL authentication to use Authorization header

### DIFF
--- a/stocks/stockKeywords.cjs
+++ b/stocks/stockKeywords.cjs
@@ -2472,7 +2472,6 @@ async function translateText(text, { targetLang, sourceLang } = {}) {
 
   console.log(`   🌐 Calling DeepL API (${sourceLang || 'auto'}→${targetLang}) for: "${normalized}"`);
   const params = new URLSearchParams();
-  params.append('auth_key', DEEPL_API_KEY);
   params.append('text', normalized);
   if (targetLang) params.append('target_lang', targetLang);
   if (sourceLang) params.append('source_lang', sourceLang);
@@ -2480,6 +2479,9 @@ async function translateText(text, { targetLang, sourceLang } = {}) {
   try {
     const res = await fetch(DEEPL_API_URL, {
       method: 'POST',
+      headers: {
+        Authorization: `DeepL-Auth-Key ${DEEPL_API_KEY}`,
+      },
       body: params,
     });
     if (!res.ok) {


### PR DESCRIPTION
### Motivation
- DeepL no longer accepts `auth_key` in the request body or query and translation calls were returning 403, so the code must use header-based authentication.

### Description
- In `stocks/stockKeywords.cjs` removed `params.append('auth_key', DEEPL_API_KEY)` and added an `Authorization: DeepL-Auth-Key ${DEEPL_API_KEY}` header on the `fetch` call while keeping the `text`, `target_lang`, and `source_lang` form fields unchanged.

### Testing
- Ran `node tests/apple_association.test.js` which printed `All tests passed` and verified `node -v` (Node 20.x) successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fc75bd570c8331b2fe20ae0a99ad75)