### PR TITLE
Fix Naver signal validation and cache robustness

### DIFF
--- a/src/signals/naver-signals.js
+++ b/src/signals/naver-signals.js
@@ -335,7 +335,10 @@ class NaverSignalCache {
    *   naverBoost = signal.getBoostValue();
    */
   get(symbol) {
-    return this.cache.get(symbol) ?? new NaverSignal(); // fallback
+    const raw = this.cache.get(symbol);
+    if (!raw) return new NaverSignal();
+    if (raw instanceof NaverSignal) return raw;
+    return new NaverSignal(raw);
   }
 
   clear() {
@@ -344,15 +347,23 @@ class NaverSignalCache {
 
   getMetrics() {
     const items = Array.from(this.cache.values());
+    const isSignalValid = (s) => typeof s?.isValid === 'function'
+      ? s.isValid()
+      : typeof s?.popularity === 'number' &&
+        s.popularity >= 0 &&
+        s.popularity <= 1 &&
+        typeof s?.asvi === 'number' &&
+        s.asvi >= -100 &&
+        s.asvi <= 100;
     return {
       totalSignals: items.length,
-      validSignals: items.filter(s => s.isValid()).length,
-      avgConfidence: items.reduce((s, sig) => s + sig.confidence.popularity, 0) / Math.max(1, items.length),
+      validSignals: items.filter(s => isSignalValid(s) && (s.popularity ?? 0) > 0).length,
+      avgConfidence: items.reduce((s, sig) => s + (sig?.confidence?.popularity ?? 0), 0) / Math.max(1, items.length),
       sources: {
-        trends: items.filter(s => s.sources.popularity === 'trends').length,
-        features: items.filter(s => s.sources.popularity === 'features').length,
-        finance: items.filter(s => s.sources.popularity === 'finance').length,
-        default: items.filter(s => !s.sources.popularity).length
+        trends: items.filter(s => s?.sources?.popularity === 'trends').length,
+        features: items.filter(s => s?.sources?.popularity === 'features').length,
+        finance: items.filter(s => s?.sources?.popularity === 'finance').length,
+        default: items.filter(s => !s?.sources?.popularity).length
       }
     };
   }

--- a/tools/validate-naver-signals.js
+++ b/tools/validate-naver-signals.js
@@ -101,7 +101,7 @@ class NaverSignalValidator {
     };
 
     const collector1 = new NaverSignalCollector('TEST1', mockContext1);
-    const signal1 = collector1.collect();
+    const signal1 = await collector1.collect();
 
     this.assert(
       signal1.popularity === 0.9 && signal1.sources.popularity === 'trends',
@@ -118,7 +118,7 @@ class NaverSignalValidator {
     };
 
     const collector2 = new NaverSignalCollector('TEST2', mockContext2);
-    const signal2 = collector2.collect();
+    const signal2 = await collector2.collect();
 
     this.assert(
       signal2.popularity === 0.6 && signal2.sources.popularity === 'features',


### PR DESCRIPTION
### Motivation
- The unified Naver signals flow could crash or miscount metrics when raw cache entries (plain objects) were present and async collection was not awaited in validator tests.
- The `buildPoolsTrendy` integration expects cached signals to expose methods like `getBoostValue()`, so cached raw objects must be normalized to `NaverSignal` instances to ensure runtime stability.

### Description
- Update `tools/validate-naver-signals.js` to `await` `collector.collect()` in the data-source priority tests so async collection is exercised correctly and Test 2 no longer fails.
- Harden `NaverSignalCache.get()` to return a `NaverSignal` instance for cached raw objects by creating a new `NaverSignal(raw)` when needed so instance methods are always available.
- Improve `NaverSignalCache.getMetrics()` to safely compute metrics by counting only valid non-zero popularity signals for `validSignals`, guarding optional fields (`confidence` / `sources`) when aggregating `avgConfidence`, and defensively reading `sources` for the breakdown to avoid runtime errors.
- Add a defensive `isSignalValid` check used by `getMetrics()` to handle mixed cache contents without relying solely on class methods.

### Testing
- Ran `node tools/validate-naver-signals.js` and the validator completed with all tests passing (100% pass rate). 
- Ran the repository test with `node tests/apple_association.test.js` and it passed. 
- Performed an integration dry-run with `OFFLINE=1 node tools/buildPoolsTrendy.js --dry-run` to exercise initialization and cache usage, which completed without crashing and produced `naver-signals` initialization metrics.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fc8272abe083318211fe83f25d0218)