### PR TITLE
Use pools-metrics entries to drive recommendation scoring reliably

### DIFF
--- a/fetchStockInfo.js
+++ b/fetchStockInfo.js
@@ -740,8 +740,43 @@ function pickDeterministic(arr, k, seed) {
   return a.slice(0, k);
 }
 
+
+function normalizeMetricKey(value) {
+  return String(value || '')
+    .trim()
+    .toUpperCase()
+    .replace(/\s+/g, ' ')
+    .replace(/\./g, '-')
+    .replace(/\s*\(\s*B\s*\)/g, '-B')
+    .replace(/\s*\(\s*A\s*\)/g, '-A');
+}
+
+function getMarketMetricsBucket(market) {
+  return poolsMetricsRaw?.markets?.[market] || poolsMetricsRaw?.[market] || null;
+}
+
+function getMetricsForEntry(market, nameOrTicker) {
+  const bucket = getMarketMetricsBucket(market);
+  if (!bucket || !nameOrTicker) return null;
+
+  if (bucket[nameOrTicker]) return bucket[nameOrTicker];
+
+  const lookupKeys = new Set();
+  lookupKeys.add(normalizeMetricKey(nameOrTicker));
+  const canon = canonSymbol(String(nameOrTicker));
+  if (canon) {
+    lookupKeys.add(normalizeMetricKey(canon));
+    const display = INDEX_NAME[canon];
+    if (display) lookupKeys.add(normalizeMetricKey(display));
+  }
+
+  for (const [k, v] of Object.entries(bucket)) {
+    if (lookupKeys.has(normalizeMetricKey(k))) return v;
+  }
+  return null;
+}
 function metricScoreFor(market, name) {
-  const metrics = poolsMetricsRaw?.markets?.[market]?.[name] || poolsMetricsRaw?.[market]?.[name];
+  const metrics = getMetricsForEntry(market, name);
   if (typeof metrics?.score === 'number') return metrics.score;
   if (typeof metrics?.score?.total === 'number') return metrics.score.total;
   if (typeof metrics?.score?.safe === 'number') return metrics.score.safe * 100;
@@ -1463,7 +1498,7 @@ async function tryFetchAndEnrich() {
 
           const news = ticker ? (newsFeatures[ticker] || {}) : {};
           const trend = ticker ? (naverTrends[ticker] || {}) : {};
-          const metrics = poolsMetricsRaw.markets?.[market]?.[rawName] || poolsMetricsRaw[market]?.[rawName];
+          const metrics = getMetricsForEntry(market, rawName);
           let baseScore = null;
           if (typeof metrics?.score === 'number') baseScore = Math.round(metrics.score);
           else if (typeof metrics?.score?.total === 'number') baseScore = Math.round(metrics.score.total);
@@ -1508,7 +1543,7 @@ async function tryFetchAndEnrich() {
           if (sector) successCount++;
         } catch (err) {
           console.error(`[ERROR] ${rawName}: ${err.message}`);
-          const metrics = poolsMetricsRaw.markets?.[market]?.[rawName] || poolsMetricsRaw[market]?.[rawName];
+          const metrics = getMetricsForEntry(market, rawName);
           let baseScore = null;
           if (typeof metrics?.score === 'number') baseScore = Math.round(metrics.score);
           else if (typeof metrics?.score?.total === 'number') baseScore = Math.round(metrics.score.total);
@@ -1591,7 +1626,7 @@ async function main() {
       for (const tier of ['safe', 'aggressive']) {
         const arr = bucket[tier] || [];
         for (const entry of arr) {
-          const metrics = poolsMetricsRaw.markets?.[market]?.[entry.name] || poolsMetricsRaw[market]?.[entry.name];
+          const metrics = getMetricsForEntry(market, entry.name);
           if (metrics) {
             if (typeof metrics.score === 'number') entry.score = Math.round(metrics.score);
             else if (typeof metrics.score?.total === 'number') entry.score = Math.round(metrics.score.total);


### PR DESCRIPTION
### Motivation
- Ensure `recommendations.json` entries inherit scores and signals from `pools-metrics.json` so the site shows the intended scoring for pool tickers. 
- Fix missed metric matches caused by differences between display names and canonical tickers (punctuation, `(B)/(A)` suffixes, and other alias forms). 
- Make the pool-based rotation and fallback selection pick tickers along with their proper scores from `pools-metrics`.

### Description
- Added `normalizeMetricKey`, `getMarketMetricsBucket`, and `getMetricsForEntry` helpers to `fetchStockInfo.js` to normalize keys and resolve metrics by name, ticker, or common aliases. 
- Switched direct `poolsMetricsRaw` lookups to use `getMetricsForEntry(...)` in `metricScoreFor(...)`, the main recommendation enrichment loop, and the rotation fallback so score/signal fields come from `pools-metrics.json`. 
- Kept existing behaviors including price enrichment and fallback rotation, and preserved default scoring (assigning `50` when no metric is found). 
- Wrote recommendations atomically and preserved the prior enhanced/remote fetch paths; changes are additive and scoped to metric resolution.

### Testing
- Ran the repository test with `node tests/apple_association.test.js` which succeeded (`All tests passed`).
- Performed a syntax/check run with `node --check fetchStockInfo.js` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fffb9a9144833191bed024e8d7b15b)