### PR TITLE
Update stocks/rationale.html to reflect scoring logic and add pie-chart visuals

### DIFF
--- a/stocks/rationale.html
+++ b/stocks/rationale.html
@@ -69,14 +69,15 @@
       gap: 20px;
       margin: 20px 0;
     }
-    
+
     .comparison-card {
       background: white;
       border: 2px solid #e5e7eb;
       border-radius: 12px;
       overflow: hidden;
+      padding-bottom: 12px;
     }
-    
+
     .comparison-header {
       background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
       color: white;
@@ -85,84 +86,45 @@
       font-size: 15px;
       text-align: center;
     }
-    
+
     .comparison-card:nth-child(2) .comparison-header {
       background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%);
     }
-    
-    .weight-item {
-      padding: 12px 16px;
-      border-bottom: 1px solid #f3f4f6;
-      display: flex;
-      align-items: center;
-      gap: 12px;
-    }
-    
-    .weight-item:last-child {
-      border-bottom: none;
-    }
-    
-    .weight-bar-container {
-      flex: 1;
-      display: flex;
-      align-items: center;
-      gap: 8px;
-    }
-    
-    .weight-bar {
-      height: 20px;
-      border-radius: 4px;
-      display: flex;
-      align-items: center;
-      justify-content: flex-end;
-      color: white;
-      font-weight: 500;
-      font-size: 12px;
-      padding-right: 6px;
-    }
-    
-    .weight-label {
-      min-width: 80px;
-      font-size: 13px;
-      color: #374151;
-      font-weight: 500;
-    }
-    
-    .weight-percent {
-      min-width: 40px;
-      text-align: right;
-      font-weight: 600;
-      font-size: 13px;
-      color: #111827;
-    }
-    
-    /* Color schemes for weight bars */
-    .naver-bar { background: linear-gradient(90deg, #10b981 0%, #34d399 100%); }
-    .financial-bar { background: linear-gradient(90deg, #3b82f6 0%, #60a5fa 100%); }
-    .news-bar { background: linear-gradient(90deg, #f59e0b 0%, #fbbf24 100%); }
-    
-    .comparison-details {
+
+    .pie-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 16px;
       padding: 16px;
+    }
+
+    .pie-box {
       background: #f9fafb;
+      border: 1px solid #e5e7eb;
+      border-radius: 10px;
+      padding: 12px;
+    }
+
+    .pie-title { font-size: 13px; font-weight: 700; margin-bottom: 10px; }
+    .pie-wrap { display:flex; gap:12px; align-items:center; }
+    .pie { width:96px; height:96px; border-radius:50%; border:1px solid #e5e7eb; }
+    .legend { list-style:none; font-size:12px; color:#374151; }
+    .legend li{ margin:4px 0; }
+    .dot{ display:inline-block; width:10px; height:10px; border-radius:50%; margin-right:6px; }
+
+    .comparison-details {
+      padding: 0 16px 8px 16px;
+      background: #fff;
       font-size: 13px;
       color: #4b5563;
       line-height: 1.6;
     }
-    
-    .comparison-details ul {
-      margin-left: 16px;
-    }
-    
-    .comparison-details li {
-      margin: 4px 0;
-    }
-    
+
     @media (max-width: 768px) {
-      .comparison-container {
-        grid-template-columns: 1fr;
-      }
+      .comparison-container { grid-template-columns: 1fr; }
+      .pie-grid { grid-template-columns: 1fr; }
     }
-    
+
     .back-link {
       display: inline-block;
       margin-bottom: 16px;
@@ -202,106 +164,68 @@
     <!-- NEW: Comparison Chart -->
     <!-- ═══════════════════════════════════════════════════════════════════════ -->
     <div class="card">
-      <h2>📊 점수 계산 방식 비교 (개선 버전)</h2>
-      
+      <h2>📊 점수 계산 방식 비교 (현재 코드 반영)</h2>
+
       <div class="comparison-container">
-        <!-- Korean Stocks -->
         <div class="comparison-card">
           <div class="comparison-header">한국주식 (KOSPI, KOSDAQ)</div>
-          
-          <div class="weight-item">
-            <div class="weight-label">Naver 지표</div>
-            <div class="weight-bar-container">
-              <div class="weight-bar naver-bar" style="width: 55%;">55%</div>
+          <div class="pie-grid">
+            <div class="pie-box">
+              <div class="pie-title">시장 점수 가중치</div>
+              <div class="pie-wrap">
+                <div class="pie" style="background: conic-gradient(#10b981 0 55%, #3b82f6 55% 90%, #f59e0b 90% 100%);"></div>
+                <ul class="legend">
+                  <li><span class="dot" style="background:#10b981"></span>Naver 55%</li>
+                  <li><span class="dot" style="background:#3b82f6"></span>Financial 35%</li>
+                  <li><span class="dot" style="background:#f59e0b"></span>News 10%</li>
+                </ul>
+              </div>
             </div>
-            <div class="weight-percent">55%</div>
-          </div>
-          
-          <div class="weight-item">
-            <div class="weight-label">Financial</div>
-            <div class="weight-bar-container">
-              <div class="weight-bar financial-bar" style="width: 35%;">35%</div>
+            <div class="pie-box">
+              <div class="pie-title">키워드/트렌드 비중 (hotness)</div>
+              <div class="pie-wrap">
+                <div class="pie" style="background: conic-gradient(#f59e0b 0 40%, #8b5cf6 40% 70%, #3b82f6 70% 90%, #14b8a6 90% 100%);"></div>
+                <ul class="legend">
+                  <li><span class="dot" style="background:#f59e0b"></span>News 40%</li>
+                  <li><span class="dot" style="background:#8b5cf6"></span>Trend 30%</li>
+                  <li><span class="dot" style="background:#3b82f6"></span>Turnover 20%</li>
+                  <li><span class="dot" style="background:#14b8a6"></span>Wiki 10%</li>
+                </ul>
+              </div>
             </div>
-            <div class="weight-percent">35%</div>
-          </div>
-          
-          <div class="weight-item">
-            <div class="weight-label">News</div>
-            <div class="weight-bar-container">
-              <div class="weight-bar news-bar" style="width: 10%;">10%</div>
-            </div>
-            <div class="weight-percent">10%</div>
-          </div>
-          
-          <div class="comparison-details">
-            <strong>Naver 지표 (55%)</strong>
-            <ul>
-              <li>인기도 (40%)</li>
-              <li>검색량지수 ASVI (30%)</li>
-              <li>뉴스 수 (15%)</li>
-              <li>급등락 감지 (10%)</li>
-              <li>데이터 신뢰도 (5%)</li>
-            </ul>
-            <strong style="display:block; margin-top:8px;">Financial (35%)</strong>
-            <ul>
-              <li>5일 수익률 (30%)</li>
-              <li>20일 수익률 (30%)</li>
-              <li>변동성 (15%)</li>
-              <li>거래량 회전율 (15%)</li>
-              <li>평균일일거래량 (10%)</li>
-            </ul>
           </div>
         </div>
-        
-        <!-- US Stocks -->
+
         <div class="comparison-card">
           <div class="comparison-header">미국주식 (S&P 500, NASDAQ 100)</div>
-          
-          <div class="weight-item">
-            <div class="weight-label">Naver 지표</div>
-            <div class="weight-bar-container">
-              <div class="weight-bar naver-bar" style="width: 50%;">50%</div>
+          <div class="pie-grid">
+            <div class="pie-box">
+              <div class="pie-title">시장 점수 가중치</div>
+              <div class="pie-wrap">
+                <div class="pie" style="background: conic-gradient(#10b981 0 50%, #3b82f6 50% 85%, #f59e0b 85% 100%);"></div>
+                <ul class="legend">
+                  <li><span class="dot" style="background:#10b981"></span>Naver 50%</li>
+                  <li><span class="dot" style="background:#3b82f6"></span>Financial 35%</li>
+                  <li><span class="dot" style="background:#f59e0b"></span>News & Rep 15%</li>
+                </ul>
+              </div>
             </div>
-            <div class="weight-percent">50%</div>
-          </div>
-          
-          <div class="weight-item">
-            <div class="weight-label">Financial</div>
-            <div class="weight-bar-container">
-              <div class="weight-bar financial-bar" style="width: 35%;">35%</div>
+            <div class="pie-box">
+              <div class="pie-title">초기 인기펄스 비중 (early)</div>
+              <div class="pie-wrap">
+                <div class="pie" style="background: conic-gradient(#f59e0b 0 5.45%, #10b981 5.45% 96.36%, #22c55e 96.36% 98.84%, #ef4444 98.84% 99.67%, #14b8a6 99.67% 100%);"></div>
+                <ul class="legend">
+                  <li><span class="dot" style="background:#f59e0b"></span>News 6</li>
+                  <li><span class="dot" style="background:#10b981"></span>Naver Pop 110</li>
+                  <li><span class="dot" style="background:#22c55e"></span>Positive KW 3</li>
+                  <li><span class="dot" style="background:#ef4444"></span>Negative KW 1</li>
+                  <li><span class="dot" style="background:#14b8a6"></span>Wiki 0.2</li>
+                </ul>
+              </div>
             </div>
-            <div class="weight-percent">35%</div>
           </div>
-          
-          <div class="weight-item">
-            <div class="weight-label">News & Rep</div>
-            <div class="weight-bar-container">
-              <div class="weight-bar news-bar" style="width: 15%;">15%</div>
-            </div>
-            <div class="weight-percent">15%</div>
-          </div>
-          
           <div class="comparison-details">
-            <strong>Naver 지표 (50%)</strong>
-            <ul>
-              <li>인기도 (50%)</li>
-              <li>검색량지수 ASVI (35%)</li>
-              <li>뉴스 수 (15%)</li>
-            </ul>
-            <strong style="display:block; margin-top:8px;">Financial (35%)</strong>
-            <ul>
-              <li>5일 수익률 (35%)</li>
-              <li>20일 수익률 (35%)</li>
-              <li>변동성 (20%)</li>
-              <li>평균일일거래량 (10%)</li>
-            </ul>
-            <strong style="display:block; margin-top:8px;">News & Reputation (15%)</strong>
-            <ul>
-              <li>뉴스 수량 (30%)</li>
-              <li>뉴스 점수 (35%)</li>
-              <li>감정 분석 (20%)</li>
-              <li>기업 평판 (15%)</li>
-            </ul>
+            trend 관련 기본 보정: NAVER_SPIKE_BOOST=0.15, NAVER_PERSIST_BOOST=0.10, TREND_EXP=1.5
           </div>
         </div>
       </div>
@@ -314,13 +238,16 @@
     <div class="card">
       <h2>0️⃣ 전체 반영 공식</h2>
       <div class="formula">
-금융 = 0.25×ret5 + 0.25×ret20 + 0.15×저변동성 + 0.20×turnover + 0.15×ADV
+KR 금융 = 0.30×ret5 + 0.30×ret20 + 0.15×저변동성 + 0.15×turnover + 0.10×ADV
+US 금융 = 0.35×ret5 + 0.35×ret20 + 0.20×저변동성 + 0.10×ADV
       </div>
       <div class="formula">
-뉴스 = 0.30×뉴스량 + 0.40×newsScore + 0.20×sentiment + 0.10×googleNews
+KR 뉴스 = 0.40×뉴스량 + 0.40×newsScore + 0.20×sentiment
+US 뉴스 = 0.30×뉴스량 + 0.35×newsScore + 0.20×sentiment + 0.15×reputation
       </div>
       <div class="formula">
-네이버 = 0.35×인기도 + 0.25×ASVI + 0.20×뉴스량 + 0.15×스파이크 + 0.05×품질보너스
+KR 네이버 = 0.40×인기도 + 0.30×ASVI + 0.15×네이버뉴스량 + 0.10×(스파이크/지속) + 0.05×데이터품질
+US 네이버 = 0.50×인기도 + 0.35×ASVI + 0.15×네이버뉴스량
       </div>
       <div class="formula">
 콘텐츠 = 0.40×blog + 0.35×wiki + 0.25×wikiViews(log)
@@ -329,7 +256,8 @@
 품질 = (0.50×reputation + sourceReliabilityBonus + eligibilityBonus) / 0.65
       </div>
       <div class="formula">
-composite = 통합점수 신뢰도(confidence)>0.7 이면 Unified 35% 우선, 아니면 5개 축 가중합
+KR composite = 0.55×네이버 + 0.35×금융 + 0.10×뉴스
+US composite = 0.50×네이버 + 0.35×금융 + 0.15×뉴스
       </div>
     </div>
 


### PR DESCRIPTION
### Motivation
- Make the explanatory `stocks/rationale.html` page match the current scoring logic implemented in `fetchStockInfo.js` and the trend/hotness weights from `tools/buildPoolsTrendy.js` so the documentation reflects real behavior. 
- Replace the previous stick/bar comparison in "점수 계산 방식 비교" with intuitive pie-chart visuals to better show relative weightings such as market score and keyword/trend rates. 
- Surface key trend constants (e.g., `NAVER_SPIKE_BOOST`, `NAVER_PERSIST_BOOST`, `TREND_EXP`) and the early/popularity pulse weights so readers can see how hotness and early signals contribute.

### Description
- Reworked `stocks/rationale.html` CSS and HTML to add `pie-grid`, `pie-box`, `pie` and legend styles and to render pie visuals via `conic-gradient` for KR and US market breakdowns. 
- Replaced the former bar/weight items with two pie charts per market: market score weights (KR: Naver 55% / Financial 35% / News 10%; US: Naver 50% / Financial 35% / News & Rep 15%) and keyword/trend or early-popularity mixes (hotness and early pulse). 
- Updated the "전체 반영 공식" formulas to document KR/US component weights and composite formulas consistent with `fetchStockInfo.js` (KR composite 0.55×Naver + 0.35×Financial + 0.10×News; US composite 0.50×Naver + 0.35×Financial + 0.15×News) and included a note on trend-related constants from `buildPoolsTrendy.js` (e.g., hotness breakdown and spike/persist boosts). 
- No runtime scripting or scoring logic was changed; this is a documentation/UI update only to reflect existing code.

### Testing
- Ran the repository test `node tests/apple_association.test.js` and it passed (`All tests passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0ceb526b208331ac713ecdada1e927)