### PR TITLE
Fix NASDAQ 100 pool shrinkage from cross-market de-dup

### DIFF
--- a/tools/buildPoolsTrendy.js
+++ b/tools/buildPoolsTrendy.js
@@ -2788,9 +2788,17 @@ async function main(){
     function filterOutEarlier(list) {
       const out = [];
       const seen = new Set();
+      // NASDAQ 100 naturally overlaps heavily with S&P 500.
+      // If we remove all earlier-market symbols, NASDAQ pools can collapse to
+      // a very small list. Keep cross-market de-dup for other markets, but
+      // preserve NASDAQ 100 breadth by only de-duping within itself.
+      const skipCrossMarketDedup = (market === 'NASDAQ 100');
       for (const n of list) {
         const sym = nameToSymbol(n) || n; rememberMapping(n, sym);
-        if (!earlierSet.has(sym) && !seen.has(sym)) { out.push(n); seen.add(sym); }
+        if (!seen.has(sym) && (skipCrossMarketDedup || !earlierSet.has(sym))) {
+          out.push(n);
+          seen.add(sym);
+        }
       }
       return out;
     }


### PR DESCRIPTION
### Motivation
- NASDAQ 100 was losing most of its constituents because the builder de-duplicated each market against symbols already selected in earlier markets (notably the S&P 500), producing undersized `safe`/`aggressive` buckets and sparse metrics.
- The intent is to preserve NASDAQ 100 breadth while still avoiding duplicate symbols within the same market.

### Description
- Modified `tools/buildPoolsTrendy.js` `filterOutEarlier` to skip cross-market de-duplication when `market === 'NASDAQ 100'` while keeping intra-market duplicate filtering.
- The change retains the existing `CROSS_MARKET_DEDUP` behavior for all other markets so cross-market dedup remains enabled elsewhere.
- Added a short comment explaining the rationale so NASDAQ 100 breadth is preserved and metrics coverage remains healthy.

### Testing
- Ran the repository test with `node tests/apple_association.test.js`, which succeeded (`All tests passed`).
- Executed `OFFLINE=1 node tools/buildPoolsTrendy.js --dry-run` and observed the NASDAQ universe maintained expected breadth (e.g., `market=NASDAQ 100 names=111`) and the run completed producing diagnostics.
- Verified offline run behavior (offline intentionally leaves `pools.json` unchanged while writing `pools-metrics.json`) and confirmed no errors in the dry-run output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0026b37ed483318e8aedc2de406f9c)