### PR TITLE
점수 분포 개선 - 평균 점수를 60점 → 75점으로 올리기

### DIFF
--- a/tools/buildPoolsTrendy.js
+++ b/tools/buildPoolsTrendy.js
@@ -589,7 +589,7 @@ const POP_CAP     = cfg('floor.popularityCap', 0.10); // hard cap of popularity 
 // =========================
 const ABSOLUTE_SCORING = cfg('flags.absoluteScoring', true); // default ON
 // Stronger size bias (absolute)
-const SIZE_ABS_WEIGHT = cfg('scoring.absolute.sizeWeight', 0.82);  // higher => more size
+const SIZE_ABS_WEIGHT = cfg('scoring.absolute.sizeWeight', 0.5);  // higher => more size
 const SIZE_ABS_WEIGHT_AGGR = cfg('scoring.absolute.sizeWeightAggressive', 0.5);  // 공격주용 (신규)
 // Market-cap range for log scaling
 const MCAP_MIN = cfg('marketCap.min', 2e9);
@@ -598,8 +598,9 @@ const MCAP_MAX = cfg('marketCap.max', 6e12);       // ~5–6T puts AAPL/NVDA nea
 const BLOG_NORM = cfg('scoring.normalization.blogMentions', 20);
 const WIKI_NORM = cfg('scoring.normalization.wikiViews', 80000);
 // Absolute popularity mixer (normalized internally)
-const ABS_W_NEWS   = cfg('weights.absolute.news', 0.65);
-const ABS_W_NAVPOP = cfg('weights.absolute.naverPopularity', 0.50);
+const ABS_W_NEWS   = cfg('weights.absolute.news', 0.35);
+const ABS_W_MOMENTUM = cfg('weights.absolute.momentum', 0.25);
+const ABS_W_NAVPOP = cfg('weights.absolute.naverPopularity', 0.40);
 const ABS_W_BLOGS  = cfg('weights.absolute.blogs', 0.05);
 const ABS_W_WIKI   = cfg('weights.absolute.wiki', 0.02);
 const ABS_W_KEYPOS = cfg('weights.absolute.positiveKeywords', 0.04);
@@ -2240,10 +2241,14 @@ async function main(){
 
       // Compose an absolute popularity/content score
       const ABS_W_NAVER_FIN = Number(process.env.ABS_W_NAVER_FIN || 0.2);
-      const denom = Math.max(1e-9, ABS_W_NEWS + ABS_W_NAVPOP + ABS_W_BLOGS + ABS_W_WIKI + ABS_W_KEYPOS + ABS_W_KEYNEG + ABS_W_NAVER_FIN);
+      const trendRaw = computeTrendMomentum(nf, PREV_METRICS?.[market]?.[n]);
+      const trendScore = scoreTrend(trendRaw);
+      const momentum01 = trendScore != null ? clamp01(trendScore / 5) : 0;
+      const denom = Math.max(1e-9, ABS_W_NEWS + ABS_W_NAVPOP + ABS_W_MOMENTUM + ABS_W_BLOGS + ABS_W_WIKI + ABS_W_KEYPOS + ABS_W_KEYNEG + ABS_W_NAVER_FIN);
       const popAbs = (ABS_W_NEWS   * news
                     + ABS_W_NAVPOP * navp
                     + ABS_W_NAVER_FIN * naverFinance01
+                    + ABS_W_MOMENTUM * momentum01
                     + ABS_W_BLOGS  * blog01
                     + ABS_W_WIKI   * wiki01
                     + ABS_W_KEYPOS * pos01


### PR DESCRIPTION
### Motivation
- 현재 절대 점수 산식이 시가총액(크기)에 지나치게 편향되어 있어 평균 점수가 낮게 형성되고 있습니다.
- 뉴스/인기도 신호 일부가 누락되면 점수 왜곡이 발생하므로 뉴스 의존도를 낮추고 대체 신호를 도입해야 합니다.
- 목표는 평균 점수를 약 60→75로 올리되 정확성(데이터 기반 판단)을 유지하는 것입니다.

### Description
- `tools/buildPoolsTrendy.js`에서 절대 점수 가중치를 조정했고 모멘텀 항을 도입했습니다.
- `SIZE_ABS_WEIGHT` 기본값을 `0.82`에서 `0.5`로 낮춰 대형주 편향을 완화했습니다.
- `ABS_W_NEWS`를 `0.65 → 0.35`, `ABS_W_NAVPOP`를 `0.50 → 0.40`으로 낮추고 `ABS_W_MOMENTUM`을 새로 추가해 기본값 `0.25`로 설정했습니다 (`cfg('weights.absolute.momentum', 0.25)`).
- 절대 popularity/content 합성식에 `computeTrendMomentum` + `scoreTrend`를 이용해 계산한 `momentum01`(0..1)을 포함하도록 분모/분자 모두를 변경하여 뉴스/인기도 누락 시에도 가격/추세 기반 신호가 보완되게 했습니다.

### Testing
- Node 버전 확인(`node -v`)을 수행해 실행 환경을 점검했습니다.
- 저장소의 단일 자동화 테스트인 `node tests/apple_association.test.js`를 실행했고 `All tests passed`로 성공했습니다.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ff184662008331a737a140cce986a0)