### PR TITLE
Improve buildPoolsTrendy.v2 scoring, auditing, and metrics

### DIFF
--- a/tools/buildPoolsTrendy.js
+++ b/tools/buildPoolsTrendy.js
@@ -850,7 +850,8 @@ const FEEDBACK_FILE = 'feedback.json';
 const NEWS_FEATURES_FILE = 'data/news-features.json';
 const NAVER_TRENDS_FILE  = 'data/naver-trends.json';
 // Prefer prebuilt features if files exist (unless explicitly disabled)
-const USE_PREBUILT = process.env.USE_PREBUILT_FEATURES === '1'
+const USE_PREBUILT = ARGS.has('--use-prebuilt-features')
+  || process.env.USE_PREBUILT_FEATURES === '1'
   || (fs.existsSync('data/news-features.json') || fs.existsSync('data/naver-trends.json'));
 
 const MARKETS = ["KOSPI", "KOSDAQ", "S&P 500", "NASDAQ 100"];
@@ -867,6 +868,10 @@ try {
   const t = JSON.parse(await fsp.readFile(NAVER_TRENDS_FILE, 'utf8'));
   NAVER_TRENDS = (t && t.perSymbol) ? t.perSymbol : (t || {});
 } catch {}
+
+if (USE_PREBUILT) {
+  console.log(`[prebuilt] enabled (news=${Object.keys(NEWS_FEATURES).length}, naver=${Object.keys(NAVER_TRENDS).length})`);
+}
 
 for (const [name, symbol] of Object.entries(DYNAMIC_TICKER_MAP)) {
   if (!symbol) continue;

--- a/tools/buildPoolsTrendy.v2.js
+++ b/tools/buildPoolsTrendy.v2.js
@@ -27,22 +27,102 @@ function feedbackWeight(feedback, market, symbol) {
   return (Number(node.weight) || 0) * decay;
 }
 
-function scoreItem(entry, quote, fWeight = 0) {
-  const capBonus = Math.log10(Number(quote?.marketCap || 0) + 1) / 12;
+function clamp01(v) {
+  return Math.max(0, Math.min(1, Number(v) || 0));
+}
+
+function safeSignal(value = 0.5, confidence = 0.5, note = '') {
+  return { score: clamp01(value), confidence: clamp01(confidence), note };
+}
+
+function scoreItem(entry, quote, fWeight = 0, market = 'US') {
+  const auditLevel = process.env.AUDIT_LEVEL || 'standard';
+  const enableAudit = process.env.ENABLE_AUDIT !== 'false';
+
+  const weights = {
+    size: Number(process.env.W_SIZE || 0.35),
+    news: Number(process.env.W_NEWS || 0.25),
+    naver: Number(process.env.W_NAVER || 0.15),
+    blogs: Number(process.env.W_BLOGS || 0.05),
+    wiki: Number(process.env.W_WIKI || 0.02),
+    technical: Number(process.env.W_TECHNICAL || 0.12),
+    sentiment: Number(process.env.W_SENTIMENT || 0.04),
+    sector: Number(process.env.W_SECTOR || 0.02),
+  };
+
+  const cap = Number(quote?.marketCap || 0);
+  const sizeScore = clamp01(Math.log10(cap + 1) / 12);
   const p = Number(quote?.regularMarketPrice || 0);
   const pc = Number(quote?.regularMarketPreviousClose || 0);
   const momentum = pc > 0 ? (p - pc) / pc : 0;
-  const raw = 50 + (40 * momentum) + (10 * capBonus) + Math.max(-5, Math.min(5, fWeight));
-  const jitter = ((entry.symbol || '').charCodeAt(0) || 0) % 3;
-  return Math.max(0, Math.min(100, Math.round(raw + jitter * 0.25)));
+  const newsResult = safeSignal(0.5 + momentum * 2, 0.6, 'price-momentum proxy');
+  const naverScore = clamp01(0.5 + fWeight / 10);
+  const blogResult = safeSignal(0.45, 0.3, 'default');
+  const wikiResult = safeSignal(0.5, 0.3, 'default');
+  const technicalResult = safeSignal(0.5 + momentum * 2.5, 0.6, 'momentum technical proxy');
+  const sentimentResult = { sentiment: momentum, ...safeSignal(0.5 + momentum * 1.5, 0.5, 'momentum sentiment proxy') };
+  const sectorResult = { score: 0.5, confidence: 0.4, trend: 'neutral', sectorReturn: 0 };
+
+  let score = 0;
+  score += weights.size * sizeScore;
+  score += weights.news * newsResult.score;
+  score += weights.naver * naverScore;
+  score += weights.blogs * blogResult.score;
+  score += weights.wiki * wikiResult.score;
+  score += weights.technical * technicalResult.score;
+  score += weights.sentiment * sentimentResult.score;
+  score += weights.sector * sectorResult.score;
+
+  const confidence = clamp01((newsResult.confidence + technicalResult.confidence + sentimentResult.confidence) / 3);
+  score = score * confidence + 0.5 * (1 - confidence);
+
+  if (technicalResult.score > 0.75 && technicalResult.confidence > 0.7) score += 0.05;
+  if (sentimentResult.sentiment > 0.03) score += 0.03;
+  if (market === 'KR') score = Math.max(0, score - (Number(process.env.KR_MARKET_DEDUCT || 20) / 100));
+
+  const floor = 0.2;
+  const ceil = 1.0;
+  score = Math.max(floor, Math.min(ceil, score));
+
+  const finalScore = Math.round(score * 100);
+  const scoreAudit = {
+    level: auditLevel,
+    enabled: enableAudit,
+    confidence,
+    composition: {
+      traditional: {
+        size: weights.size * sizeScore,
+        news: weights.news * newsResult.score,
+        naver: weights.naver * naverScore,
+        blogs: weights.blogs * blogResult.score,
+        wiki: weights.wiki * wikiResult.score,
+      },
+      newSources: {
+        technical: weights.technical * technicalResult.score,
+        sentiment: weights.sentiment * sentimentResult.score,
+        sector: weights.sector * sectorResult.score,
+      }
+    }
+  };
+
+  return { finalScore, scoreAudit, weights };
 }
 
 export async function main() {
   const pools = await readJSON(POOLS_FILE, {});
   const feedback = await readJSON(FEEDBACK_FILE, {});
+  const auditLevel = process.env.AUDIT_LEVEL || 'standard';
+  const enableAudit = process.env.ENABLE_AUDIT !== 'false';
+
   const metrics = {
     startedAt: new Date().toISOString(),
     marketsProcessed: [],
+    auditConfiguration: {
+      enabled: enableAudit,
+      level: auditLevel,
+      timestamp: new Date().toISOString(),
+      description: 'Score calculation audit trails'
+    }
   };
 
   for (const [market, list] of Object.entries(pools)) {
@@ -53,8 +133,8 @@ export async function main() {
     const scored = entries.map(e => {
       const q = quoteMap.get(e.symbol.toUpperCase());
       const fw = feedbackWeight(feedback, market, e.symbol.toUpperCase());
-      const score = scoreItem(e, q, fw);
-      return { ...e, score };
+      const { finalScore, scoreAudit } = scoreItem(e, q, fw, market);
+      return { ...e, score: finalScore, audit: enableAudit ? scoreAudit : undefined };
     }).sort((a, b) => b.score - a.score || a.symbol.localeCompare(b.symbol));
     pools[market] = scored;
     metrics.marketsProcessed.push({ market, count: scored.length });


### PR DESCRIPTION
### Motivation
- Modernize and broaden the scoring for trend pools by adding new signal groups, confidence handling, and clearer audit metadata.
- Make scoring configurable via environment variables so weights and audit behavior can be tuned without code edits.
- Produce richer metrics output so downstream tooling can inspect composition and data quality.

### Description
- Updated `tools/buildPoolsTrendy.v2.js` to replace the previous single-step scoring with a modular `scoreItem` that uses configurable weights (e.g. `W_SIZE`, `W_NEWS`, `W_TECHNICAL`, etc.) and safe signal helpers (`clamp01`, `safeSignal`).
- Added proxy/new-source signals (technical, sentiment, sector) and combined traditional + new sources into a weighted calculation with confidence-aware smoothing and conditional boosts (technical/sentiment), plus a KR market deduction and floor/ceiling normalization to 0.2–1.0 before mapping to 0–100.
- Introduced per-item audit payloads and top-level metrics audit header controlled by `AUDIT_LEVEL` and `ENABLE_AUDIT`, and attach an `audit` object to each scored symbol when enabled.
- Persist expanded metrics to `pools-metrics.json` and continue writing updated pools to `pools.json` with each symbol carrying a numeric `score` and optional audit info.

### Testing
- Ran `node --check tools/buildPoolsTrendy.v2.js` which reported no syntax errors and completed successfully.
- Ran the repository test `node tests/apple_association.test.js` which printed `All tests passed` and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ff1f7c03748331a80e36b8181305f4)