### PR TITLE
Prevent duplicate picks across safe and aggressive buckets

### DIFF
--- a/fetchStockInfo.js
+++ b/fetchStockInfo.js
@@ -1675,6 +1675,32 @@ function validateRecommendations(out) {
   }
 }
 
+function dedupeMarketBuckets(marketData = {}) {
+  const normalizeEntryName = entry => normalizeMetricKey(typeof entry === 'string' ? entry : entry?.name);
+  const seenSafe = new Set();
+  const dedupedSafe = [];
+
+  for (const entry of Array.isArray(marketData.safe) ? marketData.safe : []) {
+    const key = normalizeEntryName(entry);
+    if (!key || seenSafe.has(key)) continue;
+    seenSafe.add(key);
+    dedupedSafe.push(entry);
+  }
+
+  const seenAggressive = new Set();
+  const dedupedAggressive = [];
+  for (const entry of Array.isArray(marketData.aggressive) ? marketData.aggressive : []) {
+    const key = normalizeEntryName(entry);
+    if (!key || seenSafe.has(key) || seenAggressive.has(key)) continue;
+    seenAggressive.add(key);
+    dedupedAggressive.push(entry);
+  }
+
+  marketData.safe = dedupedSafe;
+  marketData.aggressive = dedupedAggressive;
+  return marketData;
+}
+
 // Main data fetching function
 async function tryFetchAndEnrich() {
   const POOLS = await loadPools();
@@ -1752,6 +1778,7 @@ async function tryFetchAndEnrich() {
 
     data[market].safe = finalSafe.map(n => (typeof n === 'string' ? { name: n } : n));
     data[market].aggressive = finalAggr.map(n => (typeof n === 'string' ? { name: n } : n));
+    dedupeMarketBuckets(data[market]);
 
     log[market] = {
       safe: data[market].safe?.map(x => x.name) || [],


### PR DESCRIPTION
### Motivation
- The safe/aggressive rebalance could promote an aggressive pick into `safe` and demote a safe pick without enforcing a final uniqueness check, allowing the same company to appear in both buckets for the same market.
- Ensure the final `recommendations.json` has unique company names per market with `safe` winning ties.

### Description
- Added a helper `dedupeMarketBuckets(marketData)` in `fetchStockInfo.js` which uses `normalizeMetricKey` to normalize names, deduplicates `safe`, and removes any overlapping names from `aggressive`.
- Invoked `dedupeMarketBuckets` immediately after the final `safe`/`aggressive` selection inside `tryFetchAndEnrich` so post-rebalance swaps cannot leave duplicates.

### Testing
- Ran `node tests/apple_association.test.js` and it passed.
- Ran `node fetchStockInfo.js` and the script completed, printed the `[SELECTED]` mapping and `[SUCCESS] Wrote recommendations` indicating the selection flow executed and wrote `recommendations.json` without cross-tier duplicates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a08efd4d9248331b97848932dc40620)