### PR TITLE
docs: clarify GitHub Actions auto-usage of Naver signals

### DIFF
--- a/guide/README-NAVER-SIGNALS.md
+++ b/guide/README-NAVER-SIGNALS.md
@@ -58,6 +58,23 @@ node tools/buildPoolsTrendy.js --dry-run
 
 ---
 
+
+## 🤖 GitHub Actions 연동 체크
+
+`stock-recs.yml`, `daily-build.yml`, `pools-test.yml` 같은 워크플로우는 공통으로 `node tools/buildPoolsTrendy.js`를 실행합니다.  
+따라서 **워크플로우 YAML을 바꾸지 않아도**, `tools/buildPoolsTrendy.js`가 `src/signals/naver-signals.js`를 import하는 상태라면 다음 실행부터 자동으로 새 Naver signals 로직이 적용됩니다.
+
+```yaml
+- name: Build trend-aware pools
+  run: node tools/buildPoolsTrendy.js
+```
+
+권장 순서:
+1. `src/signals/naver-signals.js` 반영
+2. `tools/buildPoolsTrendy.js` 통합 변경 + 로컬 테스트 통과
+3. 커밋/푸시
+4. 스케줄 워크플로우가 자동으로 새 코드 사용
+
 ## 🔍 핵심 개선 사항
 
 ### 문제점 분석


### PR DESCRIPTION
### Motivation
- Make it explicit that workflows which run `node tools/buildPoolsTrendy.js` (e.g. `stock-recs.yml`) will automatically pick up a `src/signals/naver-signals.js` import so operators follow the correct rollout order and avoid CI breakage.

### Description
- Added a `GitHub Actions 연동 체크` section to `guide/README-NAVER-SIGNALS.md` that explains no workflow YAML changes are required, provides the recommended rollout order (`src/signals/naver-signals.js` → patch `buildPoolsTrendy.js` → local tests → push), and shows the relevant workflow command `run: node tools/buildPoolsTrendy.js`.

### Testing
- Ran `node tests/apple_association.test.js` which passed; ran `node tools/validate-naver-signals.js` which reported 19 passed and 3 failed assertions (two Data Sources Priority failures and one Data Quality Metrics failure); ran `node tools/buildPoolsTrendy.js --dry-run` which failed due to runtime errors in `src/signals/naver-signals.js` (`OFFLINE` used before initialization and a `TypeError: s.isValid is not a function`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fc81307c4c8331b6e8272381f3bf4e)