### PR TITLE
ci: upgrade GitHub Pages deploy action to v5

### DIFF
--- a/.github/workflows/stock-recs.yml
+++ b/.github/workflows/stock-recs.yml
@@ -650,7 +650,7 @@ jobs:
 
       - name: Deploy to GitHub Pages
         if: always()
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@v5
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages


### PR DESCRIPTION
### Motivation
- Replace the `peaceiris/actions-gh-pages@v4` usage to stop the Node.js 20 deprecation warning when runners are forced to Node.js 24 and ensure the deploy step targets a Node-24-compatible action.

### Description
- Updated the GitHub Pages deploy step in `.github/workflows/stock-recs.yml` from `peaceiris/actions-gh-pages@v4` to `peaceiris/actions-gh-pages@v5`.

### Testing
- Ran the repository test `node tests/apple_association.test.js` and it completed successfully with `All tests passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fc7a05fd40833181b7124f23dcee0b)