### PR TITLE
Prefer fresh pools cache and avoid redundant ticker lookup

### DIFF
--- a/fetchStockInfo.js
+++ b/fetchStockInfo.js
@@ -1087,6 +1087,10 @@ async function loadPools() {
     const remote = await fetchPoolsRemote();
     if (remote) return remote;
   }
+  if (POOLS_URL && await isFreshPath(POOLS_CACHE, POOLS_TTL_MS)) {
+    const cached = await loadJsonSafe(POOLS_CACHE);
+    if (cached) { try { validatePoolsSchema(cached); return cached; } catch {} }
+  }
   const trendy = await loadJsonSafe(POOLS_TRENDY_PATH);
   if (trendy?.markets) { try { validatePoolsSchema(trendy.markets); return trendy.markets; } catch {} }
   if (trendy) { try { validatePoolsSchema(trendy); return trendy; } catch {} }
@@ -1897,9 +1901,13 @@ async function tryFetchAndEnrich() {
             displayName = INDEX_NAME[sym] || rawName;
             sector = sector || INDEX_SECTOR[sym] || null;
           } else {
-            const res = await fetchSector(rawName, cache);
-            ticker = ticker || res.ticker;
-            sector = sector || INDEX_SECTOR[ticker] || res.sector;
+            if (ticker) {
+              sector = sector || await fetchSectorByTicker(ticker, cache);
+            } else {
+              const res = await fetchSector(rawName, cache);
+              ticker = res.ticker;
+              sector = sector || INDEX_SECTOR[ticker] || res.sector;
+            }
             displayName = INDEX_NAME[ticker] || (!looksLikeTicker(rawName) ? rawName : undefined) || rawName;
           }
 


### PR DESCRIPTION
### Motivation
- Ensure consistent behavior when `POOLS_URL` is configured by preferring a fresh `POOLS_CACHE` instead of falling back to the local `POOLS_TRENDY_PATH`, which previously caused alternating use of remote vs local pools.
- Avoid redundant and potentially expensive ticker resolution when an entry already supplies a ticker by eliminating unnecessary calls that can trigger search fallbacks.

### Description
- In `fetchStockInfo.js`, updated `loadPools()` to check and return a validated fresh `POOLS_CACHE` (`POOLS_CACHE`) before reading `POOLS_TRENDY_PATH` when `POOLS_URL` is set, preserving cache precedence.
- In the enrichment loop, when an entry already has a `ticker`, call `fetchSectorByTicker(ticker, cache)` instead of `fetchSector(rawName, cache)` to skip redundant `resolveTicker` work and expensive search fallbacks.

### Testing
- Ran the repository test with `node tests/apple_association.test.js` and it succeeded (`All tests passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2e19c662d8833187821670f0f6f039)