### PR TITLE
Use point units for S&P 500 and KOSPI in FX ticker

### DIFF
--- a/src/template.html
+++ b/src/template.html
@@ -1004,7 +1004,9 @@
       .then(data => {
         const fmt = new Intl.NumberFormat('ko-KR', { maximumFractionDigits: 0 });
         const parts = (data.items || []).map(it => {
-          const v = (typeof it.krw === 'number') ? `${fmt.format(it.krw)}원` : '—';
+          const isPoint = ['S&P 500', 'S&P500', 'KOSPI'].includes(it.name);
+          const unit = isPoint ? 'pt' : '원';
+          const v = (typeof it.krw === 'number') ? `${fmt.format(it.krw)}${unit}` : '—';
           return `<span class="fx-item">${it.label} = ${v}</span>`;
         });
         const stamp = `<span class="fx-time">업데이트 ${String(data.lastUpdated).replace('T',' ').replace('+09:00',' KST')}</span>`;

--- a/stocks.html
+++ b/stocks.html
@@ -1004,7 +1004,9 @@
       .then(data => {
         const fmt = new Intl.NumberFormat('ko-KR', { maximumFractionDigits: 0 });
         const parts = (data.items || []).map(it => {
-          const v = (typeof it.krw === 'number') ? `${fmt.format(it.krw)}원` : '—';
+          const isPoint = ['S&P 500', 'S&P500', 'KOSPI'].includes(it.name);
+          const unit = isPoint ? 'pt' : '원';
+          const v = (typeof it.krw === 'number') ? `${fmt.format(it.krw)}${unit}` : '—';
           return `<span class="fx-item">${it.label} = ${v}</span>`;
         });
         const stamp = `<span class="fx-time">업데이트 ${String(data.lastUpdated).replace('T',' ').replace('+09:00',' KST')}</span>`;


### PR DESCRIPTION
### Motivation
- Make index entries in the FX ticker that represent index points display with `pt` instead of the currency label `원` so S&P 500 and KOSPI read naturally as point values.

### Description
- Updated the FX ticker rendering in `src/template.html` and `stocks.html` to detect `it.name` values `['S&P 500', 'S&P500', 'KOSPI']` and set `unit = 'pt'` (falling back to `unit = '원'` for other items) when building the displayed value `v`, while keeping the existing `Intl.NumberFormat('ko-KR', { maximumFractionDigits: 0 })` formatting.

### Testing
- Ran the repository test `node tests/apple_association.test.js` which printed `All tests passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a01472ee8ac833185401297f0e5fee2)