### PR TITLE
Align Nasdaq Trader symbols with index schema

### DIFF
--- a/tools/updateIndexMaps.mjs
+++ b/tools/updateIndexMaps.mjs
@@ -38,6 +38,7 @@ async function netText(url) {
   return null;
 }
 
+const US_SYMBOL_PATTERN = /^[A-Z]{1,5}(\.[A-Z]{1,2})?$/;
 const canonUS = s => s.toUpperCase().replace('/', '.').replace('-', '.');
 const six = s => (s || '').replace(/\D/g, '').padStart(6, '0');
 
@@ -201,7 +202,7 @@ function parseNasdaqTraderSymbolDirectory(txt) {
       marketCap: null,
     }))
     .filter(row => row.symbol && row.name)
-    .filter(row => /^[A-Z0-9.]+$/.test(row.symbol))
+    .filter(row => US_SYMBOL_PATTERN.test(row.symbol))
     .filter(row => !/(warrants?|units?|rights?|preferred|depositary|notes?|bonds?|debentures?)/i.test(row.name));
 }
 


### PR DESCRIPTION
### Motivation
- The Nasdaq Trader parser used a permissive regex (`/^[A-Z0-9.]+$/`) that can allow numeric, overlong, or invalid-suffix symbols which would fail JSON schema validation because `rowUS.symbol` requires `^[A-Z]{1,5}(\.[A-Z]{1,2})?$`.

### Description
- Introduced `US_SYMBOL_PATTERN = /^[A-Z]{1,5}(\.[A-Z]{1,2})?$/` in `tools/updateIndexMaps.mjs` to mirror the `rowUS` `symbol` pattern from `src/maps.indexes.schema.json`.
- Updated `parseNasdaqTraderSymbolDirectory` to filter parsed rows with `US_SYMBOL_PATTERN` instead of the previous permissive pattern so only schema-conforming symbols are emitted into `src/maps.indexes.json`.

### Testing
- Ran the repository test with `node tests/apple_association.test.js`, which succeeded.
- Validated current `src/maps.indexes.json` US symbols against the schema pattern using a small Node check (`/^[A-Z]{1,5}(\.[A-Z]{1,2})?$/`), which reported no invalid symbols.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2d435d55ec8331aebaf811af8613f6)