### PR TITLE
fix: preserve buildPoolsTrendy metrics when updating return fields

### DIFF
--- a/fetchReturns.js
+++ b/fetchReturns.js
@@ -2,11 +2,17 @@ import fs from 'fs/promises';
 import { getCandles } from './src/data/candles.js';
 
 const rec = JSON.parse(await fs.readFile('recommendations.json', 'utf8'));
-const out = {};
+let out = {};
+
+try {
+  out = JSON.parse(await fs.readFile('pools-metrics.json', 'utf8'));
+} catch {
+  out = {};
+}
 
 for (const [market, buckets] of Object.entries(rec)) {
   if (market === 'lastUpdated') continue;
-  out[market] = {};
+  if (!out[market] || typeof out[market] !== 'object') out[market] = {};
   for (const bucket of ['safe', 'aggressive']) {
     const list = Array.isArray(buckets[bucket]) ? buckets[bucket] : [];
     for (const entry of list) {
@@ -23,7 +29,8 @@ for (const [market, buckets] of Object.entries(rec)) {
         const c20 = c[n-21];
         const ret5 = (c5 != null && latest != null) ? ((latest - c5) / c5 * 100) : null;
         const ret20 = (c20 != null && latest != null) ? ((latest - c20) / c20 * 100) : null;
-        out[market][name] = { ret5, ret20 };
+        const prev = (out[market][name] && typeof out[market][name] === 'object') ? out[market][name] : {};
+        out[market][name] = { ...prev, ret5, ret20 };
       } catch (e) {
         console.warn(`[returns] ${ticker} failed: ${e.message}`);
       }
@@ -32,7 +39,7 @@ for (const [market, buckets] of Object.entries(rec)) {
 }
 
 await fs.writeFile('pools-metrics.json', JSON.stringify(out, null, 2));
-console.log('Wrote pools-metrics.json');
+console.log('Updated pools-metrics.json with return metrics (ret5/ret20).');
 /* === ADDITIVE EXPORT: expose fetchByTickers for other scripts === */
 let fetchByTickers;
 try {


### PR DESCRIPTION
### Motivation
- `pools-metrics.json` generated by `tools/buildPoolsTrendy.js` contains many diagnostic scores but was being clobbered to only return data by a later step. 
- The workflow runs `tools/buildPoolsTrendy.js` before `fetchReturns.js`, so a destructive write in `fetchReturns.js` effectively removed the richer metrics.

### Description
- Change `fetchReturns.js` to load the existing `pools-metrics.json` (if present) instead of starting with an empty object. 
- Ensure `out[market]` is preserved by initializing it only when missing and not overwriting existing market entries. 
- Merge computed `ret5` and `ret20` into each symbol entry by copying the previous object and adding the new fields instead of replacing the whole entry. 
- Update the final log to reflect that the script now updates/merges return metrics rather than rewriting the file.

### Testing
- Ran the repository test with `node tests/apple_association.test.js`, which passed. 
- Executed `node fetchReturns.js` locally to verify it reports merged-update behavior and that `pools-metrics.json` retains existing score fields while adding `ret5`/`ret20` (manual/automated run succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ff99cda638833197565d887989c616)