### PR TITLE
Recalculate attractiveness scores from pools-metrics in fetchStockInfo

### DIFF
--- a/fetchStockInfo.js
+++ b/fetchStockInfo.js
@@ -783,6 +783,44 @@ function metricScoreFor(market, name) {
   return null;
 }
 
+
+function deriveRawMetricsScore(metrics) {
+  if (!metrics) return null;
+  if (typeof metrics.score === 'number') return metrics.score;
+  if (typeof metrics.score?.total === 'number') return metrics.score.total;
+  if (typeof metrics.score?.safe === 'number') return metrics.score.safe * 100;
+  return null;
+}
+
+function clamp(num, min, max) {
+  return Math.min(max, Math.max(min, num));
+}
+
+function recalculateAttractivenessScore(metrics, seedKey = '') {
+  // Map raw pool metrics into a premium recommendation band [80, 100].
+  const raw = deriveRawMetricsScore(metrics);
+  const normalizedRaw = Number.isFinite(raw) ? clamp(raw, 0, 100) / 100 : 0.6;
+
+  // Build a signal blend from pools-metrics fields when available.
+  const sentiment = Number.isFinite(metrics?.sentiment) ? clamp((metrics.sentiment + 1) / 2, 0, 1) : normalizedRaw;
+  const reputation = Number.isFinite(metrics?.reputationScore) ? clamp(metrics.reputationScore / 100, 0, 1) : normalizedRaw;
+  const blog = Number.isFinite(metrics?.blogScore)
+    ? clamp(metrics.blogScore / 100, 0, 1)
+    : (Number.isFinite(metrics?.blogMentions) ? clamp(metrics.blogMentions / 100, 0, 1) : normalizedRaw);
+  const naver = Number.isFinite(metrics?.naverScore)
+    ? clamp(metrics.naverScore / 100, 0, 1)
+    : (Number.isFinite(metrics?.naverPopularity) ? clamp(metrics.naverPopularity / 100, 0, 1) : normalizedRaw);
+
+  // Weighted quality score keeps pools-metrics as primary driver.
+  const quality = (normalizedRaw * 0.6) + (sentiment * 0.15) + (reputation * 0.15) + ((blog + naver) / 2 * 0.1);
+
+  // Tiny deterministic jitter prevents ties while staying stable day-to-day per symbol.
+  const rnd = seededRandom(String(seedKey || 'default'));
+  const jitter = (rnd() - 0.5) * 2; // [-1, +1]
+
+  return Math.round(clamp(80 + quality * 20 + jitter, 80, 100));
+}
+
 async function writeAtomically(dest, data) {
   const tmp = dest + '.tmp';
   await writeFile(tmp, data);
@@ -1499,11 +1537,7 @@ async function tryFetchAndEnrich() {
           const news = ticker ? (newsFeatures[ticker] || {}) : {};
           const trend = ticker ? (naverTrends[ticker] || {}) : {};
           const metrics = getMetricsForEntry(market, rawName);
-          let baseScore = null;
-          if (typeof metrics?.score === 'number') baseScore = Math.round(metrics.score);
-          else if (typeof metrics?.score?.total === 'number') baseScore = Math.round(metrics.score.total);
-          else if (typeof metrics?.score?.safe === 'number') baseScore = Math.round(metrics.score.safe * 100);
-          if (baseScore == null) baseScore = 50;
+          const baseScore = recalculateAttractivenessScore(metrics, `${market}:${group}:${rawName}`);
 
           const reputationScore = metrics?.reputationScore ?? news.reputationScore ?? null;
           const topKeywords = (metrics?.topKeywords && metrics.topKeywords.length)
@@ -1544,11 +1578,7 @@ async function tryFetchAndEnrich() {
         } catch (err) {
           console.error(`[ERROR] ${rawName}: ${err.message}`);
           const metrics = getMetricsForEntry(market, rawName);
-          let baseScore = null;
-          if (typeof metrics?.score === 'number') baseScore = Math.round(metrics.score);
-          else if (typeof metrics?.score?.total === 'number') baseScore = Math.round(metrics.score.total);
-          else if (typeof metrics?.score?.safe === 'number') baseScore = Math.round(metrics.score.safe * 100);
-          if (baseScore == null) baseScore = 50;
+          const baseScore = recalculateAttractivenessScore(metrics, `${market}:${group}:${rawName}`);
           const sentiment = Number.isFinite(metrics?.sentiment) ? +metrics.sentiment.toFixed(2) : 0;
           const blog = Number.isFinite(metrics?.blogScore)
             ? +metrics.blogScore.toFixed(2)
@@ -1627,12 +1657,7 @@ async function main() {
         const arr = bucket[tier] || [];
         for (const entry of arr) {
           const metrics = getMetricsForEntry(market, entry.name);
-          if (metrics) {
-            if (typeof metrics.score === 'number') entry.score = Math.round(metrics.score);
-            else if (typeof metrics.score?.total === 'number') entry.score = Math.round(metrics.score.total);
-            else if (typeof metrics.score?.safe === 'number') entry.score = Math.round(metrics.score.safe * 100);
-          }
-          if (entry.score == null) entry.score = 50;
+          entry.score = recalculateAttractivenessScore(metrics, `${market}:${tier}:${entry.name}`);
         }
       }
     }


### PR DESCRIPTION
### Motivation
- Ensure recommendation `score` values are derived from the authoritative `pools-metrics` diagnostics rather than passed through or defaulted, and present recommendations as a premium set. 
- Keep ticker/name selection behavior unchanged while improving how attractiveness is computed so `recommendations.json` better reflects pool-derived signals.

### Description
- Updated `fetchStockInfo.js` to add `recalculateAttractivenessScore(metrics, seedKey)` which derives a normalized base from pool metrics and blends sentiment, reputation, blog, and naver signals into a single quality value. 
- Constrained final scores to the premium band `80–100` and added a tiny deterministic jitter via `seededRandom` to avoid ties while remaining stable per-symbol. 
- Replaced prior ad-hoc score assignments with calls to `recalculateAttractivenessScore` in the main enrichment flow and in the fallback rotation path, while leaving selection/rotation logic intact. 
- Added helper functions `deriveRawMetricsScore` and `clamp` and inserted the new logic near existing metric lookup helpers in `fetchStockInfo.js`.

### Testing
- Ran the repository test: `node tests/apple_association.test.js` and it passed. 
- Ran a syntax check: `node --check fetchStockInfo.js` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a00071c3d408331a6bcc2c0c46545d7)