### PR TITLE
Prioritize high-score tickers in pool rotation for recommendations

### DIFF
--- a/fetchStockInfo.js
+++ b/fetchStockInfo.js
@@ -740,6 +740,14 @@ function pickDeterministic(arr, k, seed) {
   return a.slice(0, k);
 }
 
+function metricScoreFor(market, name) {
+  const metrics = poolsMetricsRaw?.markets?.[market]?.[name] || poolsMetricsRaw?.[market]?.[name];
+  if (typeof metrics?.score === 'number') return metrics.score;
+  if (typeof metrics?.score?.total === 'number') return metrics.score.total;
+  if (typeof metrics?.score?.safe === 'number') return metrics.score.safe * 100;
+  return null;
+}
+
 async function writeAtomically(dest, data) {
   const tmp = dest + '.tmp';
   await writeFile(tmp, data);
@@ -806,7 +814,21 @@ function rotateFromPools(pools, prevData) {
         const safeNames = new Set(out[market].safe.map(e => typeof e === 'string' ? e : e.name));
         candidates = candidates.filter(n => !safeNames.has(n));
       }
-      const picked = pickDeterministic(candidates, 5, `${seed}:${market}:${bucket}`);
+      // Prioritize higher-scoring names, then rotate deterministically within the top window.
+      // This avoids selecting too many low-score names when a bucket is large.
+      candidates = candidates
+        .map((name, idx) => ({ name, idx, score: metricScoreFor(market, name) }))
+        .sort((a, b) => {
+          const sa = Number.isFinite(a.score) ? a.score : -Infinity;
+          const sb = Number.isFinite(b.score) ? b.score : -Infinity;
+          if (sb !== sa) return sb - sa;
+          return a.idx - b.idx;
+        })
+        .map(v => v.name);
+
+      const topPoolSize = Math.max(5, Number(process.env.ROTATION_TOP_POOL || 12));
+      const topCandidates = candidates.slice(0, topPoolSize);
+      const picked = pickDeterministic(topCandidates.length ? topCandidates : candidates, 5, `${seed}:${market}:${bucket}`);
       out[market][bucket] = picked.map(n => {
         const sym = canonSymbol(n);
         const displayName = INDEX_NAME[sym] || n;


### PR DESCRIPTION
### Motivation
- `fetchStockInfo.js` was deterministically shuffling entire pool buckets and picking 5 names, which allowed low-scoring tickers to be selected even when `buildPoolsTrendy` produced higher-scoring alternatives. This reduced the quality of `recommendations.json`.

### Description
- Added `metricScoreFor(market, name)` helper to read score values from `pools-metrics.json` variants (`score`, `score.total`, `score.safe`).
- Updated `rotateFromPools` in `fetchStockInfo.js` to sort candidates by metric score (descending) and then perform deterministic rotation within a configurable top window rather than across the full bucket.
- Introduced a top-window size via `ROTATION_TOP_POOL` (default 12) and ensure at least 5 are considered to balance quality vs diversity; selection remains deterministic via `pickDeterministic`.
- File changed: `fetchStockInfo.js` (prioritization logic + helper function).

### Testing
- Ran the repository test with `node tests/apple_association.test.js` which passed (`All tests passed`).
- Performed a static syntax check `node --check fetchStockInfo.js` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fecf603a5483319412db859546e502)