### PR TITLE
Pin peaceiris/actions-gh-pages to v4.0.0 in stock-recs workflow

### DIFF
--- a/.github/workflows/stock-recs.yml
+++ b/.github/workflows/stock-recs.yml
@@ -650,7 +650,7 @@ jobs:
 
       - name: Deploy to GitHub Pages
         if: always()
-        uses: peaceiris/actions-gh-pages@v5
+        uses: peaceiris/actions-gh-pages@v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages


### PR DESCRIPTION
### Motivation
- The `Deploy to GitHub Pages` step in `.github/workflows/stock-recs.yml` referenced `peaceiris/actions-gh-pages@v5`, which is not a published tag and causes the workflow to fail.
- Pinning to a known release ensures the deploy step runs deterministically and avoids immediate CI breakage while remaining compatible with the repository's Node24-forward setup.

### Description
- Replaced `uses: peaceiris/actions-gh-pages@v5` with `uses: peaceiris/actions-gh-pages@v4.0.0` in `.github/workflows/stock-recs.yml`.
- No other workflow steps, environment variables, or source files were changed.

### Testing
- Ran the repository test `node tests/apple_association.test.js`, which succeeded and printed `All tests passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fd22be03e08331a64d8cfff695c68f)