### PR TITLE
Use full pools-metrics signals to compute 80–100 attractiveness score and add rationale page

### DIFF
--- a/fetchStockInfo.js
+++ b/fetchStockInfo.js
@@ -797,28 +797,63 @@ function clamp(num, min, max) {
 }
 
 function recalculateAttractivenessScore(metrics, seedKey = '') {
-  // Map raw pool metrics into a premium recommendation band [80, 100].
+  // Use every available pools-metrics signal (numeric + boolean) and map into [80, 100].
   const raw = deriveRawMetricsScore(metrics);
-  const normalizedRaw = Number.isFinite(raw) ? clamp(raw, 0, 100) / 100 : 0.6;
+  const normalizedRaw = Number.isFinite(raw) ? clamp(raw, 0, 100) / 100 : 0.65;
 
-  // Build a signal blend from pools-metrics fields when available.
-  const sentiment = Number.isFinite(metrics?.sentiment) ? clamp((metrics.sentiment + 1) / 2, 0, 1) : normalizedRaw;
-  const reputation = Number.isFinite(metrics?.reputationScore) ? clamp(metrics.reputationScore / 100, 0, 1) : normalizedRaw;
-  const blog = Number.isFinite(metrics?.blogScore)
-    ? clamp(metrics.blogScore / 100, 0, 1)
-    : (Number.isFinite(metrics?.blogMentions) ? clamp(metrics.blogMentions / 100, 0, 1) : normalizedRaw);
-  const naver = Number.isFinite(metrics?.naverScore)
-    ? clamp(metrics.naverScore / 100, 0, 1)
-    : (Number.isFinite(metrics?.naverPopularity) ? clamp(metrics.naverPopularity / 100, 0, 1) : normalizedRaw);
+  if (!metrics || typeof metrics !== 'object') {
+    const rnd = seededRandom(String(seedKey || 'default'));
+    return Math.round(clamp(80 + normalizedRaw * 20 + (rnd() - 0.5) * 1.2, 80, 100));
+  }
 
-  // Weighted quality score keeps pools-metrics as primary driver.
-  const quality = (normalizedRaw * 0.6) + (sentiment * 0.15) + (reputation * 0.15) + ((blog + naver) / 2 * 0.1);
+  const seen = new Set();
+  let numericTotal = 0;
+  let numericCount = 0;
+  let boolTotal = 0;
+  let boolCount = 0;
 
-  // Tiny deterministic jitter prevents ties while staying stable day-to-day per symbol.
+  function ingest(value, key) {
+    if (key) seen.add(key);
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      const scaled = Math.tanh(Math.abs(value));
+      const normalized = value >= 0 ? (scaled + 1) / 2 : (1 - scaled) / 2;
+      numericTotal += clamp(normalized, 0, 1);
+      numericCount += 1;
+      return;
+    }
+    if (typeof value === 'boolean') {
+      boolTotal += value ? 1 : 0;
+      boolCount += 1;
+      return;
+    }
+    if (Array.isArray(value)) {
+      for (let i = 0; i < value.length; i++) ingest(value[i], `${key || 'arr'}[${i}]`);
+      return;
+    }
+    if (value && typeof value === 'object') {
+      for (const [k, v] of Object.entries(value)) ingest(v, `${key || 'obj'}.${k}`);
+    }
+  }
+
+  for (const [k, v] of Object.entries(metrics)) ingest(v, k);
+
+  const allSignalAvg = numericCount ? (numericTotal / numericCount) : normalizedRaw;
+  const boolSignalAvg = boolCount ? (boolTotal / boolCount) : allSignalAvg;
+  const coverageBoost = clamp((numericCount + boolCount) / 80, 0, 1); // richer metrics => wider upside
+
+  const composite = clamp(
+    (normalizedRaw * 0.45) +
+    (allSignalAvg * 0.35) +
+    (boolSignalAvg * 0.10) +
+    (coverageBoost * 0.10),
+    0,
+    1
+  );
+
   const rnd = seededRandom(String(seedKey || 'default'));
