### PR TITLE
Fix daily builder crash when pool market entries are not arrays

### DIFF
--- a/tools/buildPoolsTrendy.v2.js
+++ b/tools/buildPoolsTrendy.v2.js
@@ -17,6 +17,15 @@ function toMap(list, key = 'symbol') {
   return m;
 }
 
+function toArray(value) {
+  if (Array.isArray(value)) return value;
+  if (value && typeof value === 'object') {
+    if (Array.isArray(value.items)) return value.items;
+    if (Array.isArray(value.list)) return value.list;
+  }
+  return [];
+}
+
 function feedbackWeight(feedback, market, symbol) {
   const node = feedback?.[market]?.[symbol];
   if (!node) return 0;
@@ -126,7 +135,7 @@ export async function main() {
   };
 
   for (const [market, list] of Object.entries(pools)) {
-    const entries = (list || []).map(x => typeof x === 'string' ? { symbol: x } : { ...x });
+    const entries = toArray(list).map(x => typeof x === 'string' ? { symbol: x } : { ...x });
     const tickers = entries.map(x => x.symbol).filter(Boolean);
     const quotes = await fetchByTickers(tickers);
     const quoteMap = toMap(quotes);


### PR DESCRIPTION
### Motivation
- The daily builder crashed with `TypeError: (list || []).map is not a function` when a market entry in `pools.json` was not an array, so the script must tolerate varied pool shapes.

### Description
- Added a `toArray` normalizer in `tools/buildPoolsTrendy.v2.js` that returns an array, or extracts `items`/`list` when the market value is an object, and otherwise returns `[]`.
- Replaced the direct `(list || []).map(...)` usage with `toArray(list).map(...)` to avoid the runtime error and produce a predictable entries list.
- Preserved existing scoring logic and output behavior, continuing to write `pools.json` and `pools-metrics.json` as before.

### Testing
- Ran the repository test with `node tests/apple_association.test.js` and it passed (`All tests passed`).
- Executed the builder with `node tools/buildPoolsTrendy.v2.js` which completed successfully and updated outputs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ffe8cf0a308331bd5bf9c6ad0bd62c)