### PR TITLE
ci: refresh index map artifact in stock-recs workflow

### DIFF
--- a/.github/workflows/stock-recs.yml
+++ b/.github/workflows/stock-recs.yml
@@ -202,8 +202,13 @@ jobs:
           node --version
           node --test tests/*.test.js
 
-      - name: Build index ticker maps
-        run: node tools/updateIndexMaps.mjs
+      - name: Refresh index ticker maps (src/maps.indexes.json)
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          node tools/updateIndexMaps.mjs
+          test -s src/maps.indexes.json
+          node -e "const m=require('./src/maps.indexes.json'); console.log('[indexes] updatedAt=', m.updatedAt || 'n/a')"
         env:
           FMP_KEY: ${{ secrets.FMP_KEY }}
 


### PR DESCRIPTION
### Motivation
- Ensure the index ticker map file `src/maps.indexes.json` is refreshed as part of the periodic `stock-recs.yml` run so downstream steps always see up-to-date index mappings. 
- `src/maps.indexes.json` is produced by `tools/updateIndexMaps.mjs`, so the scheduled workflow is the appropriate periodic trigger for updating it.

### Description
- Replace the old index-map step with a clearer step named `Refresh index ticker maps (src/maps.indexes.json)` that explicitly invokes `node tools/updateIndexMaps.mjs`.
- Run the step under `bash` with strict options via `set -Eeuo pipefail` to fail fast on errors.
- Add a post-step validation `test -s src/maps.indexes.json` and a small `node -e` command to log `updatedAt` from `src/maps.indexes.json` for observability.

### Testing
- Ran the repository test `node tests/apple_association.test.js`, which completed successfully and printed `All tests passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a0dac0a13f083318293a3711034e480)