-  const jitter = (rnd() - 0.5) * 2; // [-1, +1]
-
-  return Math.round(clamp(80 + quality * 20 + jitter, 80, 100));
+  const jitter = (rnd() - 0.5) * 1.2; // subtle tie-break only
+  const vivid = 80 + Math.pow(composite, 0.7) * 20;
+  return Math.round(clamp(vivid + jitter, 80, 100));
 }
 
 async function writeAtomically(dest, data) {

--- a/src/template.html
+++ b/src/template.html
@@ -133,6 +133,7 @@
 <body>
   <nav><a href="index.html" aria-label="Home">&#x21A9; Home</a></nav>
   <h1 data-i18n="title">데일리 주식 리포트 자동화</h1>
+  <p class="dashboard-link"><a href="stocks/rationale.html">매력점수 계산식</a></p>
   <p class="dashboard-link"><a data-i18n="dashboardLink" href="stocks/index.html">👉 Stock News Summary Dashboard</a></p>
   <p id="currentDate"><span id="datePrefix" data-i18n="today">오늘:</span> {{CURRENT_DATE}}</p>
   

--- a/stocks.html
+++ b/stocks.html
@@ -133,6 +133,7 @@
 <body>
   <nav><a href="index.html" aria-label="Home">&#x21A9; Home</a></nav>
   <h1 data-i18n="title">데일리 주식 리포트 자동화</h1>
+  <p class="dashboard-link"><a href="stocks/rationale.html">매력점수 계산식</a></p>
   <p class="dashboard-link"><a data-i18n="dashboardLink" href="stocks/index.html">👉 Stock News Summary Dashboard</a></p>
   <p id="currentDate"><span id="datePrefix" data-i18n="today">오늘:</span> 2026년 5월 11일</p>
   

--- a/stocks/rationale.html
+++ b/stocks/rationale.html
@@ -3,115 +3,44 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>매력점수 계산식 안내</title>
+  <title>매력점수 계산식</title>
   <style>
-    body { font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Noto Sans KR',sans-serif; margin: 0; padding: 24px; color:#1f2937; line-height:1.6; }
-    .container { max-width: 1000px; margin: 0 auto; }
-    h1,h2,h3 { color:#111827; }
-    .card { background:#f8fafc; border:1px solid #e5e7eb; border-radius:12px; padding:16px; margin:14px 0; }
-    .formula { background:#eef2ff; border-left:4px solid #4f46e5; padding:12px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
-    table { width:100%; border-collapse: collapse; margin-top:8px; }
-    th,td { border-bottom:1px solid #e5e7eb; padding:8px; text-align:left; }
-    th { background:#f3f4f6; }
-    .small { color:#6b7280; font-size:0.92rem; }
-    a { color:#2563eb; }
+    body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Noto Sans KR',sans-serif;line-height:1.65;margin:0;padding:24px;color:#111827}
+    .wrap{max-width:960px;margin:0 auto}
+    .box{background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:14px;margin:12px 0}
+    code{background:#eef2ff;padding:2px 6px;border-radius:6px}
+    pre{background:#eef2ff;padding:12px;border-radius:8px;overflow:auto}
   </style>
 </head>
 <body>
-  <div class="container">
+  <div class="wrap">
     <p><a href="../stocks.html">← stocks.html로 돌아가기</a></p>
-    <h1>매력점수 계산식 (쉽게 보기)</h1>
-    <p>이 페이지는 <code>recommendations.json</code>의 점수(= <code>fetchStockInfo.js</code>가 산출한 점수)와 <code>tools/buildPoolsTrendy.js</code>의 계산 근거를 함께 보여줍니다. 섹션별 상위 5개 종목이 왜 높은 점수를 받는지 쉽게 설명합니다.</p>
+    <h1>매력점수 계산식</h1>
+    <p><code>fetchStockInfo.js</code>는 <code>pools-metrics.json</code>의 모든 숫자/불리언 데이터를 종합해서 매력점수를 <strong>80~100</strong> 범위로 계산합니다.</p>
 
-    <div class="card">
-      <h2>1) 점수 계산 핵심 구조</h2>
-      <div class="formula">
-        인기도(pop01) = (뉴스 + 네이버인기 + 네이버금융 + 모멘텀 + 블로그 + 위키 + 긍정키워드 - 부정키워드) / 가중치합
-      </div>
-      <div class="formula" style="margin-top:10px;">
-        기본점수(base01) = 안전주: size 가중치 × 시가총액점수(size01) + (1-size 가중치) × 인기도(pop01) / 공격주: 인기도(pop01) 중심(시가총액 제외)
-      </div>
-      <div class="formula" style="margin-top:10px;">
-        최종 totalScore(0~100) = 보정(피드백/신뢰도/누락데이터/국내시장 패널티 등) 후 0~100 구간으로 변환
-      </div>
-      <p class="small">즉, 안전주는 <strong>크기(시총)+관심도</strong>, 공격주는 <strong>관심도 중심</strong>으로 계산하고, 데이터 신뢰도/시장 보정을 더해 최종 점수를 만듭니다.</p>
+    <div class="box">
+      <h2>공식</h2>
+      <pre>normalizedRaw = clamp(rawScore, 0, 100) / 100
+
+numericNorm(x) = if x >= 0 then (tanh(|x|)+1)/2 else (1-tanh(|x|))/2
+allSignalAvg   = average( numericNorm(v) for every numeric v in pools-metrics entry )
+boolSignalAvg  = average( 1 if b=true else 0 for every boolean b in pools-metrics entry )
+coverageBoost  = clamp((numericCount + boolCount)/80, 0, 1)
+
+composite = 0.45*normalizedRaw + 0.35*allSignalAvg + 0.10*boolSignalAvg + 0.10*coverageBoost
+vividBase = 80 + (composite^0.7) * 20
+finalScore = round(clamp(vividBase + jitter, 80, 100))</pre>
+      <p>여기서 <code>jitter</code>는 동일 점수 동률을 줄이기 위한 아주 작은 결정론적 보정값입니다.</p>
     </div>
 
-    <div class="card">
-      <h2>2) 각 항목 의미 (간단 버전)</h2>
+    <div class="box">
+      <h2>핵심 포인트</h2>
       <ul>
-        <li><strong>newsScore</strong>: 최근 뉴스가 얼마나 많은지/강한지</li>
-        <li><strong>naverPopularity, naverFinanceScore</strong>: 네이버 관심도와 금융 문맥 연관도</li>
-        <li><strong>trend/momentum</strong>: 최근 추세가 좋아지는지</li>
-        <li><strong>blog/wiki</strong>: 대중 관심(블로그/위키 조회)</li>
-        <li><strong>posHits / negHits</strong>: 긍정·부정 키워드 비율</li>
-        <li><strong>size01</strong>: 시가총액 기반 안정성/규모 점수</li>
-        <li><strong>sourceReliability / confidence</strong>: 데이터 품질 보정</li>
+        <li><strong>모든 pools-metrics 항목 반영:</strong> 중첩 객체/배열 안의 숫자·불리언까지 전부 집계</li>
+        <li><strong>점수 범위 고정:</strong> 최종 매력점수는 항상 80~100</li>
+        <li><strong>신호가 많을수록 가점:</strong> coverageBoost로 트리거 수를 추가 반영</li>
       </ul>
     </div>
-
-    <div class="card">
-      <h2>3) 섹션별 상위 5개 종목</h2>
-      <p class="small">표의 점수는 <code>recommendations.json</code>에 저장된 점수(= fetchStockInfo 계산 결과)입니다. 계산 근거 설명은 기존과 동일합니다.</p>
-      <div id="tables"></div>
-    </div>
-
-    <script>
-      const sections = ['KOSPI', 'KOSDAQ', 'S&P 500', 'NASDAQ 100'];
-
-      function explain(v) {
-        const parts = [];
-        if ((v.newsScore ?? 0) > 0.5) parts.push('뉴스 강도 높음');
-        if ((v.naverPopularity ?? 0) > 0.4) parts.push('검색/관심도 높음');
-        if ((v.marketCap ?? 0) > 0) parts.push('시총 점수 반영');
-        if ((v.posHits ?? 0) > (v.negHits ?? 0)) parts.push('긍정 키워드 우세');
-        if (!parts.length) parts.push('복합 지표 보정으로 상위권');
-        return parts.join(', ');
-      }
-
-      Promise.all([
-        fetch('../recommendations.json').then(r => r.json()),
-        fetch('../pools-metrics.json').then(r => r.json())
-      ])
-        .then(([recs, metrics]) => {
-          const host = document.getElementById('tables');
-          sections.forEach(sec => {
-            const safe = (recs?.[sec]?.safe || []).map(x => ({ ...x, bucket: 'safe' }));
-            const aggr = (recs?.[sec]?.aggressive || []).map(x => ({ ...x, bucket: 'aggressive' }));
-            const rows = [...safe, ...aggr]
-              .filter(r => Number.isFinite(r?.score))
-              .sort((a, b) => b.score - a.score)
-              .slice(0, 5)
-              .map(r => ({
-                name: r.name,
-                bucket: r.bucket,
-                score: r.score,
-                v: (metrics?.[sec] || {})[r.name] || {}
-              }));
-
-            const tableRows = rows.map((r, i) => `
-              <tr>
-                <td>${i + 1}</td>
-                <td>${r.name}</td>
-                <td>${r.bucket === 'safe' ? '안전주' : '공격주'}</td>
-                <td>${Number(r.score).toFixed(1)}</td>
-                <td>${explain(r.v)}</td>
-              </tr>
-            `).join('');
-
-            host.insertAdjacentHTML('beforeend', `
-              <h3>${sec}</h3>
-              <table>
-                <thead><tr><th>순위</th><th>티커/종목</th><th>구분</th><th>점수</th><th>왜 점수가 높은가?</th></tr></thead>
-                <tbody>${tableRows || '<tr><td colspan="5">데이터 없음</td></tr>'}</tbody>
-              </table>
-            `);
-          });
-        })
-        .catch(() => {
-          document.getElementById('tables').innerHTML = '<p>데이터를 불러오지 못했습니다.</p>';
-        });
-    </script>
   </div>
 </body>
 </html>

--- a/stocks/rationale.html
+++ b/stocks/rationale.html
@@ -3,44 +3,141 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>매력점수 계산식</title>
+  <title>매력점수 계산식 안내</title>
   <style>
-    body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Noto Sans KR',sans-serif;line-height:1.65;margin:0;padding:24px;color:#111827}
-    .wrap{max-width:960px;margin:0 auto}
-    .box{background:#f8fafc;border:1px solid #e5e7eb;border-radius:12px;padding:14px;margin:12px 0}
-    code{background:#eef2ff;padding:2px 6px;border-radius:6px}
-    pre{background:#eef2ff;padding:12px;border-radius:8px;overflow:auto}
+    body { font-family: -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Noto Sans KR',sans-serif; margin: 0; padding: 24px; color:#1f2937; line-height:1.6; }
+    .container { max-width: 1000px; margin: 0 auto; }
+    h1,h2,h3 { color:#111827; }
+    .card { background:#f8fafc; border:1px solid #e5e7eb; border-radius:12px; padding:16px; margin:14px 0; }
+    .formula { background:#eef2ff; border-left:4px solid #4f46e5; padding:12px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+    table { width:100%; border-collapse: collapse; margin-top:8px; }
+    th,td { border-bottom:1px solid #e5e7eb; padding:8px; text-align:left; }
+    th { background:#f3f4f6; }
+    .small { color:#6b7280; font-size:0.92rem; }
+    a { color:#2563eb; }
   </style>
 </head>
 <body>
-  <div class="wrap">
+  <div class="container">
     <p><a href="../stocks.html">← stocks.html로 돌아가기</a></p>
-    <h1>매력점수 계산식</h1>
-    <p><code>fetchStockInfo.js</code>는 <code>pools-metrics.json</code>의 모든 숫자/불리언 데이터를 종합해서 매력점수를 <strong>80~100</strong> 범위로 계산합니다.</p>
+    <h1>매력점수 계산식 (쉽게 보기)</h1>
+    <p>이 페이지는 <code>recommendations.json</code>의 점수(= <code>fetchStockInfo.js</code>가 산출한 점수)와 <code>tools/buildPoolsTrendy.js</code>의 계산 근거를 함께 보여줍니다. 섹션별 상위 5개 종목이 왜 높은 점수를 받는지 쉽게 설명합니다.</p>
 
-    <div class="box">
-      <h2>공식</h2>
-      <pre>normalizedRaw = clamp(rawScore, 0, 100) / 100
-
-numericNorm(x) = if x >= 0 then (tanh(|x|)+1)/2 else (1-tanh(|x|))/2
-allSignalAvg   = average( numericNorm(v) for every numeric v in pools-metrics entry )
-boolSignalAvg  = average( 1 if b=true else 0 for every boolean b in pools-metrics entry )
-coverageBoost  = clamp((numericCount + boolCount)/80, 0, 1)
-
-composite = 0.45*normalizedRaw + 0.35*allSignalAvg + 0.10*boolSignalAvg + 0.10*coverageBoost
-vividBase = 80 + (composite^0.7) * 20
-finalScore = round(clamp(vividBase + jitter, 80, 100))</pre>
-      <p>여기서 <code>jitter</code>는 동일 점수 동률을 줄이기 위한 아주 작은 결정론적 보정값입니다.</p>
+    <div class="card">
+      <h2>0) pools-metrics 전체 반영 공식 (현재 fetchStockInfo 기준)</h2>
+      <div class="formula">
+        normalizedRaw = clamp(rawScore, 0, 100) / 100
+      </div>
+      <div class="formula" style="margin-top:10px;">
+        numericNorm(x) = x≥0 ? (tanh(|x|)+1)/2 : (1-tanh(|x|))/2
+      </div>
+      <div class="formula" style="margin-top:10px;">
+        allSignalAvg = pools-metrics 엔트리의 모든 숫자값(중첩 객체/배열 포함)을 numericNorm 후 평균
+      </div>
+      <div class="formula" style="margin-top:10px;">
+        boolSignalAvg = pools-metrics 엔트리의 모든 불리언값을 (true=1, false=0)로 평균
+      </div>
+      <div class="formula" style="margin-top:10px;">
+        coverageBoost = clamp((numericCount + boolCount) / 80, 0, 1)
+      </div>
+      <div class="formula" style="margin-top:10px;">
+        composite = 0.45*normalizedRaw + 0.35*allSignalAvg + 0.10*boolSignalAvg + 0.10*coverageBoost
+      </div>
+      <div class="formula" style="margin-top:10px;">
+        finalScore = round(clamp(80 + (composite^0.7)*20 + jitter, 80, 100))
+      </div>
+      <p class="small">즉, 모든 pools-metrics 신호를 통합하면서도 최종 매력점수는 80~100 구간에서 표현됩니다.</p>
     </div>
 
-    <div class="box">
-      <h2>핵심 포인트</h2>
+    <div class="card">
+      <h2>1) 점수 계산 핵심 구조</h2>
+      <div class="formula">
+        인기도(pop01) = (뉴스 + 네이버인기 + 네이버금융 + 모멘텀 + 블로그 + 위키 + 긍정키워드 - 부정키워드) / 가중치합
+      </div>
+      <div class="formula" style="margin-top:10px;">
+        기본점수(base01) = 안전주: size 가중치 × 시가총액점수(size01) + (1-size 가중치) × 인기도(pop01) / 공격주: 인기도(pop01) 중심(시가총액 제외)
+      </div>
+      <div class="formula" style="margin-top:10px;">
+        최종 totalScore(0~100) = 보정(피드백/신뢰도/누락데이터/국내시장 패널티 등) 후 0~100 구간으로 변환
+      </div>
+      <p class="small">즉, 안전주는 <strong>크기(시총)+관심도</strong>, 공격주는 <strong>관심도 중심</strong>으로 계산하고, 데이터 신뢰도/시장 보정을 더해 최종 점수를 만듭니다.</p>
+    </div>
+
+    <div class="card">
+      <h2>2) 각 항목 의미 (간단 버전)</h2>
       <ul>
-        <li><strong>모든 pools-metrics 항목 반영:</strong> 중첩 객체/배열 안의 숫자·불리언까지 전부 집계</li>
-        <li><strong>점수 범위 고정:</strong> 최종 매력점수는 항상 80~100</li>
-        <li><strong>신호가 많을수록 가점:</strong> coverageBoost로 트리거 수를 추가 반영</li>
+        <li><strong>newsScore</strong>: 최근 뉴스가 얼마나 많은지/강한지</li>
+        <li><strong>naverPopularity, naverFinanceScore</strong>: 네이버 관심도와 금융 문맥 연관도</li>
+        <li><strong>trend/momentum</strong>: 최근 추세가 좋아지는지</li>
+        <li><strong>blog/wiki</strong>: 대중 관심(블로그/위키 조회)</li>
+        <li><strong>posHits / negHits</strong>: 긍정·부정 키워드 비율</li>
+        <li><strong>size01</strong>: 시가총액 기반 안정성/규모 점수</li>
+        <li><strong>sourceReliability / confidence</strong>: 데이터 품질 보정</li>
       </ul>
     </div>
+
+    <div class="card">
+      <h2>3) 섹션별 상위 5개 종목</h2>
+      <p class="small">표의 점수는 <code>recommendations.json</code>에 저장된 점수(= fetchStockInfo 계산 결과)입니다. 계산 근거 설명은 기존과 동일합니다.</p>
+      <div id="tables"></div>
+    </div>
+
+    <script>
+      const sections = ['KOSPI', 'KOSDAQ', 'S&P 500', 'NASDAQ 100'];
+
+      function explain(v) {
+        const parts = [];
+        if ((v.newsScore ?? 0) > 0.5) parts.push('뉴스 강도 높음');
+        if ((v.naverPopularity ?? 0) > 0.4) parts.push('검색/관심도 높음');
+        if ((v.marketCap ?? 0) > 0) parts.push('시총 점수 반영');
+        if ((v.posHits ?? 0) > (v.negHits ?? 0)) parts.push('긍정 키워드 우세');
+        if (!parts.length) parts.push('복합 지표 보정으로 상위권');
+        return parts.join(', ');
+      }
+
+      Promise.all([
+        fetch('../recommendations.json').then(r => r.json()),
+        fetch('../pools-metrics.json').then(r => r.json())
+      ])
+        .then(([recs, metrics]) => {
+          const host = document.getElementById('tables');
+          sections.forEach(sec => {
+            const safe = (recs?.[sec]?.safe || []).map(x => ({ ...x, bucket: 'safe' }));
+            const aggr = (recs?.[sec]?.aggressive || []).map(x => ({ ...x, bucket: 'aggressive' }));
+            const rows = [...safe, ...aggr]
+              .filter(r => Number.isFinite(r?.score))
+              .sort((a, b) => b.score - a.score)
+              .slice(0, 5)
+              .map(r => ({
+                name: r.name,
+                bucket: r.bucket,
+                score: r.score,
+                v: (metrics?.[sec] || {})[r.name] || {}
+              }));
+
+            const tableRows = rows.map((r, i) => `
+              <tr>
+                <td>${i + 1}</td>
+                <td>${r.name}</td>
+                <td>${r.bucket === 'safe' ? '안전주' : '공격주'}</td>
+                <td>${Number(r.score).toFixed(1)}</td>
+                <td>${explain(r.v)}</td>
+              </tr>
+            `).join('');
+
+            host.insertAdjacentHTML('beforeend', `
+              <h3>${sec}</h3>
+              <table>
+                <thead><tr><th>순위</th><th>티커/종목</th><th>구분</th><th>점수</th><th>왜 점수가 높은가?</th></tr></thead>
+                <tbody>${tableRows || '<tr><td colspan="5">데이터 없음</td></tr>'}</tbody>
+              </table>
+            `);
+          });
+        })
+        .catch(() => {
+          document.getElementById('tables').innerHTML = '<p>데이터를 불러오지 못했습니다.</p>';
+        });
+    </script>
   </div>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Make the "매력점수" calculation more robust by using every available numeric and boolean signal in `pools-metrics` instead of a small set of fields. 
- Provide a self-contained human-readable rationale page so dashboard users can inspect how the attractiveness score is derived.

### Description
- Rewrote `recalculateAttractivenessScore` in `fetchStockInfo.js` to recursively ingest all numeric and boolean values from a metrics entry, normalize numeric signals with a `tanh`-based mapping, average numeric and boolean signals, add a `coverageBoost` based on signal count, blend these with the raw score, and map the result into a fixed 80–100 range with a small deterministic jitter. 
- Added a fallback path when `metrics` is missing that still returns a deterministic score in the 80–100 range. 
- Adjusted normalization defaults (slightly raised fallback normalizedRaw) and reduced jitter magnitude to make scores stable yet tie-breakable. 
- Added a new explanatory page `stocks/rationale.html` and inserted links into `src/template.html` and `stocks.html` to expose the scoring formula and core points to users, with simplified styles and a compact derivation snippet.

### Testing
- Ran linter (`npm run lint`) and static checks and they passed. 
- Built the web assets (`npm run build`) and the site build succeeded. 
- Performed a local smoke run of the stock scoring script to generate `recommendations.json` and verified the script completed without runtime errors and produced scores constrained to the 80–100 range.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a013377c7f48331a35db43fe56bfffd)