### PR TITLE
Fix bubble game startup delay

### DIFF
--- a/bubble-game.js
+++ b/bubble-game.js
@@ -15,9 +15,16 @@ const NAME_PATTERN = /^[A-Za-z\u3131-\u318E\uAC00-\uD7A3\s]+$/;
 // Google Apps Script URL for leaderboard
 const GOOGLE_SCRIPT_URL = 'https://script.google.com/macros/s/AKfycbxIcVsfDX3bOZzWf9FjsYLx7oIS3HKVshr-EbmtdIBM67GdcXhoc7JFZ8MpXSIogz4p/exec';
 
-// Initialize game elements
-window.onload = function() {
+// Initialize game elements as soon as the DOM is ready. Waiting for window.onload
+// can block game startup behind slow third-party resources such as ads or fonts.
+let gameInitialized = false;
+
+function initBubbleGame() {
+    if (gameInitialized) return;
+
     canvas = document.getElementById('gameCanvas');
+    if (!canvas) return;
+
     ctx = canvas.getContext('2d');
     nameInput = document.getElementById('playerName');
     nameError = document.getElementById('nameError');
@@ -29,7 +36,14 @@ window.onload = function() {
     fetchLeaderboard();
     setupEventListeners();
     setupNameValidation();
-};
+    gameInitialized = true;
+}
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initBubbleGame);
+} else {
+    initBubbleGame();
+}
 
 function resizeCanvas() {
     const gameScreen = document.getElementById('gameScreen');
@@ -190,10 +204,14 @@ function createBubble(x, y, size) {
 }
 
 function startGame() {
+    initBubbleGame();
+    if (!canvas || !ctx) return;
+
     document.getElementById('gameMenu').style.display = 'none';
     canvas.style.display = 'block';
     document.getElementById('gameStats').style.display = 'flex';
     document.getElementById('gameBackBtn').style.display = 'block';
+    resizeCanvas();
 
     bubbles = [];
     score = 0;


### PR DESCRIPTION
### Motivation
- The bubble game sometimes failed to start or was very slow because initialization was tied to `window.onload`, which can be blocked by slow third-party resources (ads/fonts) and can cause a race where the canvas/context are not ready when the user presses Start. 
- Canvas sizing could be incorrect if the canvas was displayed after initialization, causing layout issues at game start.

### Description
- Replace the `window.onload` initializer with a `DOMContentLoaded`-based `initBubbleGame()` and add a `gameInitialized` guard to ensure one-time initialization. 
- Make `initBubbleGame()` bail out early if the canvas is not present and defer full setup until the DOM is ready. 
- Add a lazy initialization call inside `startGame()` (`initBubbleGame()` + a safety `if (!canvas || !ctx) return`) so the Start button works even if initialization hasn't completed. 
- Call `resizeCanvas()` after showing the canvas to ensure correct dimensions before spawning bubbles.

### Testing
- Ran the repository test with `node tests/apple_association.test.js` and it passed. 
- Verified syntax with `node --check bubble-game.js` with no errors. 
- Ran `git diff --check` to ensure no whitespace/format issues were introduced and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a28e384c2288331922554fb46a97e23)