### PR TITLE
Process index maps in trendy stock pools

### DIFF
--- a/fetchStockInfo.js
+++ b/fetchStockInfo.js
@@ -90,6 +90,7 @@ const SKIP_FRESH = ARGS.has('--skip-fresh');
 const DELAY_ARG = Number((process.argv.find(a => a.startsWith('--delay=')) || '').split('=')[1]);
 const CACHE_FILE = path.resolve(process.cwd(), 'ticker-cache.json');
 const POOLS_PATH = path.resolve(process.cwd(), 'pools.json');
+const POOLS_TRENDY_PATH = path.resolve(process.cwd(), 'pools-trendy.json');
 const POOLS_CACHE = path.resolve(process.cwd(), 'pools-cache.json');
 const POOLS_TTL_MS = Number(process.env.POOLS_TTL_MS || 24 * 60 * 60 * 1000); // default 24h
 const POOLS_URL = process.env.POOLS_URL || ''; // optional remote JSON endpoint
@@ -1059,6 +1060,7 @@ async function isFreshPath(p, ttlMs) { try { const s = await fs.stat(p); return 
 function validatePoolsSchema(pools) {
   if (!pools || typeof pools !== 'object') throw new Error('pools not object');
   for (const [m, b] of Object.entries(pools)) {
+    if (m === 'lastUpdated') continue;
     if (!b || !Array.isArray(b.safe) || !Array.isArray(b.aggressive)) {
       throw new Error(`invalid pools schema at ${m}`);
     }
@@ -1085,6 +1087,9 @@ async function loadPools() {
     const remote = await fetchPoolsRemote();
     if (remote) return remote;
   }
+  const trendy = await loadJsonSafe(POOLS_TRENDY_PATH);
+  if (trendy?.markets) { try { validatePoolsSchema(trendy.markets); return trendy.markets; } catch {} }
+  if (trendy) { try { validatePoolsSchema(trendy); return trendy; } catch {} }
   const cached = await loadJsonSafe(POOLS_CACHE);
   if (cached) { try { validatePoolsSchema(cached); return cached; } catch {} }
   const local = await loadJsonSafe(POOLS_PATH);
@@ -1878,21 +1883,23 @@ async function tryFetchAndEnrich() {
       const updated = [];
       for (const entry of entries) {
         const rawName = typeof entry === 'string' ? entry : entry.name;
+        const providedTicker = typeof entry === 'object' ? entry.ticker : null;
+        const providedSector = typeof entry === 'object' ? entry.sector : null;
+        let ticker = providedTicker ? canonSymbol(providedTicker) : null;
+        let sector = providedSector || null;
+        let displayName = rawName;
 
         try {
-          const sym = canonSymbol(rawName);
-          let ticker = null;
-          let sector = null;
-          let displayName = rawName;
+          const sym = canonSymbol(providedTicker || rawName);
 
           if (INDEX_NAME[sym] || INDEX_SECTOR[sym]) {
-            ticker = sym;
+            ticker = ticker || sym;
             displayName = INDEX_NAME[sym] || rawName;
-            sector = INDEX_SECTOR[sym] || null;
+            sector = sector || INDEX_SECTOR[sym] || null;
           } else {
             const res = await fetchSector(rawName, cache);
-            ticker = res.ticker;
-            sector = INDEX_SECTOR[ticker] || res.sector;
+            ticker = ticker || res.ticker;
+            sector = sector || INDEX_SECTOR[ticker] || res.sector;
             displayName = INDEX_NAME[ticker] || (!looksLikeTicker(rawName) ? rawName : undefined) || rawName;
           }
 
@@ -1905,7 +1912,7 @@ async function tryFetchAndEnrich() {
 
           const news = ticker ? (newsFeatures[ticker] || {}) : {};
           const trend = ticker ? (naverTrends[ticker] || {}) : {};
-          const metrics = getMetricsForEntry(market, rawName);
+          const metrics = getMetricsForEntry(market, ticker || rawName) || getMetricsForEntry(market, rawName);
           const enrichedMetrics = {
             ...metrics,
             ...(newsFeatures[ticker] || {}),
@@ -1956,7 +1963,7 @@ async function tryFetchAndEnrich() {
           if (sector) successCount++;
         } catch (err) {
           console.error(`[ERROR] ${rawName}: ${err.message}`);
-          const metrics = getMetricsForEntry(market, rawName);
+          const metrics = getMetricsForEntry(market, ticker || rawName) || getMetricsForEntry(market, rawName);
           const enrichedMetrics = {
             ...metrics,
             ...(newsFeatures[ticker] || {}),

--- a/tools/buildPoolsTrendy.js
+++ b/tools/buildPoolsTrendy.js
@@ -558,9 +558,19 @@ const INDEX_ROWS = (() => {
 })();
 
 const INDEX_SECTOR = {};
-for (const r of INDEX_ROWS) {
-  const sym = normIndexKey(r.symbol || r.ticker || '');
-  if (sym) INDEX_SECTOR[sym] = r.sector || r.gicsSector || r.industry || null;
+const INDEX_NAME = {};
+const INDEX_MARKET = {};
+const INDEX_NAME_TO_SYMBOL = {};
+const INDEX_MARKET_KEYS = { sp500: 'S&P 500', nasdaq100: 'NASDAQ 100', kospi200: 'KOSPI', kosdaq100: 'KOSDAQ' };
+for (const [idxKey, marketName] of Object.entries(INDEX_MARKET_KEYS)) {
+  for (const r of (INDEX_RAW?.[idxKey] || [])) {
+    const sym = normIndexKey(r.symbol || r.ticker || '');
+    if (!sym) continue;
+    INDEX_NAME[sym] = r.name || r.companyName || sym;
+    if (INDEX_NAME[sym]) INDEX_NAME_TO_SYMBOL[normalizeKey(INDEX_NAME[sym])] = sym;
+    INDEX_SECTOR[sym] = r.sector || r.gicsSector || r.industry || null;
+    INDEX_MARKET[sym] = marketName;
+  }
 }
 
 const SP500 = new Map((INDEX_RAW.sp500 || []).map(r => [r.symbol || r.ticker, r.name]));
@@ -852,6 +862,30 @@ function mergeIndexNames(base, idxMap) {
   return Array.from(out);
 }
 
+function buildTrendyPools(pools, metricsOut = {}) {
+  const out = { lastUpdated: new Date().toISOString(), markets: {} };
+  for (const market of MARKETS) {
+    const buckets = pools?.[market] || {};
+    out.markets[market] = {};
+    for (const bucket of ['safe', 'aggressive']) {
+      out.markets[market][bucket] = (buckets[bucket] || []).map(entry => {
+        const rawName = typeof entry === 'string' ? entry : entry?.name;
+        const sym = (typeof entry === 'object' && entry?.ticker) || nameToSymbol(rawName) || fallbackSymbolFromRaw(rawName);
+        const canon = normIndexKey(sym || '');
+        const metrics = metricsOut?.[market]?.[rawName] || metricsOut?.[market]?.[INDEX_NAME[canon]] || metricsOut?.[market]?.[canon] || null;
+        return {
+          name: INDEX_NAME[canon] || rawName,
+          ticker: sym || null,
+          sector: INDEX_SECTOR[canon] || metrics?.sector || null,
+          score: Number.isFinite(metrics?.score) ? metrics.score : (Number.isFinite(metrics?.score?.total) ? metrics.score.total : null),
+          index: INDEX_MARKET[canon] || market
+        };
+      });
+    }
+  }
+  return out;
+}
+
 const PROVIDER_SCORE_FILE = path.join(CACHE_DIR, 'provider-score.json');
 function loadProviderScore() {
   const txt = tryRead(PROVIDER_SCORE_FILE);
@@ -888,6 +922,7 @@ const TWELVE = process.env.TWELVEDATA_API_KEY || '';
 const FMP = !!FMP_API_KEY;
 
 const POOLS_FILE = 'pools.json';
+const POOLS_TRENDY_FILE = 'pools-trendy.json';
 const METRICS_FILE = 'pools-metrics.json';
 const FEEDBACK_FILE = 'feedback.json';
 const NEWS_FEATURES_FILE = 'data/news-features.json';
@@ -1146,7 +1181,7 @@ function nameToSymbol(name){
   const learned = lookupLearnedMapping(name);
   if (learned) return learned;
 
-  const dict = NAME_TO_SYMBOL[name] || TICKER_MAP[name];
+  const dict = NAME_TO_SYMBOL[name] || TICKER_MAP[name] || INDEX_NAME_TO_SYMBOL[name];
   if (dict) return dict;
 
   // Normalize BRK-B / BRK.B / BRK/B styles
@@ -3078,7 +3113,8 @@ async function main(){
   if (OFFLINE) {
     console.warn(`[buildPools] offline mode, leaving pools.json unchanged`);
     await writeAtomic(METRICS_FILE, JSON.stringify(metricsOut, null, 2));
-    console.log('[buildPools] wrote pools-metrics.json (pools.json unchanged)');
+    await writeAtomic(POOLS_TRENDY_FILE, JSON.stringify(buildTrendyPools(pools, metricsOut), null, 2));
+    console.log('[buildPools] wrote pools-metrics.json and pools-trendy.json (pools.json unchanged)');
     return;
   }
   if (DRY_RUN) {
@@ -3098,6 +3134,7 @@ async function main(){
     const lastGood = loadLastGoodPools();
     const outPools = lastGood ?? namesOnlyRank(universe, NEWS_FEATURES) ?? pools;
     await writeAtomic(POOLS_FILE, JSON.stringify(outPools, null, 2));
+    await writeAtomic(POOLS_TRENDY_FILE, JSON.stringify(buildTrendyPools(outPools, metricsOut), null, 2));
     await writeAtomic(METRICS_FILE, JSON.stringify(metricsOut, null, 2));
     if (lastGood) console.log('[buildPools] wrote pools.json from last good snapshot');
     else if (outPools !== pools) console.log('[buildPools] wrote pools.json and pools-metrics.json :: names-only');
@@ -3113,6 +3150,7 @@ async function main(){
 
   // Write outputs
   await writeAtomic(POOLS_FILE, JSON.stringify(pools, null, 2));
+  await writeAtomic(POOLS_TRENDY_FILE, JSON.stringify(buildTrendyPools(pools, metricsOut), null, 2));
   await writeAtomic(METRICS_FILE, JSON.stringify(metricsOut, null, 2));
   // Small sanity log so it's obvious scores are present
   try {
@@ -3120,7 +3158,7 @@ async function main(){
       metricsOut['S&P 500']?.['Microsoft']?.score ?? '(missing)');
   } catch {}
   snapshotPools(pools);
-  console.log('[buildPools] wrote pools.json and pools-metrics.json :: done');
+  console.log('[buildPools] wrote pools.json, pools-trendy.json and pools-metrics.json :: done');
 }
 
 main()


### PR DESCRIPTION
### Motivation
- Make pool outputs richer and machine-friendly by using index maps so pools can carry tickers, sectors and index metadata used downstream. 
- Ensure `fetchStockInfo.js` can consume that enriched output so `recommendations.json` includes resolved `ticker`/`sector` for the stock page.

### Description
- Parse `src/maps.indexes.json` in `tools/buildPoolsTrendy.js` and build index-backed maps: `INDEX_NAME`, `INDEX_SECTOR`, `INDEX_MARKET` and a reverse `INDEX_NAME_TO_SYMBOL` lookup. 
- Add `buildTrendyPools(pools, metricsOut)` in `tools/buildPoolsTrendy.js` to produce `pools-trendy.json` entries enriched with `name`, `ticker`, `sector`, `score`, and `index`, and emit `pools-trendy.json` alongside `pools.json`/`pools-metrics.json` in offline/fallback/done paths. 
- Wire index-name lookup into the generator by falling back to index-derived name→symbol mappings in `nameToSymbol`. 
- Update `fetchStockInfo.js` to prefer `pools-trendy.json` (if present) when loading pools, to accept `lastUpdated` in pool payloads, and to preserve provided `ticker`/`sector` metadata from pool entries while selecting/enriching recommendations so `recommendations.json` includes recommended tickers. 

### Testing
- Ran `node --check tools/buildPoolsTrendy.js` and it passed without syntax errors. 
- Ran `node --check fetchStockInfo.js` and it passed without syntax errors. 
- Ran the repository test `node tests/apple_association.test.js` and it passed (`All tests passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2df40e123c8331a2563119826dd6ab)