### PR TITLE
Fix ConfigLoader initialization in tools/buildPoolsTrendy.js

### DIFF
--- a/tools/buildPoolsTrendy.js
+++ b/tools/buildPoolsTrendy.js
@@ -24,7 +24,8 @@ if (typeof fetch === 'undefined') {
 fs.mkdirSync('cache', { recursive: true });
 
 
-const configLoader = await new ConfigLoader().load('config/pools-config.json', process.env);
+const configLoader = new ConfigLoader();
+await configLoader.load('config/pools-config.json', process.env);
 const cfg = (path, fallback) => configLoader.get(path, fallback);
 
 const CACHE_DIR = 'cache';


### PR DESCRIPTION
### Motivation
- The trendy pools builder crashed with `TypeError: configLoader.get is not a function` because `ConfigLoader.load()` returned the plain config object and the code assigned that object to `configLoader` before calling `.get()`.

### Description
- Change initialization to create a `ConfigLoader` instance first, then `await configLoader.load('config/pools-config.json', process.env)`, and keep using `configLoader.get(...)` via `const cfg = (path, fallback) => configLoader.get(path, fallback);`.
- The change is a single-line initialization fix in `tools/buildPoolsTrendy.js` replacing `const configLoader = await new ConfigLoader().load(...)` with a two-step instantiation and `load(...)` call.

### Testing
- Ran the repository test with `node tests/apple_association.test.js` and it passed (`All tests passed`).
- Verified loader behavior with `node --input-type=module -e "import { ConfigLoader } from './src/config/config-loader.js'; const cl=new ConfigLoader(); await cl.load('config/pools-config.json', process.env); console.log(typeof cl.get==='function' ? 'config-loader-ok':'bad');"` which printed success.
- Performed an ESM syntax check with `node --check tools/buildPoolsTrendy.js` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fd438f4ef88331b91750de65b3c36b)