### PR TITLE
Persist confidence and unified scoring data in pool metrics

### DIFF
--- a/tools/buildPoolsTrendy.js
+++ b/tools/buildPoolsTrendy.js
@@ -2702,6 +2702,16 @@ async function main(){
         byName[n].totalScore = Math.round(
           byName[n].totalScore * 0.5 + unifiedResult.score * 0.5
         );
+        byName[n].unifiedScoreData = {
+          score: unifiedResult.score,
+          ruleScore: unifiedResult.ruleScore ?? null,
+          mlScore: unifiedResult.mlScore ?? null,
+          confidence: unifiedResult.confidence ?? 0.5,
+          reasoning: unifiedResult.reasoning ?? ''
+        };
+        if (!Number.isFinite(byName[n].confidence)) {
+          byName[n].confidence = unifiedResult.confidence ?? 0.5;
+        }
       }
 
       byName[n].reasons = byName[n].reasons || {};
@@ -2880,6 +2890,8 @@ async function main(){
         components: byName[n].componentScores,
         wikiScore: byName[n].wikiScore,
         sourceReliability: byName[n].sourceReliability,
+        confidence: byName[n].confidence ?? byName[n].sourceReliability ?? 0.5,
+        unifiedScoreData: byName[n].unifiedScoreData ?? null,
         // --- diagnostics for KR penalty & floors (0..1) ---
         krPenalty01: krOff01,
         base01:            Number(((dbgBase01[n] ?? 0)).toFixed(4)),


### PR DESCRIPTION
### Motivation

- Ensure unified scoring outputs are retained for inspection and downstream tooling instead of being discarded. 
- Surface a `confidence` value for each symbol so metrics consumers can reason about score reliability. 
- Persist these values into the serialized `metricsOut` so `pools-metrics.json` includes the new fields.

### Description

- Save the `unifiedScoreData` object returned by `unifiedScorer.scoreItem` onto `byName[n]` when `useUnifiedScoring` is enabled in `tools/buildPoolsTrendy.js` by storing `score`, `ruleScore`, `mlScore`, `confidence`, and `reasoning`.
- Populate `byName[n].confidence` with `unifiedResult.confidence` (fallback `0.5`) when no numeric confidence already exists.
- Persist `confidence` and `unifiedScoreData` into the `metricsOut[market]` entry so they are written into the final `pools-metrics.json` output.
- Changes are localized to `tools/buildPoolsTrendy.js` around the unified scoring and `metricsOut` serialization sections.

### Testing

- Ran the repository test with `node tests/apple_association.test.js`, which printed `All tests passed`.
- No other automated tests were added or modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ff4b7914a08331aa773a956f9db4db)