### PR TITLE
Add data/indexes refresh script and wire into index map generation

### DIFF
--- a/.github/workflows/stock-recs.yml
+++ b/.github/workflows/stock-recs.yml
@@ -202,6 +202,12 @@ jobs:
           node --version
           node --test tests/*.test.js
 
+      - name: Update data index JSON files
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          node tools/updateDataIndexes.mjs
+
       - name: Refresh index ticker maps (src/maps.indexes.json)
         shell: bash
         run: |

--- a/data/indexes/kosdaq100.json
+++ b/data/indexes/kosdaq100.json
@@ -1,0 +1,572 @@
+[
+  {
+    "symbol": "005290.KQ",
+    "name": "동진쎄미켐",
+    "sector": "소재",
+    "marketCap": null
+  },
+  {
+    "symbol": "006730.KQ",
+    "name": "서부T&D",
+    "sector": "산업재",
+    "marketCap": null
+  },
+  {
+    "symbol": "007390.KQ",
+    "name": "네이처셀",
+    "sector": "헬스케어",
+    "marketCap": null
+  },
+  {
+    "symbol": "009520.KQ",
+    "name": "포스코엠텍",
+    "sector": "소재",
+    "marketCap": null
+  },
+  {
+    "symbol": "018290.KQ",
+    "name": "브이티",
+    "sector": "정보기술",
+    "marketCap": null
+  },
+  {
+    "symbol": "028300.KQ",
+    "name": "HLB",
+    "sector": "헬스케어",
+    "marketCap": null
+  },
+  {
+    "symbol": "034230.KQ",
+    "name": "파라다이스",
+    "sector": "경기소비재",
+    "marketCap": null
+  },
+  {
+    "symbol": "035720.KQ",
+    "name": "카카오",
+    "sector": "커뮤니케이션서비스",
+    "marketCap": null
+  },
+  {
+    "symbol": "035760.KQ",
+    "name": "CJ ENM",
+    "sector": "커뮤니케이션서비스",
+    "marketCap": null
+  },
+  {
+    "symbol": "036030.KQ",
+    "name": "케이씨티",
+    "sector": "정보기술",
+    "marketCap": null
+  },
+  {
+    "symbol": "036540.KQ",
+    "name": "SFA반도체",
+    "sector": "정보기술",
+    "marketCap": null
+  },
+  {
+    "symbol": "036810.KQ",
+    "name": "에프에스티",
+    "sector": "정보기술",
+    "marketCap": null
+  },
+  {
+    "symbol": "036930.KQ",
+    "name": "주성엔지니어링",
+    "sector": "정보기술",
+    "marketCap": null
+  },
+  {
+    "symbol": "038540.KQ",
+    "name": "상상인",
+    "sector": "정보기술",
+    "marketCap": null
+  },
+  {
+    "symbol": "039030.KQ",
+    "name": "이오테크닉스",
+    "sector": "정보기술",
+    "marketCap": null
+  },
+  {
+    "symbol": "041510.KQ",
+    "name": "에스엠",
+    "sector": "커뮤니케이션서비스",
+    "marketCap": null
+  },
+  {
+    "symbol": "042000.KQ",
+    "name": "카페24",
+    "sector": "정보기술",
+    "marketCap": null
+  },
+  {
+    "symbol": "045660.KQ",
+    "name": "에이치엘비",
+    "sector": "헬스케어",
+    "marketCap": null
+  },
+  {
+    "symbol": "047920.KQ",
+    "name": "HLB제약",
+    "sector": "헬스케어",
+    "marketCap": null
+  },
+  {
+    "symbol": "048260.KQ",
+    "name": "오스템임플란트",
+    "sector": "헬스케어",
+    "marketCap": null
+  },
+  {
+    "symbol": "048410.KQ",
+    "name": "현대바이오",
+    "sector": "헬스케어",
+    "marketCap": null
+  },
+  {
+    "symbol": "053800.KQ",
+    "name": "안랩",
+    "sector": "정보기술",
+    "marketCap": null
+  },
+  {
+    "symbol": "054300.KQ",
+    "name": "라이콤",
+    "sector": "정보기술",
+    "marketCap": null
+  },
+  {
+    "symbol": "056190.KQ",
+    "name": "에스에프에이",
+    "sector": "정보기술",
+    "marketCap": null
+  },
+  {
+    "symbol": "058470.KQ",
+    "name": "리노공업",
+    "sector": "정보기술",
+    "marketCap": null
+  },
+  {
+    "symbol": "060250.KQ",
+    "name": "NHN KCP",
+    "sector": "정보기술",
+    "marketCap": null
+  },
+  {
+    "symbol": "060310.KQ",
+    "name": "3S",
+    "sector": "정보기술",
+    "marketCap": null
+  },
+  {
+    "symbol": "064760.KQ",
+    "name": "티씨케이",
+    "sector": "정보기술",
+    "marketCap": null
+  },
+  {
+    "symbol": "066970.KQ",
+    "name": "엘앤에프",
+    "sector": "소재",
+    "marketCap": null
+  },
+  {
+    "symbol": "067160.KQ",
+    "name": "아프리카TV",
+    "sector": "커뮤니케이션서비스",
+    "marketCap": null
+  },
+  {
+    "symbol": "067630.KQ",
+    "name": "HLB생명과학",
+    "sector": "헬스케어",
+    "marketCap": null
+  },
+  {
+    "symbol": "068760.KQ",
+    "name": "셀트리온제약",
+    "sector": "헬스케어",
+    "marketCap": null
+  },
+  {
+    "symbol": "078340.KQ",
+    "name": "컴투스",
+    "sector": "커뮤니케이션서비스",
+    "marketCap": null
+  },
+  {
+    "symbol": "083790.KQ",
+    "name": "크리스탈지노믹스",
+    "sector": "헬스케어",
+    "marketCap": null
+  },
+  {
+    "symbol": "084370.KQ",
+    "name": "유진테크",
+    "sector": "정보기술",
+    "marketCap": null
+  },
+  {
+    "symbol": "084850.KQ",
+    "name": "아이티엠반도체",
+    "sector": "정보기술",
+    "marketCap": null
+  },
+  {
+    "symbol": "085660.KQ",
+    "name": "차바이오텍",
+    "sector": "헬스케어",
+    "marketCap": null
+  },
+  {
+    "symbol": "086520.KQ",
+    "name": "에코프로",
+    "sector": "산업재",
+    "marketCap": null
+  },
+  {
+    "symbol": "088390.KQ",
+    "name": "이녹스",
+    "sector": "소재",
+    "marketCap": null
+  },
+  {
+    "symbol": "089030.KQ",
+    "name": "테크윙",
+    "sector": "정보기술",
+    "marketCap": null
+  },
+  {
+    "symbol": "089980.KQ",
+    "name": "상아프론테크",
+    "sector": "정보기술",
+    "marketCap": null
+  },
+  {
+    "symbol": "090460.KQ",
+    "name": "비에이치",
+    "sector": "정보기술",
+    "marketCap": null
+  },
+  {
+    "symbol": "091990.KQ",
+    "name": "셀트리온헬스케어",
+    "sector": "헬스케어",
+    "marketCap": null
+  },
+  {
+    "symbol": "093320.KQ",
+    "name": "케이아이엔엑스",
+    "sector": "정보기술",
+    "marketCap": null
+  },
+  {
+    "symbol": "094170.KQ",
+    "name": "동운아나텍",
+    "sector": "정보기술",
+    "marketCap": null
+  },
+  {
+    "symbol": "094360.KQ",
+    "name": "칩스앤미디어",
+    "sector": "정보기술",
+    "marketCap": null
+  },
+  {
+    "symbol": "095340.KQ",
+    "name": "ISC",
+    "sector": "정보기술",
+    "marketCap": null
+  },
+  {
+    "symbol": "095660.KQ",
+    "name": "네오위즈",
+    "sector": "커뮤니케이션서비스",
+    "marketCap": null
+  },
+  {
+    "symbol": "098460.KQ",
+    "name": "고영",
+    "sector": "정보기술",
+    "marketCap": null
+  },
+  {
+    "symbol": "099320.KQ",
+    "name": "쎄트렉아이",
+    "sector": "산업재",
+    "marketCap": null
+  },
+  {
+    "symbol": "100790.KQ",
+    "name": "미래생명자원",
+    "sector": "헬스케어",
+    "marketCap": null
+  },
+  {
+    "symbol": "101490.KQ",
+    "name": "에스앤에스텍",
+    "sector": "정보기술",
+    "marketCap": null
+  },
+  {
+    "symbol": "102710.KQ",
+    "name": "이엔에프테크놀로지",
+    "sector": "정보기술",
+    "marketCap": null
+  },
+  {
+    "symbol": "108230.KQ",
+    "name": "톱텍",
+    "sector": "정보기술",
+    "marketCap": null
+  },
+  {
+    "symbol": "112040.KQ",
+    "name": "위메이드",
+    "sector": "커뮤니케이션서비스",
+    "marketCap": null
+  },
+  {
+    "symbol": "119860.KQ",
+    "name": "커넥트웨이브",
+    "sector": "정보기술",
+    "marketCap": null
+  },
+  {
+    "symbol": "121600.KQ",
+    "name": "나노신소재",
+    "sector": "소재",
+    "marketCap": null
+  },
+  {
+    "symbol": "122870.KQ",
+    "name": "와이지엔터테인먼트",
+    "sector": "커뮤니케이션서비스",
+    "marketCap": null
+  },
+  {
+    "symbol": "131970.KQ",
+    "name": "테스나",
+    "sector": "정보기술",
+    "marketCap": null
+  },
+  {
+    "symbol": "137400.KQ",
+    "name": "피엔티",
+    "sector": "정보기술",
+    "marketCap": null
+  },
+  {
+    "symbol": "140410.KQ",
+    "name": "메지온",
+    "sector": "헬스케어",
+    "marketCap": null
+  },
+  {
+    "symbol": "141080.KQ",
+    "name": "레고켐바이오",
+    "sector": "헬스케어",
+    "marketCap": null
+  },
+  {
+    "symbol": "145020.KQ",
+    "name": "휴젤",
+    "sector": "헬스케어",
+    "marketCap": null
+  },
+  {
+    "symbol": "181710.KQ",
+    "name": "NHN",
+    "sector": "정보기술",
+    "marketCap": null
+  },
+  {
+    "symbol": "183300.KQ",
+    "name": "코미코",
+    "sector": "정보기술",
+    "marketCap": null
+  },
+  {
+    "symbol": "194480.KQ",
+    "name": "데브시스터즈",
+    "sector": "커뮤니케이션서비스",
+    "marketCap": null
+  },
+  {
+    "symbol": "195870.KQ",
+    "name": "해성디에스",
+    "sector": "정보기술",
+    "marketCap": null
+  },
+  {
+    "symbol": "196170.KQ",
+    "name": "알테오젠",
+    "sector": "헬스케어",
+    "marketCap": null
+  },
+  {
+    "symbol": "200670.KQ",
+    "name": "휴메딕스",
+    "sector": "헬스케어",
+    "marketCap": null
+  },
+  {
+    "symbol": "213420.KQ",
+    "name": "덕산네오룩스",
+    "sector": "소재",
+    "marketCap": null
+  },
+  {
+    "symbol": "214150.KQ",
+    "name": "클래시스",
+    "sector": "헬스케어",
+    "marketCap": null
+  },
+  {
+    "symbol": "214370.KQ",
+    "name": "케어젠",
+    "sector": "헬스케어",
+    "marketCap": null
+  },
+  {
+    "symbol": "218410.KQ",
+    "name": "RFHIC",
+    "sector": "정보기술",
+    "marketCap": null
+  },
+  {
+    "symbol": "222080.KQ",
+    "name": "씨아이에스",
+    "sector": "정보기술",
+    "marketCap": null
+  },
+  {
+    "symbol": "225570.KQ",
+    "name": "넥슨게임즈",
+    "sector": "커뮤니케이션서비스",
+    "marketCap": null
+  },
+  {
+    "symbol": "237690.KQ",
+    "name": "에스티팜",
+    "sector": "헬스케어",
+    "marketCap": null
+  },
+  {
+    "symbol": "247540.KQ",
+    "name": "에코프로비엠",
+    "sector": "소재",
+    "marketCap": null
+  },
+  {
+    "symbol": "251630.KQ",
+    "name": "브이원텍",
+    "sector": "정보기술",
+    "marketCap": null
+  },
+  {
+    "symbol": "253450.KQ",
+    "name": "스튜디오드래곤",
+    "sector": "커뮤니케이션서비스",
+    "marketCap": null
+  },
+  {
+    "symbol": "263750.KQ",
+    "name": "펄어비스",
+    "sector": "커뮤니케이션서비스",
+    "marketCap": null
+  },
+  {
+    "symbol": "272290.KQ",
+    "name": "이녹스첨단소재",
+    "sector": "소재",
+    "marketCap": null
+  },
+  {
+    "symbol": "281740.KQ",
+    "name": "레이크머티리얼즈",
+    "sector": "소재",
+    "marketCap": null
+  },
+  {
+    "symbol": "293490.KQ",
+    "name": "카카오게임즈",
+    "sector": "커뮤니케이션서비스",
+    "marketCap": null
+  },
+  {
+    "symbol": "319660.KQ",
+    "name": "피에스케이",
+    "sector": "정보기술",
+    "marketCap": null
+  },
+  {
+    "symbol": "322310.KQ",
+    "name": "오로스테크놀로지",
+    "sector": "정보기술",
+    "marketCap": null
+  },
+  {
+    "symbol": "328130.KQ",
+    "name": "루닛",
+    "sector": "헬스케어",
+    "marketCap": null
+  },
+  {
+    "symbol": "336570.KQ",
+    "name": "원텍",
+    "sector": "소재",
+    "marketCap": null
+  },
+  {
+    "symbol": "348370.KQ",
+    "name": "엔켐",
+    "sector": "소재",
+    "marketCap": null
+  },
+  {
+    "symbol": "352820.KQ",
+    "name": "하이브",
+    "sector": "커뮤니케이션서비스",
+    "marketCap": null
+  },
+  {
+    "symbol": "357780.KQ",
+    "name": "솔브레인",
+    "sector": "소재",
+    "marketCap": null
+  },
+  {
+    "symbol": "365340.KQ",
+    "name": "성일하이텍",
+    "sector": "소재",
+    "marketCap": null
+  },
+  {
+    "symbol": "393890.KQ",
+    "name": "더블유씨피",
+    "sector": "소재",
+    "marketCap": null
+  },
+  {
+    "symbol": "399720.KQ",
+    "name": "가온칩스",
+    "sector": "정보기술",
+    "marketCap": null
+  },
+  {
+    "symbol": "403870.KQ",
+    "name": "HPSP",
+    "sector": "정보기술",
+    "marketCap": null
+  },
+  {
+    "symbol": "950130.KQ",
+    "name": "엑세스바이오",
+    "sector": "헬스케어",
+    "marketCap": null
+  }
+]

--- a/data/indexes/kospi200.json
+++ b/data/indexes/kospi200.json
@@ -1,0 +1,1190 @@
+[
+  {
+    "symbol": "000080.KS",
+    "name": "하이트진로",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "000100.KS",
+    "name": "유한양행",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "000120.KS",
+    "name": "CJ대한통운",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "000150.KS",
+    "name": "두산",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "000210.KS",
+    "name": "DL",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "000240.KS",
+    "name": "한국앤컴퍼니",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "000270.KS",
+    "name": "기아",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "000660.KS",
+    "name": "SK하이닉스",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "000670.KS",
+    "name": "영풍",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "000720.KS",
+    "name": "현대건설",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "000810.KS",
+    "name": "삼성화재",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "000880.KS",
+    "name": "한화",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "001040.KS",
+    "name": "CJ",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "001430.KS",
+    "name": "세아베스틸지주",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "001440.KS",
+    "name": "대한전선",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "001450.KS",
+    "name": "현대해상",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "001680.KS",
+    "name": "대상",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "001800.KS",
+    "name": "오리온홀딩스",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "002030.KS",
+    "name": "아세아",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "002380.KS",
+    "name": "KCC",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "002790.KS",
+    "name": "아모레퍼시픽홀딩스",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "002840.KS",
+    "name": "미원상사",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "003030.KS",
+    "name": "세아제강지주",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "003090.KS",
+    "name": "대웅",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "003230.KS",
+    "name": "삼양식품",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "003240.KS",
+    "name": "태광산업",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "003490.KS",
+    "name": "대한항공",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "003550.KS",
+    "name": "LG",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "003670.KS",
+    "name": "포스코퓨처엠",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "004000.KS",
+    "name": "롯데정밀화학",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "004020.KS",
+    "name": "현대제철",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "004170.KS",
+    "name": "신세계",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "004370.KS",
+    "name": "농심",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "004490.KS",
+    "name": "세방전지",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "004990.KS",
+    "name": "롯데지주",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "005250.KS",
+    "name": "녹십자홀딩스",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "005300.KS",
+    "name": "롯데칠성",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "005380.KS",
+    "name": "현대차",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "005420.KS",
+    "name": "코스모화학",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "005490.KS",
+    "name": "POSCO홀딩스",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "005830.KS",
+    "name": "DB손해보험",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "005850.KS",
+    "name": "에스엘",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "005930.KS",
+    "name": "삼성전자",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "005940.KS",
+    "name": "NH투자증권",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "006040.KS",
+    "name": "동원산업",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "006260.KS",
+    "name": "LS",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "006280.KS",
+    "name": "녹십자",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "006360.KS",
+    "name": "GS건설",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "006400.KS",
+    "name": "삼성SDI",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "006650.KS",
+    "name": "대한유화",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "006800.KS",
+    "name": "미래에셋증권",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "007070.KS",
+    "name": "GS리테일",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "007310.KS",
+    "name": "오뚜기",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "007340.KS",
+    "name": "DN오토모티브",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "007660.KS",
+    "name": "이수페타시스",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "008730.KS",
+    "name": "율촌화학",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "008770.KS",
+    "name": "호텔신라",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "008930.KS",
+    "name": "한미사이언스",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "009150.KS",
+    "name": "삼성전기",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "009240.KS",
+    "name": "한샘",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "009420.KS",
+    "name": "한올바이오파마",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "009540.KS",
+    "name": "HD한국조선해양",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "009830.KS",
+    "name": "한화솔루션",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "009970.KS",
+    "name": "영원무역홀딩스",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "010060.KS",
+    "name": "OCI홀딩스",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "010120.KS",
+    "name": "LS일렉트릭",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "010130.KS",
+    "name": "고려아연",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "010140.KS",
+    "name": "삼성중공업",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "010950.KS",
+    "name": "S-Oil",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "011070.KS",
+    "name": "LG이노텍",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "011170.KS",
+    "name": "롯데케미칼",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "011200.KS",
+    "name": "HMM",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "011210.KS",
+    "name": "현대위아",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "011780.KS",
+    "name": "금호석유화학",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "011790.KS",
+    "name": "SKC",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "012330.KS",
+    "name": "현대모비스",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "012450.KS",
+    "name": "한화에어로스페이스",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "012750.KS",
+    "name": "에스원",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "014680.KS",
+    "name": "한솔케미칼",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "014820.KS",
+    "name": "동원시스템즈",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "015760.KS",
+    "name": "한국전력",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "016360.KS",
+    "name": "삼성에피스홀딩스",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "017670.KS",
+    "name": "SK텔레콤",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "017800.KS",
+    "name": "현대엘리베이터",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "017960.KS",
+    "name": "한국카본",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "018260.KS",
+    "name": "삼성SDS",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "018880.KS",
+    "name": "한온시스템",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "021240.KS",
+    "name": "코웨이",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "022100.KS",
+    "name": "포스코DX",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "023530.KS",
+    "name": "롯데쇼핑",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "024110.KS",
+    "name": "기업은행",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "026960.KS",
+    "name": "동서",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "028050.KS",
+    "name": "삼성E&A",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "028260.KS",
+    "name": "삼성물산",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "028670.KS",
+    "name": "팬오션",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "029780.KS",
+    "name": "삼성카드",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "030000.KS",
+    "name": "제일기획",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "030200.KS",
+    "name": "KT",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "032640.KS",
+    "name": "LG유플러스",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "032830.KS",
+    "name": "삼성생명",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "033780.KS",
+    "name": "KT&G",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "034020.KS",
+    "name": "두산에너빌리티",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "034220.KS",
+    "name": "LG디스플레이",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "034230.KS",
+    "name": "파라다이스",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "034730.KS",
+    "name": "SK",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "035250.KS",
+    "name": "강원랜드",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "035420.KS",
+    "name": "NAVER",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "035720.KS",
+    "name": "카카오",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "036460.KS",
+    "name": "한국가스공사",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "036570.KS",
+    "name": "엔씨소프트",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "039490.KS",
+    "name": "키움증권",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "042660.KS",
+    "name": "한화오션",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "042700.KS",
+    "name": "한미반도체",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "047040.KS",
+    "name": "대우건설",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "047050.KS",
+    "name": "포스코인터내셔널",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "047810.KS",
+    "name": "한국항공우주",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "051600.KS",
+    "name": "한전KPS",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "051900.KS",
+    "name": "LG생활건강",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "051910.KS",
+    "name": "LG화학",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "052690.KS",
+    "name": "한전기술",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "055550.KS",
+    "name": "신한지주",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "062040.KS",
+    "name": "산일전기",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "064350.KS",
+    "name": "현대로템",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "064400.KS",
+    "name": "LG씨엔에스",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "066570.KS",
+    "name": "LG전자",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "066970.KS",
+    "name": "엘앤에프",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "068270.KS",
+    "name": "셀트리온",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "069260.KS",
+    "name": "TKG휴켐스",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "069620.KS",
+    "name": "대웅제약",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "069960.KS",
+    "name": "현대백화점",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "071050.KS",
+    "name": "한국금융지주",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "071320.KS",
+    "name": "지역난방공사",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "071970.KS",
+    "name": "HD현대마린엔진",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "073240.KS",
+    "name": "금호타이어",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "078930.KS",
+    "name": "GS",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "079550.KS",
+    "name": "LIG넥스원",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "081660.KS",
+    "name": "미스토홀딩스",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "082740.KS",
+    "name": "한화엔진",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "086280.KS",
+    "name": "현대글로비스",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "086790.KS",
+    "name": "하나금융지주",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "088350.KS",
+    "name": "한화생명",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "090430.KS",
+    "name": "아모레퍼시픽",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "093370.KS",
+    "name": "후성",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "096770.KS",
+    "name": "SK이노베이션",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "097950.KS",
+    "name": "CJ제일제당",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "103140.KS",
+    "name": "풍산",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "105560.KS",
+    "name": "KB금융",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "111770.KS",
+    "name": "에이피알",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "112610.KS",
+    "name": "씨에스윈드",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "114090.KS",
+    "name": "GKL",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "120110.KS",
+    "name": "코오롱인더",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "128940.KS",
+    "name": "한미약품",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "137310.KS",
+    "name": "에스디바이오센서",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "138040.KS",
+    "name": "메리츠금융지주",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "138930.KS",
+    "name": "BNK금융지주",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "139130.KS",
+    "name": "iM금융지주",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "139480.KS",
+    "name": "영원무역",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "161390.KS",
+    "name": "한국타이어앤테크놀로지",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "161890.KS",
+    "name": "한국콜마",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "175330.KS",
+    "name": "JB금융지주",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "180640.KS",
+    "name": "한진칼",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "185750.KS",
+    "name": "종근당",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "192080.KS",
+    "name": "더블유게임즈",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "192820.KS",
+    "name": "코스맥스",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "204320.KS",
+    "name": "HL만도",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "207940.KS",
+    "name": "삼성바이오로직스",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "241560.KS",
+    "name": "두산밥캣",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "251270.KS",
+    "name": "넷마블",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "259960.KS",
+    "name": "크래프톤",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "267250.KS",
+    "name": "HD현대",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "267260.KS",
+    "name": "HD현대일렉트릭",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "268280.KS",
+    "name": "미원에스씨",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "271560.KS",
+    "name": "오리온",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "272210.KS",
+    "name": "한화시스템",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "280360.KS",
+    "name": "롯데웰푸드",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "282330.KS",
+    "name": "BGF리테일",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "285130.KS",
+    "name": "SK케미칼",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "298020.KS",
+    "name": "효성티앤씨",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "298040.KS",
+    "name": "효성중공업",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "298050.KS",
+    "name": "HS효성첨단소재",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "300720.KS",
+    "name": "한일시멘트",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "302440.KS",
+    "name": "SK바이오사이언스",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "307950.KS",
+    "name": "현대오토에버",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "316140.KS",
+    "name": "우리금융지주",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "323410.KS",
+    "name": "카카오뱅크",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "326030.KS",
+    "name": "SK바이오팜",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "329180.KS",
+    "name": "HD현대중공업",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "352820.KS",
+    "name": "하이브",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "361610.KS",
+    "name": "SK아이이테크놀로지",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "373220.KS",
+    "name": "LG에너지솔루션",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "375500.KS",
+    "name": "DL이앤씨",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "377300.KS",
+    "name": "카카오페이",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "383220.KS",
+    "name": "F&F",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "402340.KS",
+    "name": "SK스퀘어",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "443060.KS",
+    "name": "HD현대마린솔루션",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "450080.KS",
+    "name": "에코프로머티",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "454910.KS",
+    "name": "두산로보틱스",
+    "sector": null,
+    "marketCap": null
+  },
+  {
+    "symbol": "457190.KS",
+    "name": "이수스페셜티케미컬",
+    "sector": null,
+    "marketCap": null
+  }
+]

--- a/data/indexes/nasdaq-trader.json
+++ b/data/indexes/nasdaq-trader.json
@@ -1,0 +1,27487 @@
+[
+  {
+    "symbol": "A",
+    "name": "Agilent Technologies, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AA",
+    "name": "Alcoa Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AACB",
+    "name": "Artius II Acquisition Inc. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "AACI",
+    "name": "Armada Acquisition Corp. III - Class A Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "AACO",
+    "name": "Abony Acquisition Corp. I - Class A Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "AACP",
+    "name": "Apogee Acquisition Corp - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "AADX",
+    "name": "Applied Aerospace & Defense, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AAL",
+    "name": "American Airlines Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AAME",
+    "name": "Atlantic American Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "AAMI",
+    "name": "Acadian Asset Management Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AAOI",
+    "name": "Applied Optoelectronics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AAON",
+    "name": "AAON, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AAP",
+    "name": "Advance Auto Parts Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AAPG",
+    "name": "Ascentage Pharma Group International - American Depository Shares",
+    "sector": null
+  },
+  {
+    "symbol": "AAPL",
+    "name": "Apple Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AARD",
+    "name": "Aardvark Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AAT",
+    "name": "American Assets Trust, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AAUC",
+    "name": "Allied Gold Corporation Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ABAT",
+    "name": "American Battery Technology Company",
+    "sector": null
+  },
+  {
+    "symbol": "ABBV",
+    "name": "AbbVie Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ABCB",
+    "name": "Ameris Bancorp Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ABCL",
+    "name": "AbCellera Biologics Inc. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ABEO",
+    "name": "Abeona Therapeutics Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ABG",
+    "name": "Asbury Automotive Group Inc Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ABLV",
+    "name": "Able View Global Inc. - Class B Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ABM",
+    "name": "ABM Industries Incorporated Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ABNB",
+    "name": "Airbnb, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ABOS",
+    "name": "Acumen Pharmaceuticals, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ABR",
+    "name": "Arbor Realty Trust Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ABSI",
+    "name": "Absci Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "ABT",
+    "name": "Abbott Laboratories Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ABTC",
+    "name": "American Bitcoin Corp. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ABTS",
+    "name": "Abits Group Inc - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ABUS",
+    "name": "Arbutus Biopharma Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "ABVC",
+    "name": "ABVC BioPharma, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ABX",
+    "name": "Abacus Global Management, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ACA",
+    "name": "Arcosa, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ACAA",
+    "name": "Averin Capital Acquisition Corp. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ACAD",
+    "name": "ACADIA Pharmaceuticals Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ACB",
+    "name": "Aurora Cannabis Inc. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ACCL",
+    "name": "Acco Group Holdings Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ACCO",
+    "name": "Acco Brands Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ACCS",
+    "name": "ACCESS Newswire Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ACDC",
+    "name": "ProFrac Holding Corp. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ACEL",
+    "name": "Accel Entertainment, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ACET",
+    "name": "Adicet Bio, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ACFN",
+    "name": "Acorn Energy, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ACGC",
+    "name": "ACP Holdings Acquisition Corp. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ACGL",
+    "name": "Arch Capital Group Ltd.",
+    "sector": null
+  },
+  {
+    "symbol": "ACH",
+    "name": "Accendra Health, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ACHC",
+    "name": "Acadia Healthcare Company, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ACHR",
+    "name": "Archer Aviation Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ACHV",
+    "name": "Achieve Life Sciences, Inc. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ACI",
+    "name": "Albertsons Companies, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ACIC",
+    "name": "American Coastal Insurance Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "ACIU",
+    "name": "AC Immune SA",
+    "sector": null
+  },
+  {
+    "symbol": "ACIW",
+    "name": "ACI Worldwide, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ACLS",
+    "name": "Axcelis Technologies, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ACM",
+    "name": "AECOM Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ACMR",
+    "name": "ACM Research, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ACN",
+    "name": "Accenture plc Class A Ordinary Shares (Ireland)",
+    "sector": null
+  },
+  {
+    "symbol": "ACNB",
+    "name": "ACNB Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "ACNT",
+    "name": "Ascent Industries Co.",
+    "sector": null
+  },
+  {
+    "symbol": "ACOG",
+    "name": "Alpha Cognition Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ACON",
+    "name": "Aclarion, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ACP",
+    "name": "abrdn Income Credit Strategies Fund Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ACR",
+    "name": "ACRES Commercial Realty Corp. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ACRE",
+    "name": "Ares Commercial Real Estate Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ACRS",
+    "name": "Aclaris Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ACRV",
+    "name": "Acrivon Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ACT",
+    "name": "Enact Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ACTG",
+    "name": "Acacia Research Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "ACTU",
+    "name": "Actuate Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ACV",
+    "name": "Virtus Diversified Income & Convertible Fund Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "ACVA",
+    "name": "ACV Auctions Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ACXP",
+    "name": "Acurx Pharmaceuticals, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AD",
+    "name": "Array Digital Infrastructure, Inc. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ADAC",
+    "name": "American Drive Acquisition Company - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ADAG",
+    "name": "Adagene Inc. - ADS, each representing 1.25 ordinary shares",
+    "sector": null
+  },
+  {
+    "symbol": "ADAM",
+    "name": "Adamas Trust, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ADBE",
+    "name": "Adobe Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ADC",
+    "name": "Agree Realty Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ADCT",
+    "name": "ADC Therapeutics SA Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ADEA",
+    "name": "Adeia Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ADGM",
+    "name": "Adagio Medical Holdings, Inc",
+    "sector": null
+  },
+  {
+    "symbol": "ADI",
+    "name": "Analog Devices, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ADIL",
+    "name": "Adial Pharmaceuticals, Inc",
+    "sector": null
+  },
+  {
+    "symbol": "ADM",
+    "name": "Archer-Daniels-Midland Company Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ADMA",
+    "name": "ADMA Biologics Inc",
+    "sector": null
+  },
+  {
+    "symbol": "ADNT",
+    "name": "Adient plc Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ADP",
+    "name": "Automatic Data Processing, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ADPT",
+    "name": "Adaptive Biotechnologies Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "ADSE",
+    "name": "ADS-TEC ENERGY PLC - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ADSK",
+    "name": "Autodesk, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ADT",
+    "name": "ADT Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ADTN",
+    "name": "ADTRAN Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ADTX",
+    "name": "Aditxt, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ADUR",
+    "name": "Aduro Clean Technologies Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ADUS",
+    "name": "Addus HomeCare Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "ADV",
+    "name": "Advantage Solutions Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ADVB",
+    "name": "Advanced Biomed Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ADX",
+    "name": "Adams Diversified Equity Fund Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AEAQ",
+    "name": "Activate Energy Acquisition Corp. - Class A Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "AEBI",
+    "name": "Aebi Schmidt Holding AG",
+    "sector": null
+  },
+  {
+    "symbol": "AEC",
+    "name": "Anfield Energy Inc. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "AEE",
+    "name": "Ameren Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AEF",
+    "name": "abrdn Emerging Markets ex-China Fund, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AEG",
+    "name": "Aegon Ltd. New York Registry Shares",
+    "sector": null
+  },
+  {
+    "symbol": "AEHL",
+    "name": "Antelope Enterprise Holdings Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "AEHR",
+    "name": "Aehr Test Systems",
+    "sector": null
+  },
+  {
+    "symbol": "AEI",
+    "name": "Alset Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AEIS",
+    "name": "Advanced Energy Industries, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AEM",
+    "name": "Agnico Eagle Mines Limited Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AEMD",
+    "name": "Aethlon Medical, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AENT",
+    "name": "Alliance Entertainment Holding Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "AEO",
+    "name": "American Eagle Outfitters, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AEON",
+    "name": "AEON Biopharma, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AEP",
+    "name": "American Electric Power Company, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AER",
+    "name": "AerCap Holdings N.V. Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "AERT",
+    "name": "Aeries Technology, Inc. - Class A Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "AES",
+    "name": "The AES Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AESI",
+    "name": "Atlas Energy Solutions Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AEVA",
+    "name": "Aeva Technologies, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AEXA",
+    "name": "American Exceptionalism Acquisition Corp. A Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "AEYE",
+    "name": "AudioEye, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AFB",
+    "name": "AllianceBernstein National Municipal Income Fund Inc",
+    "sector": null
+  },
+  {
+    "symbol": "AFBI",
+    "name": "Affinity Bancshares, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AFCG",
+    "name": "Advanced Flower Capital Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AFG",
+    "name": "American Financial Group, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AFJK",
+    "name": "Aimei Health Technology Co., Ltd - Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "AFL",
+    "name": "AFLAC Incorporated Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AFRI",
+    "name": "Forafric Global PLC - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "AFRM",
+    "name": "Affirm Holdings, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AFYA",
+    "name": "Afya Limited - Class A Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "AG",
+    "name": "First Majestic Silver Corp. Ordinary Shares (Canada)",
+    "sector": null
+  },
+  {
+    "symbol": "AGBK",
+    "name": "AGI Inc Class A Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "AGCC",
+    "name": "Agencia Comercial Spirits Ltd - Class A Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "AGCO",
+    "name": "AGCO Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AGD",
+    "name": "abrdn Global Dynamic Dividend Fund Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "AGEN",
+    "name": "Agenus Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AGI",
+    "name": "Alamos Gold Inc. Class A Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "AGIG",
+    "name": "Abundia Global Impact Group Inc. Common stock",
+    "sector": null
+  },
+  {
+    "symbol": "AGIO",
+    "name": "Agios Pharmaceuticals, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AGL",
+    "name": "agilon health, inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AGM",
+    "name": "Federal Agricultural Mortgage Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AGM.A",
+    "name": "Federal Agricultural Mortgage Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AGMB",
+    "name": "AgomAb Therapeutics NV - ADRs representing one common share.",
+    "sector": null
+  },
+  {
+    "symbol": "AGMH",
+    "name": "AGM Group Holdings Inc. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "AGNC",
+    "name": "AGNC Investment Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "AGNT",
+    "name": "AGNT, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AGO",
+    "name": "Assured Guaranty Ltd. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AGPU",
+    "name": "Axe Compute Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AGRO",
+    "name": "Adecoagro S.A. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "AGRZ",
+    "name": "Agroz Inc. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "AGX",
+    "name": "Argan, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AGYS",
+    "name": "Agilysys, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AHCO",
+    "name": "AdaptHealth Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "AHMA",
+    "name": "Ambitions Enterprise Management Co. L.L.C - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "AHR",
+    "name": "American Healthcare REIT, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AHRT",
+    "name": "AH Realty Trust, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AHT",
+    "name": "Ashford Hospitality Trust Inc Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AI",
+    "name": "C3.ai, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AIAI",
+    "name": "AIAI Holdings Corporation - Class A common stock",
+    "sector": null
+  },
+  {
+    "symbol": "AIB",
+    "name": "BlockchAIn Digital Infrastructure, Inc Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "AIBZ",
+    "name": "Bitzero Holdings Inc. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "AIDX",
+    "name": "20/20 Biolabs, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AIFA",
+    "name": "All In FutureTech Alliance, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AIFC",
+    "name": "AI Financial Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "AIFF",
+    "name": "Firefly Neuroscience, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AIFU",
+    "name": "AIFU Inc. - Class A Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "AIG",
+    "name": "American International Group, Inc. New Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AIHS",
+    "name": "Senmiao Technology Limited",
+    "sector": null
+  },
+  {
+    "symbol": "AII",
+    "name": "American Integrity Insurance Group, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AIIA",
+    "name": "AI Infrastructure Acquisition Corp. Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "AIIO",
+    "name": "Robo.ai Inc. - Class B Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "AIIR",
+    "name": "Air Global PLC - Ordinary shares",
+    "sector": null
+  },
+  {
+    "symbol": "AIMD",
+    "name": "Ainos, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AIN",
+    "name": "Albany International Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AIOS",
+    "name": "AIOS Tech Inc. - Class A Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "AIOT",
+    "name": "PowerFleet, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AIP",
+    "name": "Arteris, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AIR",
+    "name": "AAR Corp. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AIRE",
+    "name": "reAlpha Tech Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "AIRG",
+    "name": "Airgain, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AIRI",
+    "name": "Air Industries Group Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AIRJ",
+    "name": "AirJoule Technologies Corporation - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AIRO",
+    "name": "AIRO Group Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AIRS",
+    "name": "AirSculpt Technologies, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AIRT",
+    "name": "Air T, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AISP",
+    "name": "Airship AI Holdings, Inc - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AIT",
+    "name": "Applied Industrial Technologies, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AIV",
+    "name": "Apartment Investment and Management Company Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AIXC",
+    "name": "AIxCrypto Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AIZ",
+    "name": "Assurant, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AJG",
+    "name": "Arthur J. Gallagher & Co. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AKA",
+    "name": "a.k.a. Brands Holding Corp. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AKAM",
+    "name": "Akamai Technologies, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AKAN",
+    "name": "Akanda Corp. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "AKBA",
+    "name": "Akebia Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AKO.A",
+    "name": "Embotelladora Andina S.A. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AKO.B",
+    "name": "Embotelladora Andina S.A. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AKR",
+    "name": "Acadia Realty Trust Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AKTS",
+    "name": "Aktis Oncology, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ALAB",
+    "name": "Astera Labs, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ALB",
+    "name": "Albemarle Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ALBT",
+    "name": "Avalon GloboCare Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "ALC",
+    "name": "Alcon Inc. Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ALCO",
+    "name": "Alico, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ALDF",
+    "name": "Aldel Financial II Inc. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ALDX",
+    "name": "Aldeyra Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ALEC",
+    "name": "Alector, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ALF",
+    "name": "Centurion Acquisition Corp. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ALG",
+    "name": "Alamo Group, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ALGM",
+    "name": "Allegro MicroSystems, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ALGN",
+    "name": "Align Technology, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ALGS",
+    "name": "Aligos Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ALGT",
+    "name": "Allegiant Travel Company",
+    "sector": null
+  },
+  {
+    "symbol": "ALH",
+    "name": "Alliance Laundry Holdings Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ALHC",
+    "name": "Alignment Healthcare, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ALIS",
+    "name": "Calisa Acquisition Corp - Ordinary shares",
+    "sector": null
+  },
+  {
+    "symbol": "ALIT",
+    "name": "Alight, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ALK",
+    "name": "Alaska Air Group, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ALKS",
+    "name": "Alkermes plc - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ALKT",
+    "name": "Alkami Technology, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ALL",
+    "name": "Allstate Corporation (The) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ALLE",
+    "name": "Allegion plc Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ALLO",
+    "name": "Allogene Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ALLR",
+    "name": "Allarity Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ALLT",
+    "name": "Allot Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ALLY",
+    "name": "Ally Financial Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ALM",
+    "name": "Almonty Industries Inc. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ALMR",
+    "name": "Alamar Biosciences, Inc. - Class A common stock",
+    "sector": null
+  },
+  {
+    "symbol": "ALMS",
+    "name": "Alumis Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ALMU",
+    "name": "Aeluma, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ALNT",
+    "name": "Allient Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ALNY",
+    "name": "Alnylam Pharmaceuticals, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ALOT",
+    "name": "AstroNova, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ALOY",
+    "name": "REalloys Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ALP",
+    "name": "Alpha Compute Corp",
+    "sector": null
+  },
+  {
+    "symbol": "ALPS",
+    "name": "ALPS Group Inc - Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "ALRM",
+    "name": "Alarm.com Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ALRS",
+    "name": "Alerus Financial Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "ALSN",
+    "name": "Allison Transmission Holdings, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ALT",
+    "name": "Altimmune, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ALTG",
+    "name": "Alta Equipment Group Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ALTI",
+    "name": "AlTi Global, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ALTO",
+    "name": "Alto Ingredients, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ALUB",
+    "name": "Alussa Energy Acquisition Corp. II Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ALV",
+    "name": "Autoliv, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ALVO",
+    "name": "Alvotech - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ALX",
+    "name": "Alexander's, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ALXO",
+    "name": "ALX Oncology Holdings Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ALZN",
+    "name": "Alzamend Neuro, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AM",
+    "name": "Antero Midstream Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AMAL",
+    "name": "Amalgamated Financial Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "AMAN",
+    "name": "Amanat Acquisition Corp - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "AMAT",
+    "name": "Applied Materials, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AMBA",
+    "name": "Ambarella, Inc. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "AMBO",
+    "name": "Ambow Education Holding Ltd. American Depository Shares (each representing twenty (20) Class A Ordinary Shares)",
+    "sector": null
+  },
+  {
+    "symbol": "AMBP",
+    "name": "Ardagh Metal Packaging S.A. Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "AMBQ",
+    "name": "Ambiq Micro, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AMC",
+    "name": "AMC Entertainment Holdings, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AMCI",
+    "name": "AMC Robotics Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "AMCR",
+    "name": "Amcor plc Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "AMCX",
+    "name": "AMC Global Media Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AMD",
+    "name": "Advanced Micro Devices, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AME",
+    "name": "AMETEK, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AMG",
+    "name": "Affiliated Managers Group, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AMGN",
+    "name": "Amgen Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AMH",
+    "name": "American Homes 4 Rent Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "AMIX",
+    "name": "Autonomix Medical, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AMKR",
+    "name": "Amkor Technology, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AMLX",
+    "name": "Amylyx Pharmaceuticals, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AMN",
+    "name": "AMN Healthcare Services Inc",
+    "sector": null
+  },
+  {
+    "symbol": "AMOD",
+    "name": "Alpha Modus Holdings, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AMP",
+    "name": "Ameriprise Financial, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AMPG",
+    "name": "Amplitech Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AMPH",
+    "name": "Amphastar Pharmaceuticals, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AMPL",
+    "name": "Amplitude, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AMPX",
+    "name": "Amprius Technologies, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AMPY",
+    "name": "Amplify Energy Corp. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AMR",
+    "name": "Alpha Metallurgical Resources, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AMRC",
+    "name": "Ameresco, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AMRX",
+    "name": "Amneal Pharmaceuticals, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AMRZ",
+    "name": "Amrize Ltd Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "AMS",
+    "name": "American Shared Hospital Services Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AMSC",
+    "name": "American Superconductor Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "AMSF",
+    "name": "AMERISAFE, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AMSS",
+    "name": "AMASS Brands Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AMST",
+    "name": "Amesite Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AMT",
+    "name": "American Tower Corporation (REIT) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AMTB",
+    "name": "Amerant Bancorp Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AMTM",
+    "name": "Amentum Holdings, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AMTX",
+    "name": "Aemetis, Inc",
+    "sector": null
+  },
+  {
+    "symbol": "AMUB",
+    "name": "ETRACS Alerian MLP Index ETN Series B due July 18, 2042",
+    "sector": null
+  },
+  {
+    "symbol": "AMWL",
+    "name": "American Well Corporation Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AMZE",
+    "name": "Amaze Holdings, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AMZN",
+    "name": "Amazon.com, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AN",
+    "name": "AutoNation, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ANAB",
+    "name": "AnaptysBio, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ANDE",
+    "name": "The Andersons, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ANDG",
+    "name": "Andersen Group Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ANET",
+    "name": "Arista Networks, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ANF",
+    "name": "Abercrombie & Fitch Company Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ANGH",
+    "name": "Anghami Inc. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ANGI",
+    "name": "Angi Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ANGO",
+    "name": "AngioDynamics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ANGX",
+    "name": "Angel Studios, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ANIK",
+    "name": "Anika Therapeutics Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ANIP",
+    "name": "ANI Pharmaceuticals, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ANIX",
+    "name": "Anixa Biosciences, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ANNA",
+    "name": "AleAnna, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ANNX",
+    "name": "Annexon, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ANPA",
+    "name": "Rich Sparkle Holdings Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ANRO",
+    "name": "Alto Neuroscience, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ANSC",
+    "name": "Agriculture & Natural Solutions Acquisition Corporation - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ANTA",
+    "name": "Antalpha Platform Holding Company - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ANTX",
+    "name": "AN2 Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ANVS",
+    "name": "Annovis Bio, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ANY",
+    "name": "Sphere 3D Corp. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "AOD",
+    "name": "abrdn Total Dynamic Dividend Fund Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "AOMR",
+    "name": "Angel Oak Mortgage REIT, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AON",
+    "name": "Aon plc Class A Ordinary Shares (Ireland)",
+    "sector": null
+  },
+  {
+    "symbol": "AORT",
+    "name": "Artivion, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AOS",
+    "name": "A.O. Smith Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AOSL",
+    "name": "Alpha and Omega Semiconductor Limited - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "AOUT",
+    "name": "American Outdoor Brands, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AP",
+    "name": "Ampco-Pittsburgh Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "APA",
+    "name": "APA Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "APAC",
+    "name": "StoneBridge Acquisition II Corporation - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "APAM",
+    "name": "Artisan Partners Asset Management Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "APC",
+    "name": "ARKO Petroleum Corp. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "APD",
+    "name": "Air Products and Chemicals, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "APEI",
+    "name": "American Public Education, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "APG",
+    "name": "APi Group Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "APGE",
+    "name": "Apogee Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "APH",
+    "name": "Amphenol Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "API",
+    "name": "Agora, Inc. - ADS",
+    "sector": null
+  },
+  {
+    "symbol": "APLD",
+    "name": "Applied Digital Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "APLE",
+    "name": "Apple Hospitality REIT, Inc. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "APLM",
+    "name": "Apollomics Inc. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "APM",
+    "name": "Aptorum Group Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "APO",
+    "name": "Apollo Global Management, Inc. (New) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "APOG",
+    "name": "Apogee Enterprises, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "APP",
+    "name": "Applovin Corporation - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "APPF",
+    "name": "AppFolio, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "APPN",
+    "name": "Appian Corporation - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "APPS",
+    "name": "Digital Turbine, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "APRE",
+    "name": "Aprea Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "APT",
+    "name": "Alpha Pro Tech, Ltd. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "APTV",
+    "name": "Aptiv PLC Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "APUR",
+    "name": "Aperture AC - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "APUS",
+    "name": "Apimeds Pharmaceuticals US, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "APVO",
+    "name": "Aptevo Therapeutics Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "APWC",
+    "name": "Asia Pacific Wire & Cable Corporation Limited - Common shares, Par value .01 per share",
+    "sector": null
+  },
+  {
+    "symbol": "APXT",
+    "name": "Apex Treasury Corporation - Class A Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "APYX",
+    "name": "Apyx Medical Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "AQB",
+    "name": "AquaBounty Technologies, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AQMS",
+    "name": "Aqua Metals, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AQN",
+    "name": "Algonquin Power & Utilities Corp. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "AQST",
+    "name": "Aquestive Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AR",
+    "name": "Antero Resources Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ARAI",
+    "name": "Arrive AI Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ARAY",
+    "name": "Accuray Incorporated",
+    "sector": null
+  },
+  {
+    "symbol": "ARBB",
+    "name": "ARB IOT Group Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ARBE",
+    "name": "Arbe Robotics Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ARCB",
+    "name": "ArcBest Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "ARCC",
+    "name": "Ares Capital Corporation - Closed End Fund",
+    "sector": null
+  },
+  {
+    "symbol": "ARCI",
+    "name": "Archimedes Tech SPAC Partners III Co. - Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "ARCL",
+    "name": "ARC Group Acquisition I Corp - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ARCO",
+    "name": "Arcos Dorados Holdings Inc. Class A Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ARCT",
+    "name": "Arcturus Therapeutics Holdings Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ARDC",
+    "name": "Ares Dynamic Credit Allocation Fund, Inc. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ARDT",
+    "name": "Ardent Health, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ARDX",
+    "name": "Ardelyx, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ARE",
+    "name": "Alexandria Real Estate Equities, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AREC",
+    "name": "American Resources Corporation - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AREN",
+    "name": "The Arena Group Holdings, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ARES",
+    "name": "Ares Management Corporation Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ARHS",
+    "name": "Arhaus, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ARI",
+    "name": "Apollo Commercial Real Estate Finance, Inc",
+    "sector": null
+  },
+  {
+    "symbol": "ARIS",
+    "name": "Aris Mining Corporation Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ARKO",
+    "name": "ARKO Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "ARKR",
+    "name": "Ark Restaurants Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "ARL",
+    "name": "American Realty Investors, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ARLO",
+    "name": "Arlo Technologies, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ARMK",
+    "name": "Aramark Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ARMP",
+    "name": "Armata Pharmaceuticals, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AROC",
+    "name": "Archrock, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AROW",
+    "name": "Arrow Financial Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "ARQ",
+    "name": "Arq, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ARQQ",
+    "name": "Arqit Quantum Inc. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ARQT",
+    "name": "Arcutis Biotherapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ARR",
+    "name": "ARMOUR Residential REIT, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ARRY",
+    "name": "Array Technologies, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ARTC",
+    "name": "Art Technology Acquisition Corp. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ARTL",
+    "name": "Artelo Biosciences, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ARTNA",
+    "name": "Artesian Resources Corporation - Class A Non-Voting Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ARTV",
+    "name": "Artiva Biotherapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ARTW",
+    "name": "Art's-Way Manufacturing Co., Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ARVN",
+    "name": "Arvinas, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ARW",
+    "name": "Arrow Electronics, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ARWR",
+    "name": "Arrowhead Pharmaceuticals, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ARX",
+    "name": "Accelerant Holdings Class A Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ARXS",
+    "name": "Arxis, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AS",
+    "name": "Amer Sports, Inc. Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ASA",
+    "name": "ASA Gold and Precious Metals Limited",
+    "sector": null
+  },
+  {
+    "symbol": "ASAN",
+    "name": "Asana, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ASB",
+    "name": "Associated Banc-Corp Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ASBP",
+    "name": "Aspire Biopharma Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ASC",
+    "name": "Ardmore Shipping Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ASG",
+    "name": "Liberty All-Star Growth Fund, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ASGI",
+    "name": "abrdn Global Infrastructure Income Fund Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "ASH",
+    "name": "Ashland Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ASIC",
+    "name": "Ategrity Specialty Insurance Company Holdings Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ASIX",
+    "name": "AdvanSix Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ASLE",
+    "name": "AerSale Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "ASM",
+    "name": "Avino Silver & Gold Mines Ltd. Common Shares (Canada)",
+    "sector": null
+  },
+  {
+    "symbol": "ASMB",
+    "name": "Assembly Biosciences, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ASML",
+    "name": "ASML Holding N.V. - New York Registry Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ASND",
+    "name": "Ascendis Pharma A/S - Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "ASO",
+    "name": "Academy Sports and Outdoors, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ASPC",
+    "name": "A SPAC III Acquisition Corp. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ASPI",
+    "name": "ASP Isotopes Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ASPN",
+    "name": "Aspen Aerogels, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ASPS",
+    "name": "Altisource Portfolio Solutions S.A.",
+    "sector": null
+  },
+  {
+    "symbol": "ASR",
+    "name": "Grupo Aeroportuario del Sureste, S.A. de C.V. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ASRT",
+    "name": "Assertio Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ASRV",
+    "name": "AmeriServ Financial Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ASST",
+    "name": "Strive, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ASTC",
+    "name": "Astrotech Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "ASTE",
+    "name": "Astec Industries, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ASTH",
+    "name": "Astrana Health Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ASTI",
+    "name": "Ascent Solar Technologies, Inc",
+    "sector": null
+  },
+  {
+    "symbol": "ASTL",
+    "name": "Algoma Steel Group Inc. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ASTS",
+    "name": "AST SpaceMobile, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ASUR",
+    "name": "Asure Software Inc",
+    "sector": null
+  },
+  {
+    "symbol": "ASYS",
+    "name": "Amtech Systems, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ATAI",
+    "name": "AtaiBeckley Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ATCH",
+    "name": "AtlasClear Holdings, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ATCX",
+    "name": "Atlas Critical Minerals Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "ATEC",
+    "name": "Alphatec Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ATEN",
+    "name": "A10 Networks, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ATER",
+    "name": "Aterian, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ATEX",
+    "name": "Anterix Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ATGL",
+    "name": "Alpha Technology Group Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ATHR",
+    "name": "Aether Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ATI",
+    "name": "ATI Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ATII",
+    "name": "Archimedes Tech SPAC Partners II Co. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ATKR",
+    "name": "Atkore Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ATLC",
+    "name": "Atlanticus Holdings Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "ATLN",
+    "name": "Atlantic International Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "ATLO",
+    "name": "Ames National Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "ATLX",
+    "name": "Atlas Lithium Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "ATMP",
+    "name": "iPath Select MLP ETN",
+    "sector": null
+  },
+  {
+    "symbol": "ATMU",
+    "name": "Atmus Filtration Technologies Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ATNI",
+    "name": "ATN International, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ATNM",
+    "name": "Actinium Pharmaceuticals, Inc. (Delaware) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ATO",
+    "name": "Atmos Energy Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ATOM",
+    "name": "Atomera Incorporated",
+    "sector": null
+  },
+  {
+    "symbol": "ATOS",
+    "name": "Atossa Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ATPC",
+    "name": "Agape ATP Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "ATR",
+    "name": "AptarGroup, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ATRA",
+    "name": "Atara Biotherapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ATRC",
+    "name": "AtriCure, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ATRO",
+    "name": "Astronics Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "ATS",
+    "name": "ATS Corporation Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ATXG",
+    "name": "Addentax Group Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "ATYR",
+    "name": "aTyr Pharma, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AU",
+    "name": "AngloGold Ashanti PLC Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "AUB",
+    "name": "Atlantic Union Bankshares Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AUBN",
+    "name": "Auburn National Bancorporation, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AUC",
+    "name": "ATIF Holdings Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "AUDC",
+    "name": "AudioCodes Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "AUGO",
+    "name": "Aura Minerals Inc. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "AUID",
+    "name": "authID Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AUNA",
+    "name": "Auna SA Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "AUPH",
+    "name": "Aurinia Pharmaceuticals Inc - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "AUR",
+    "name": "Aurora Innovation, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AURA",
+    "name": "Aura Biosciences, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AURE",
+    "name": "Aurelion Inc. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "AUST",
+    "name": "Austin Gold Corp. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "AUUD",
+    "name": "Auddia Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AVA",
+    "name": "Avista Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AVAH",
+    "name": "Aveanna Healthcare Holdings Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AVAT",
+    "name": "Avalanche Treasury Corporation - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AVAV",
+    "name": "AeroVironment, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AVBC",
+    "name": "Avidia Bancorp, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AVBH",
+    "name": "Avidbank Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AVBP",
+    "name": "ArriVent BioPharma, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AVD",
+    "name": "American Vanguard Corporation Common Stock ($0.10 Par Value)",
+    "sector": null
+  },
+  {
+    "symbol": "AVEX",
+    "name": "AEVEX Corp. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AVGO",
+    "name": "Broadcom Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AVIR",
+    "name": "Atea Pharmaceuticals, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AVK",
+    "name": "Advent Convertible and Income Fund",
+    "sector": null
+  },
+  {
+    "symbol": "AVLN",
+    "name": "Avalyn Pharma Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AVNS",
+    "name": "Avanos Medical, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AVNT",
+    "name": "Avient Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AVNW",
+    "name": "Aviat Networks, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AVO",
+    "name": "Mission Produce, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AVPT",
+    "name": "AvePoint, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AVR",
+    "name": "Anteris Technologies Global Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "AVT",
+    "name": "Avnet, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AVTR",
+    "name": "Avantor, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AVTX",
+    "name": "Avalo Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AVX",
+    "name": "Avax One Technology Ltd. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "AVXL",
+    "name": "Anavex Life Sciences Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "AVY",
+    "name": "Avery Dennison Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AWF",
+    "name": "Alliancebernstein Global High Income Fund",
+    "sector": null
+  },
+  {
+    "symbol": "AWI",
+    "name": "Armstrong World Industries Inc Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AWK",
+    "name": "American Water Works Company, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AWP",
+    "name": "abrdn Global Premier Properties Fund Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "AWR",
+    "name": "American States Water Company Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AWRE",
+    "name": "Aware, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AWX",
+    "name": "Avalon Holdings Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AX",
+    "name": "Axos Financial, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AXG",
+    "name": "Solowin Holdings - Class A Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "AXGN",
+    "name": "Axogen, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AXIL",
+    "name": "AXIL Brands, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AXIN",
+    "name": "Axiom Intelligence Acquisition Corp 1 - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "AXON",
+    "name": "Axon Enterprise, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AXP",
+    "name": "American Express Company Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AXR",
+    "name": "AMREP Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AXS",
+    "name": "Axis Capital Holdings Limited Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AXSM",
+    "name": "Axsome Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AXTA",
+    "name": "Axalta Coating Systems Ltd. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "AXTI",
+    "name": "AXT Inc",
+    "sector": null
+  },
+  {
+    "symbol": "AYA",
+    "name": "Aya Gold & Silver Inc. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "AYI",
+    "name": "Acuity Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AYTU",
+    "name": "Aytu BioPharma, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AZ",
+    "name": "A2Z Cust2Mate Solutions Corp. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "AZI",
+    "name": "Autozi Internet Technology (Global) Ltd. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "AZN",
+    "name": "AstraZeneca PLC Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "AZO",
+    "name": "AutoZone, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AZTA",
+    "name": "Azenta, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "AZTR",
+    "name": "Azitra Inc Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "AZZ",
+    "name": "AZZ Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "B",
+    "name": "Barrick Mining Corporation Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BA",
+    "name": "Boeing Company (The) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BAC",
+    "name": "Bank of America Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BACC",
+    "name": "Blue Acquisition Corp. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BAER",
+    "name": "Bridger Aerospace Group Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BAFN",
+    "name": "BayFirst Financial Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "BAH",
+    "name": "Booz Allen Hamilton Holding Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BAK",
+    "name": "Braskem SA ADR",
+    "sector": null
+  },
+  {
+    "symbol": "BALL",
+    "name": "Ball Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BALY",
+    "name": "Bally's Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BAM",
+    "name": "Brookfield Asset Management Inc Class A Limited Voting Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BANC",
+    "name": "Banc of California, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BAND",
+    "name": "Bandwidth Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BANF",
+    "name": "BancFirst Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "BANL",
+    "name": "CBL International Limited - Class B Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BANR",
+    "name": "Banner Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "BANX",
+    "name": "ArrowMark Financial Corp. - Closed End Fund",
+    "sector": null
+  },
+  {
+    "symbol": "BAOS",
+    "name": "Baosheng Media Group Holdings Limited - Ordinary shares",
+    "sector": null
+  },
+  {
+    "symbol": "BAP",
+    "name": "Credicorp Ltd. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BAR",
+    "name": "GraniteShares Gold Trust Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "BARK",
+    "name": "BARK, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BATL",
+    "name": "Battalion Oil Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BATRA",
+    "name": "Atlanta Braves Holdings, Inc. - Series A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BATRK",
+    "name": "Atlanta Braves Holdings, Inc. - Series C Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BAX",
+    "name": "Baxter International Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BAYA",
+    "name": "Bayview Acquisition Corp - Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "BB",
+    "name": "BlackBerry Limited Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BBAI",
+    "name": "BigBear.ai, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BBAR",
+    "name": "Banco BBVA Argentina S.A. ADS",
+    "sector": null
+  },
+  {
+    "symbol": "BBBY",
+    "name": "Bed Bath & Beyond, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BBCP",
+    "name": "Concrete Pumping Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BBCQ",
+    "name": "Bleichroeder Acquisition Corp. II - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BBDC",
+    "name": "Barings BDC, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BBGI",
+    "name": "Beasley Broadcast Group, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BBIO",
+    "name": "BridgeBio Pharma, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BBLG",
+    "name": "Bone Biologics Corp",
+    "sector": null
+  },
+  {
+    "symbol": "BBNX",
+    "name": "Beta Bionics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BBOT",
+    "name": "BridgeBio Oncology Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BBSI",
+    "name": "Barrett Business Services, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BBT",
+    "name": "Beacon Financial Corporation Common stock",
+    "sector": null
+  },
+  {
+    "symbol": "BBUC",
+    "name": "Brookfield Business Corporation Class A Subordinate Voting Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BBVA",
+    "name": "Banco Bilbao Vizcaya Argentaria S.A. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BBW",
+    "name": "Build-A-Bear Workshop, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BBWI",
+    "name": "Bath & Body Works, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BBY",
+    "name": "Best Buy Co., Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BC",
+    "name": "Brunswick Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BCAB",
+    "name": "BioAtla, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BCAL",
+    "name": "California BanCorp",
+    "sector": null
+  },
+  {
+    "symbol": "BCAR",
+    "name": "D. Boral ARC Acquisition I Corp. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BCAT",
+    "name": "BlackRock Capital Allocation Term Trust Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "BCAX",
+    "name": "Bicara Therapeutics Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BCBP",
+    "name": "BCB Bancorp, Inc. (NJ)",
+    "sector": null
+  },
+  {
+    "symbol": "BCC",
+    "name": "Boise Cascade, L.L.C. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BCDA",
+    "name": "BioCardia, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BCE",
+    "name": "BCE, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BCG",
+    "name": "Binah Capital Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BCH",
+    "name": "Banco De Chile ADS",
+    "sector": null
+  },
+  {
+    "symbol": "BCHT",
+    "name": "Birchtech Corp. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BCIC",
+    "name": "BCP Investment Corporation - Closed End Fund",
+    "sector": null
+  },
+  {
+    "symbol": "BCML",
+    "name": "BayCom Corp",
+    "sector": null
+  },
+  {
+    "symbol": "BCO",
+    "name": "Brinks Company (The) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BCPC",
+    "name": "Balchem Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "BCRX",
+    "name": "BioCryst Pharmaceuticals, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BCS",
+    "name": "Barclays PLC Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BCSF",
+    "name": "Bain Capital Specialty Finance, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BCSS",
+    "name": "Bain Capital GSS Investment Corp. Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BCTX",
+    "name": "BriaCell Therapeutics Corp. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BCV",
+    "name": "Bancroft Fund, Ltd.",
+    "sector": null
+  },
+  {
+    "symbol": "BCX",
+    "name": "BlackRock Resources Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "BDC",
+    "name": "Belden Inc Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BDCI",
+    "name": "BTC Development Corp. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BDCZ",
+    "name": "ETRACS MarketVector Business Development Companies Liquid Index ETN due April 26, 2041",
+    "sector": null
+  },
+  {
+    "symbol": "BDJ",
+    "name": "Blackrock Enhanced Equity Dividend Trust",
+    "sector": null
+  },
+  {
+    "symbol": "BDL",
+    "name": "Flanigan's Enterprises, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BDMD",
+    "name": "Baird Medical Investment Holdings Ltd - Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "BDN",
+    "name": "Brandywine Realty Trust Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BDSX",
+    "name": "Biodesix, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BDTX",
+    "name": "Black Diamond Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BDX",
+    "name": "Becton, Dickinson and Company Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BE",
+    "name": "Bloom Energy Corporation Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BEAG",
+    "name": "Bold Eagle Acquisition Corp. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BEAM",
+    "name": "Beam Therapeutics Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BEAT",
+    "name": "Heartbeam, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BEBE",
+    "name": "TGE Value Creative Solutions Corp Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BEEM",
+    "name": "Beam Global",
+    "sector": null
+  },
+  {
+    "symbol": "BEEP",
+    "name": "Mobile Infrastructure Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "BELFA",
+    "name": "Bel Fuse Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BELFB",
+    "name": "Bel Fuse Inc. - Class B Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BEN",
+    "name": "Franklin Resources, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BENF",
+    "name": "Beneficient - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BEPC",
+    "name": "Brookfield Renewable Corporation Brookfield Renewable Corporation Class A Subordinate Voting Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BESS",
+    "name": "Bimergen Energy Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BETA",
+    "name": "Beta Technologies, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BETR",
+    "name": "Better Home & Finance Holding Company - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BF.A",
+    "name": "Brown Forman Inc Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BF.B",
+    "name": "Brown Forman Inc Class B Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BFC",
+    "name": "Bank First Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "BFH",
+    "name": "Bread Financial Holdings, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BFLY",
+    "name": "Butterfly Network, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BFRG",
+    "name": "Bullfrog AI Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BFRI",
+    "name": "Biofrontera Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BFS",
+    "name": "Saul Centers, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BFST",
+    "name": "Business First Bancshares, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BG",
+    "name": "Bunge Limited Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BGB",
+    "name": "Blackstone Strategic Credit 2027 Term Fund Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "BGC",
+    "name": "BGC Group, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BGDE",
+    "name": "Big Digital Energy, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BGH",
+    "name": "Barings Global Short Duration High Yield Fund Common Shares of Beneficial Interests",
+    "sector": null
+  },
+  {
+    "symbol": "BGI",
+    "name": "Birks Group Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BGIN",
+    "name": "Bgin Blockchain Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BGL",
+    "name": "Blue Gold Limited - Class A ordinary shares",
+    "sector": null
+  },
+  {
+    "symbol": "BGLC",
+    "name": "BioNexus Gene Lab Corp",
+    "sector": null
+  },
+  {
+    "symbol": "BGM",
+    "name": "BGM Group Ltd. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BGMS",
+    "name": "Bio Green Med Solution, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BGR",
+    "name": "BlackRock Energy and Resources Trust",
+    "sector": null
+  },
+  {
+    "symbol": "BGS",
+    "name": "B&G Foods, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BGSF",
+    "name": "BGSF, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BGSI",
+    "name": "Boyd Group Services Inc. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BGT",
+    "name": "BlackRock Floating Rate Income Trust",
+    "sector": null
+  },
+  {
+    "symbol": "BGX",
+    "name": "Blackstone Long Short Credit Income Fund Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BGY",
+    "name": "Blackrock Enhanced International Dividend Trust",
+    "sector": null
+  },
+  {
+    "symbol": "BH",
+    "name": "Biglari Holdings Inc. Class B Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BH.A",
+    "name": "Biglari Holdings Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BHAV",
+    "name": "BHAV Acquisition Corp - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BHB",
+    "name": "Bar Harbor Bankshares, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BHC",
+    "name": "Bausch Health Companies Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BHE",
+    "name": "Benchmark Electronics, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BHM",
+    "name": "Bluerock Homes Trust, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BHR",
+    "name": "Braemar Hotels & Resorts Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BHRB",
+    "name": "Burke & Herbert Financial Services Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "BHST",
+    "name": "BioHarvest Sciences Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BHVN",
+    "name": "Biohaven Ltd. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BIAF",
+    "name": "bioAffinity Technologies, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BIIB",
+    "name": "Biogen Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BIII",
+    "name": "Black Spade Acquisition III Co Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BILL",
+    "name": "BILL Holdings, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BIO",
+    "name": "Bio-Rad Laboratories, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BIO.B",
+    "name": "Bio-Rad Laboratories, Inc. Class B Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BIOA",
+    "name": "BioAge Labs, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BIOX",
+    "name": "Bioceres Crop Solutions Corp. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BIPC",
+    "name": "Brookfield Infrastructure Corporation Brookfield Infrastructure Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "BIRD",
+    "name": "Allbirds, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BIRK",
+    "name": "Birkenstock Holding plc Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BIT",
+    "name": "BlackRock Multi-Sector Income Trust Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "BIVI",
+    "name": "BioVie Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BIXI",
+    "name": "Bitcoin Infrastructure Acquisition Corp Ltd. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BIYA",
+    "name": "Baiya International Group Inc. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BJ",
+    "name": "BJ's Wholesale Club Holdings, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BJDX",
+    "name": "Bluejay Diagnostics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BJRI",
+    "name": "BJ's Restaurants, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BKD",
+    "name": "Brookdale Senior Living Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BKE",
+    "name": "Buckle, Inc. (The) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BKH",
+    "name": "Black Hills Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BKHA",
+    "name": "Black Hawk Acquisition Corporation - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BKKT",
+    "name": "Bakkt, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BKNG",
+    "name": "Booking Holdings Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BKR",
+    "name": "Baker Hughes Company",
+    "sector": null
+  },
+  {
+    "symbol": "BKSY",
+    "name": "BlackSky Technology Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BKT",
+    "name": "BlackRock Income Trust Inc. (The)",
+    "sector": null
+  },
+  {
+    "symbol": "BKTI",
+    "name": "BK Technologies Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BKV",
+    "name": "BKV Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BL",
+    "name": "BlackLine, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BLBD",
+    "name": "Blue Bird Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "BLCO",
+    "name": "Bausch + Lomb Corporation Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BLD",
+    "name": "TopBuild Corp. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BLDP",
+    "name": "Ballard Power Systems, Inc. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BLDR",
+    "name": "Builders FirstSource, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BLFS",
+    "name": "BioLife Solutions, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BLIN",
+    "name": "Bridgeline Digital, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BLIV",
+    "name": "BeLive Holdings - ordinary shares",
+    "sector": null
+  },
+  {
+    "symbol": "BLK",
+    "name": "BlackRock, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BLKB",
+    "name": "Blackbaud, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BLLN",
+    "name": "BillionToOne, Inc. - Class A common stock",
+    "sector": null
+  },
+  {
+    "symbol": "BLMN",
+    "name": "Bloomin' Brands, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BLND",
+    "name": "Blend Labs, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BLNE",
+    "name": "Beeline Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BLNK",
+    "name": "Blink Charging Co.",
+    "sector": null
+  },
+  {
+    "symbol": "BLRK",
+    "name": "Bluerock Acquisition Corp. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BLSH",
+    "name": "Bullish Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BLUW",
+    "name": "Blue Water Acquisition Corp. III - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BLW",
+    "name": "Blackrock Limited Duration Income Trust",
+    "sector": null
+  },
+  {
+    "symbol": "BLX",
+    "name": "Banco Latinoamericano de Comercio Exterior, S.A.",
+    "sector": null
+  },
+  {
+    "symbol": "BLZE",
+    "name": "Backblaze, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BLZR",
+    "name": "Trailblazer Acquisition Corp. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BMA",
+    "name": "Banco Macro S.A. ADR (representing Ten Class B Common Shares)",
+    "sector": null
+  },
+  {
+    "symbol": "BMBL",
+    "name": "Bumble Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BME",
+    "name": "Blackrock Health Sciences Trust",
+    "sector": null
+  },
+  {
+    "symbol": "BMEA",
+    "name": "Biomea Fusion, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BMEZ",
+    "name": "BlackRock Health Sciences Term Trust Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "BMGL",
+    "name": "Basel Medical Group Ltd - ordinary shares",
+    "sector": null
+  },
+  {
+    "symbol": "BMHL",
+    "name": "Bluemount Holdings Limited - Class B Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BMI",
+    "name": "Badger Meter, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BMM",
+    "name": "Blue Moon Metals Inc. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BMN",
+    "name": "BlackRock 2037 Municipal Target Term Trust Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "BMNR",
+    "name": "BitMine Immersion Technologies, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BMO",
+    "name": "Bank Of Montreal Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BMR",
+    "name": "Beamr Imaging Ltd. - Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "BMRA",
+    "name": "Biomerica, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BMRC",
+    "name": "Bank of Marin Bancorp",
+    "sector": null
+  },
+  {
+    "symbol": "BMRN",
+    "name": "BioMarin Pharmaceutical Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BMY",
+    "name": "Bristol-Myers Squibb Company Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BN",
+    "name": "Brookfield Corporation Class A Limited Voting Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BNAI",
+    "name": "Brand Engagement Network Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BNBX",
+    "name": "BNB Plus Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "BNC",
+    "name": "CEA Industries Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BNED",
+    "name": "Barnes & Noble Education, Inc Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BNGO",
+    "name": "Bionano Genomics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BNKK",
+    "name": "Bonk, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BNL",
+    "name": "Broadstone Net Lease, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BNRG",
+    "name": "Brenmiller Energy Ltd - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BNS",
+    "name": "Bank Nova Scotia Halifax Pfd 3 Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BNT",
+    "name": "Brookfield Wealth Solutions Ltd. Class A Exchangeable Limited Voting Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BNTC",
+    "name": "Benitec Biopharma Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BNY",
+    "name": "The Bank of New York Mellon Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BNZI",
+    "name": "Banzai International, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BOBS",
+    "name": "Bob's Discount Furniture, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BOC",
+    "name": "Boston Omaha Corporation Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BODI",
+    "name": "The Beachbody Company, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BOE",
+    "name": "Blackrock Enhanced Global Dividend Trust Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "BOF",
+    "name": "BranchOut Food Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BOH",
+    "name": "Bank of Hawaii Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BOKF",
+    "name": "BOK Financial Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "BOLD",
+    "name": "Boundless Bio, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BOLT",
+    "name": "Bolt Biotherapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BON",
+    "name": "Bon Natural Life Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BOOM",
+    "name": "DMC Global Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BOOT",
+    "name": "Boot Barn Holdings, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BORR",
+    "name": "Borr Drilling Limited Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BOSC",
+    "name": "B.O.S. Better Online Solutions - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BOT",
+    "name": "RoboStrategy, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BOTJ",
+    "name": "Bank of the James Financial Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BOW",
+    "name": "Bowhead Specialty Holdings Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BOX",
+    "name": "Box, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BOXL",
+    "name": "Boxlight Corporation - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BP",
+    "name": "BP p.l.c. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BPAC",
+    "name": "Blueport Acquisition Ltd - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BPOP",
+    "name": "Popular, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BPRE",
+    "name": "Bluerock Private Real Estate Fund Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "BPRN",
+    "name": "Princeton Bancorp, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BQ",
+    "name": "Boqii Holding Limited Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BR",
+    "name": "Broadridge Financial Solutions, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BRAG",
+    "name": "Bragg Gaming Group Inc. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BRAI",
+    "name": "Braiin Limited",
+    "sector": null
+  },
+  {
+    "symbol": "BRBI",
+    "name": "BRBI BR Partners S.A. - ADSs",
+    "sector": null
+  },
+  {
+    "symbol": "BRBR",
+    "name": "BellRing Brands, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BRBS",
+    "name": "Blue Ridge Bankshares, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BRC",
+    "name": "Brady Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BRCB",
+    "name": "Black Rock Coffee Bar, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BRCC",
+    "name": "BRC Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BREZ",
+    "name": "Breeze Acquisition Corp. II - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BRFH",
+    "name": "Barfresh Food Group Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BRIA",
+    "name": "BrilliA Inc Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BRID",
+    "name": "Bridgford Foods Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "BRK.A",
+    "name": "Berkshire Hathaway Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BRK.B",
+    "name": "Berkshire Hathaway Inc. New Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BRKR",
+    "name": "Bruker Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "BRLS",
+    "name": "Borealis Foods Inc. - Class A Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BRLT",
+    "name": "Brilliant Earth Group, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BRN",
+    "name": "Barnwell Industries, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BRO",
+    "name": "Brown & Brown, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BROS",
+    "name": "Dutch Bros Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BRR",
+    "name": "ProCap Financial, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BRT",
+    "name": "BRT Apartments Corp. (MD) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BRTX",
+    "name": "BioRestorative Therapies, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BRUN",
+    "name": "Boost Run Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BRX",
+    "name": "Brixmor Property Group Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BRZE",
+    "name": "Braze, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BSAA",
+    "name": "BEST SPAC I Acquisition Corp. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BSAC",
+    "name": "Banco Santander - Chile ADS",
+    "sector": null
+  },
+  {
+    "symbol": "BSBK",
+    "name": "Bogota Financial Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "BSET",
+    "name": "Bassett Furniture Industries, Incorporated",
+    "sector": null
+  },
+  {
+    "symbol": "BSIN",
+    "name": "Big Sky Industrial Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BSL",
+    "name": "Blackstone Senior Floating Rate 2027 Term Fund Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "BSRR",
+    "name": "Sierra Bancorp",
+    "sector": null
+  },
+  {
+    "symbol": "BST",
+    "name": "BlackRock Science and Technology Trust Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "BSTZ",
+    "name": "BlackRock Science and Technology Term Trust Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "BSVN",
+    "name": "Bank7 Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "BSX",
+    "name": "Boston Scientific Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BSY",
+    "name": "Bentley Systems, Incorporated - Class B Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BTAI",
+    "name": "BioXcel Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BTBD",
+    "name": "BT Brands, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BTBT",
+    "name": "Bit Digital, Inc. - Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "BTCS",
+    "name": "BTCS Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BTCT",
+    "name": "BTC Digital Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BTDR",
+    "name": "Bitdeer Technologies Group - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BTE",
+    "name": "Baytex Energy Corp Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BTG",
+    "name": "B2Gold Corp Common shares (Canada)",
+    "sector": null
+  },
+  {
+    "symbol": "BTGO",
+    "name": "BitGo Holdings, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BTI",
+    "name": "British American Tobacco Industries, p.l.c. Common Stock ADR",
+    "sector": null
+  },
+  {
+    "symbol": "BTMD",
+    "name": "Biote Corp. - Class A common stock",
+    "sector": null
+  },
+  {
+    "symbol": "BTOC",
+    "name": "Armlogi Holding Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "BTOG",
+    "name": "Bit Origin Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BTQ",
+    "name": "BTQ Technologies Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "BTT",
+    "name": "BlackRock Municipal 2030 Target Term Trust",
+    "sector": null
+  },
+  {
+    "symbol": "BTTC",
+    "name": "Black Titan Corp - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BTU",
+    "name": "Peabody Energy Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BTX",
+    "name": "BlackRock Technology and Private Equity Term Trust Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "BTZ",
+    "name": "BlackRock Credit Allocation Income Trust",
+    "sector": null
+  },
+  {
+    "symbol": "BUD",
+    "name": "Anheuser-Busch Inbev SA Sponsored ADR (Belgium)",
+    "sector": null
+  },
+  {
+    "symbol": "BUDA",
+    "name": "Buda Juice, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BULL",
+    "name": "Webull Corporation - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BUR",
+    "name": "Burford Capital Limited Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BURL",
+    "name": "Burlington Stores, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BURU",
+    "name": "Nuburu, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BUSE",
+    "name": "First Busey Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "BUUU",
+    "name": "BUUU Group Limited - Class A Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "BVC",
+    "name": "BitVentures Limited - Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "BVFL",
+    "name": "BV Financial, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BVN",
+    "name": "Buenaventura Mining Company Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BVS",
+    "name": "Bioventus Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BW",
+    "name": "Babcock & Wilcox Enterprises, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BWA",
+    "name": "BorgWarner Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BWB",
+    "name": "Bridgewater Bancshares, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BWEN",
+    "name": "Broadwind, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BWFG",
+    "name": "Bankwell Financial Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BWIN",
+    "name": "The Baldwin Insurance Group, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BWIV",
+    "name": "Blue Water Acquisition Corp. IV Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BWLP",
+    "name": "BW LPG Limited Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BWMN",
+    "name": "Bowman Consulting Group Ltd.",
+    "sector": null
+  },
+  {
+    "symbol": "BWMX",
+    "name": "Betterware de Mexico, S.A.P.I. de C.V. Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BWXT",
+    "name": "BWX Technologies, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BX",
+    "name": "Blackstone Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BXC",
+    "name": "Bluelinx Holdings Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BXDC",
+    "name": "Blackstone Digital Infrastructure Trust Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BXMT",
+    "name": "Blackstone Mortgage Trust, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BXP",
+    "name": "BXP, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BXSL",
+    "name": "Blackstone Secured Lending Fund Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "BY",
+    "name": "Byline Bancorp, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BYAH",
+    "name": "Park Ha Biological Technology Co., Ltd. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BYD",
+    "name": "Boyd Gaming Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BYFC",
+    "name": "Broadway Financial Corporation - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BYND",
+    "name": "Beyond Meat, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BYRN",
+    "name": "Byrna Technologies, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BYSI",
+    "name": "BeyondSpring, Inc. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BZ",
+    "name": "KANZHUN LIMITED - American Depository Shares",
+    "sector": null
+  },
+  {
+    "symbol": "BZAI",
+    "name": "Blaize Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "BZFD",
+    "name": "BuzzFeed, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "BZH",
+    "name": "Beazer Homes USA, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "C",
+    "name": "Citigroup, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CAAP",
+    "name": "Corporacion America Airports SA Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CAAS",
+    "name": "China Automotive Systems, Inc. - Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "CABA",
+    "name": "Cabaletta Bio, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CABO",
+    "name": "Cable One, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CABR",
+    "name": "Caring Brands, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CAC",
+    "name": "Camden National Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "CACC",
+    "name": "Credit Acceptance Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "CACI",
+    "name": "CACI International, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CADL",
+    "name": "Candel Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CAE",
+    "name": "CAE Inc. Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CAF",
+    "name": "Morgan Stanley China A Share Fund Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CAG",
+    "name": "ConAgra Brands, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CAH",
+    "name": "Cardinal Health, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CAI",
+    "name": "Caris Life Sciences, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CAKE",
+    "name": "The Cheesecake Factory Incorporated",
+    "sector": null
+  },
+  {
+    "symbol": "CAL",
+    "name": "Caleres, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CALC",
+    "name": "CalciMedica, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CALM",
+    "name": "Cal-Maine Foods, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CALX",
+    "name": "Calix, Inc Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CALY",
+    "name": "Callaway Golf Company Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CAMP",
+    "name": "CAMP4 Therapeutics Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "CAMT",
+    "name": "Camtek Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CANG",
+    "name": "Cango Inc. Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CAPN",
+    "name": "Cayson Acquisition Corp - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CAPR",
+    "name": "Capricor Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CAPS",
+    "name": "Capstone Holding Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "CAQ",
+    "name": "Cambridge Acquisition Corp. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CAR",
+    "name": "Avis Budget Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CARE",
+    "name": "Carter Bankshares, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CARG",
+    "name": "CarGurus, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CARL",
+    "name": "Carlsmed, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CARR",
+    "name": "Carrier Global Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CARS",
+    "name": "Cars.com Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CART",
+    "name": "Maplebear Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CASH",
+    "name": "Pathward Financial, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CASS",
+    "name": "Cass Information Systems, Inc",
+    "sector": null
+  },
+  {
+    "symbol": "CAST",
+    "name": "FreeCast, Inc. - Class A common stock",
+    "sector": null
+  },
+  {
+    "symbol": "CASY",
+    "name": "Caseys General Stores, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CAT",
+    "name": "Caterpillar, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CATO",
+    "name": "Cato Corporation (The) Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CATX",
+    "name": "Perspective Therapeutics, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CATY",
+    "name": "Cathay General Bancorp",
+    "sector": null
+  },
+  {
+    "symbol": "CAVA",
+    "name": "CAVA Group, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CB",
+    "name": "Chubb Limited Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CBAN",
+    "name": "Colony Bankcorp, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CBAT",
+    "name": "CBAK Energy Technology, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CBC",
+    "name": "Central Bancompany, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CBFV",
+    "name": "CB Financial Services, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CBIO",
+    "name": "Crescent Biopharma, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CBK",
+    "name": "Commercial Bancgroup, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CBL",
+    "name": "CBL & Associates Properties, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CBLL",
+    "name": "CeriBell, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CBNA",
+    "name": "Chain Bridge Bancorp, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CBNK",
+    "name": "Capital Bancorp, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CBOE",
+    "name": "Cboe Global Markets, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CBRE",
+    "name": "CBRE Group Inc Common Stock Class A",
+    "sector": null
+  },
+  {
+    "symbol": "CBRL",
+    "name": "Cracker Barrel Old Country Store, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CBRS",
+    "name": "Cerebras Systems Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CBSH",
+    "name": "Commerce Bancshares, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CBT",
+    "name": "Cabot Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CBUS",
+    "name": "Cibus, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CBZ",
+    "name": "CBIZ, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CC",
+    "name": "Chemours Company (The) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CCAP",
+    "name": "Crescent Capital BDC, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CCAQ",
+    "name": "Collective Acquisition Corp. - Class A ordinary shares",
+    "sector": null
+  },
+  {
+    "symbol": "CCB",
+    "name": "Coastal Financial Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "CCBG",
+    "name": "Capital City Bank Group",
+    "sector": null
+  },
+  {
+    "symbol": "CCC",
+    "name": "CCC Intelligent Solutions Holdings Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CCCC",
+    "name": "C4 Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CCD",
+    "name": "Calamos Dynamic Convertible & Income Fund - Closed End Fund",
+    "sector": null
+  },
+  {
+    "symbol": "CCEC",
+    "name": "Capital Clean Energy Carriers Corp. - Common Share",
+    "sector": null
+  },
+  {
+    "symbol": "CCEL",
+    "name": "Cryo-Cell International, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CCEP",
+    "name": "Coca-Cola Europacific Partners plc - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CCG",
+    "name": "Cheche Group Inc. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CCHH",
+    "name": "CCH Holdings Ltd - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CCI",
+    "name": "Crown Castle Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CCIF",
+    "name": "Carlyle Credit Income Fund Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "CCII",
+    "name": "Cohen Circle Acquisition Corp. II - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CCIX",
+    "name": "Churchill Capital Corp IX - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CCJ",
+    "name": "Cameco Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CCK",
+    "name": "Crown Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CCL",
+    "name": "Carnival Corporation Ltd. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CCLD",
+    "name": "CareCloud, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CCNE",
+    "name": "CNB Financial Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "CCO",
+    "name": "Clear Channel Outdoor Holdings, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CCOI",
+    "name": "Cogent Communications Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CCRN",
+    "name": "Cross Country Healthcare, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CCSI",
+    "name": "Consensus Cloud Solutions, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CCTG",
+    "name": "CCSC Technology International Holdings Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CCU",
+    "name": "Compania Cervecerias Unidas, S.A. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CCXI",
+    "name": "Churchill Capital Corp XI - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CCZ",
+    "name": "Comcast Holdings ZONES",
+    "sector": null
+  },
+  {
+    "symbol": "CD",
+    "name": "Chaince Digital Holdings Inc. - American Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CDE",
+    "name": "Coeur Mining, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CDIO",
+    "name": "Cardio Diagnostics Holdings Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CDLX",
+    "name": "Cardlytics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CDNA",
+    "name": "CareDx, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CDNL",
+    "name": "Cardinal Infrastructure Group Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CDNS",
+    "name": "Cadence Design Systems, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CDP",
+    "name": "COPT Defense Properties Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "CDRE",
+    "name": "Cadre Holdings, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CDRO",
+    "name": "Codere Online Luxembourg, S.A. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CDT",
+    "name": "CDT Equity Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CDTG",
+    "name": "CDT Environmental Technology Investment Holdings Limited - ordinary shares",
+    "sector": null
+  },
+  {
+    "symbol": "CDW",
+    "name": "CDW Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "CDXS",
+    "name": "Codexis, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CDZI",
+    "name": "Cadiz, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CE",
+    "name": "Celanese Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CECO",
+    "name": "CECO Environmental Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "CEE",
+    "name": "The Central and Eastern Europe Fund, Inc. (The) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CEG",
+    "name": "Constellation Energy Corporation - Common Stock When-Issued",
+    "sector": null
+  },
+  {
+    "symbol": "CELC",
+    "name": "Celcuity Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CELH",
+    "name": "Celsius Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CELU",
+    "name": "Celularity Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CELZ",
+    "name": "Creative Medical Technology Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CENN",
+    "name": "Cenntro Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CENT",
+    "name": "Central Garden & Pet Company",
+    "sector": null
+  },
+  {
+    "symbol": "CENTA",
+    "name": "Central Garden & Pet Company - Class A Common Stock Nonvoting",
+    "sector": null
+  },
+  {
+    "symbol": "CENX",
+    "name": "Century Aluminum Company",
+    "sector": null
+  },
+  {
+    "symbol": "CEPF",
+    "name": "Cantor Equity Partners IV, Inc. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CEPO",
+    "name": "Cantor Equity Partners I, Inc. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CEPS",
+    "name": "Cantor Equity Partners VI, Inc. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CEPT",
+    "name": "Cantor Equity Partners II, Inc. - Class A ordinary share",
+    "sector": null
+  },
+  {
+    "symbol": "CEPV",
+    "name": "Cantor Equity Partners V, Inc. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CERS",
+    "name": "Cerus Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "CERT",
+    "name": "Certara, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CET",
+    "name": "Central Securities Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CETX",
+    "name": "Cemtrex Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CETY",
+    "name": "Clean Energy Technologies, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CEV",
+    "name": "Eaton Vance California Municipal Income Trust Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "CEVA",
+    "name": "CEVA, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CF",
+    "name": "CF Industries Holdings, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CFBK",
+    "name": "CF Bankshares Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CFFI",
+    "name": "C&F Financial Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "CFFN",
+    "name": "Capitol Federal Financial, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CFG",
+    "name": "Citizens Financial Group, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CFND",
+    "name": "C1 Fund Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CFR",
+    "name": "Cullen/Frost Bankers, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CG",
+    "name": "The Carlyle Group Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CGAU",
+    "name": "Centerra Gold Inc. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CGBD",
+    "name": "Carlyle Secured Lending, Inc. - Closed End Fund",
+    "sector": null
+  },
+  {
+    "symbol": "CGC",
+    "name": "Canopy Growth Corporation - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CGEM",
+    "name": "Cullinan Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CGEN",
+    "name": "Compugen Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CGNT",
+    "name": "Cognyte Software Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CGNX",
+    "name": "Cognex Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "CGO",
+    "name": "Calamos Global Total Return Fund - Closed End Fund",
+    "sector": null
+  },
+  {
+    "symbol": "CGON",
+    "name": "CG Oncology, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CGTL",
+    "name": "Creative Global Technology Holdings Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CGTX",
+    "name": "Cognition Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CHAI",
+    "name": "Core AI Holdings, Inc. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CHAR",
+    "name": "Charlton Aria Acquisition Corporation - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CHCI",
+    "name": "Comstock Holding Companies, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CHCO",
+    "name": "City Holding Company",
+    "sector": null
+  },
+  {
+    "symbol": "CHD",
+    "name": "Church & Dwight Company, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CHDN",
+    "name": "Churchill Downs, Incorporated",
+    "sector": null
+  },
+  {
+    "symbol": "CHE",
+    "name": "Chemed Corp",
+    "sector": null
+  },
+  {
+    "symbol": "CHEC",
+    "name": "Chenghe Acquisition III Co. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CHEF",
+    "name": "The Chefs' Warehouse, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CHGG",
+    "name": "Chegg, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CHH",
+    "name": "Choice Hotels International, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CHKP",
+    "name": "Check Point Software Technologies Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CHMG",
+    "name": "Chemung Financial Corp",
+    "sector": null
+  },
+  {
+    "symbol": "CHMI",
+    "name": "Cherry Hill Mortgage Investment Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CHNR",
+    "name": "China Natural Resources, Inc. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CHOW",
+    "name": "ChowChow Cloud International Holdings Limited Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CHPG",
+    "name": "ChampionsGate Acquisition Corporation - Class A Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "CHPT",
+    "name": "ChargePoint Holdings, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CHR",
+    "name": "Cheer Holding, Inc. - Class A Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "CHRD",
+    "name": "Chord Energy Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "CHRN",
+    "name": "ChronoScale Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "CHRS",
+    "name": "Coherus Oncology, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CHRW",
+    "name": "C.H. Robinson Worldwide, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CHSN",
+    "name": "Chanson International Holding - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CHT",
+    "name": "Chunghwa Telecom Co., Ltd.",
+    "sector": null
+  },
+  {
+    "symbol": "CHTR",
+    "name": "Charter Communications, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CHW",
+    "name": "Calamos Global Dynamic Income Fund - Closed End Fund",
+    "sector": null
+  },
+  {
+    "symbol": "CHWY",
+    "name": "Chewy, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CHY",
+    "name": "Calamos Convertible and High Income Fund - Closed End Fund",
+    "sector": null
+  },
+  {
+    "symbol": "CHYM",
+    "name": "Chime Financial, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CI",
+    "name": "The Cigna Group Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CIA",
+    "name": "Citizens, Inc. Class A Common Stock ($1.00 Par)",
+    "sector": null
+  },
+  {
+    "symbol": "CIEN",
+    "name": "Ciena Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CIF",
+    "name": "MFS Intermediate High Income Fund Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CIFR",
+    "name": "Cipher Digital Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CIGI",
+    "name": "Colliers International Group Inc. - Subordinate Voting Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CII",
+    "name": "BlackRock Enhanced Large Cap Core Fund, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CIIT",
+    "name": "Tianci International, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CIK",
+    "name": "Credit Suisse Asset Management Income Fund, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CIM",
+    "name": "Chimera Investment Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CINF",
+    "name": "Cincinnati Financial Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "CING",
+    "name": "Cingulate Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CINT",
+    "name": "CI&T Inc Class A Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CION",
+    "name": "CION Investment Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CISO",
+    "name": "CISO Global, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CISS",
+    "name": "C3is Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CITR",
+    "name": "CitroTech Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CIVB",
+    "name": "Civista Bancshares, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CIX",
+    "name": "CompX International Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CJMB",
+    "name": "Callan JMB Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CKX",
+    "name": "CKX Lands, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CL",
+    "name": "Colgate-Palmolive Company Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CLAR",
+    "name": "Clarus Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "CLB",
+    "name": "Core Laboratories Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CLBK",
+    "name": "Columbia Financial, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CLBR",
+    "name": "Colombier Acquisition Corp. III Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CLBT",
+    "name": "Cellebrite DI Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CLDI",
+    "name": "Calidi Biotherapeutics, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CLDT",
+    "name": "Chatham Lodging Trust (REIT) Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "CLDX",
+    "name": "Celldex Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CLF",
+    "name": "Cleveland-Cliffs Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CLFD",
+    "name": "Clearfield, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CLGN",
+    "name": "CollPlant Biotechnologies Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CLH",
+    "name": "Clean Harbors, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CLIK",
+    "name": "Click Holdings Limited - Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "CLIR",
+    "name": "ClearSign Technologies Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "CLM",
+    "name": "Cornerstone Strategic Investment Fund, Inc. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CLMB",
+    "name": "Climb Global Solutions, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CLMT",
+    "name": "Calumet, Inc",
+    "sector": null
+  },
+  {
+    "symbol": "CLNE",
+    "name": "Clean Energy Fuels Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "CLNN",
+    "name": "Clene Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CLOV",
+    "name": "Clover Health Investments, Corp. - Class A Common stock",
+    "sector": null
+  },
+  {
+    "symbol": "CLPR",
+    "name": "Clipper Realty Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CLPS",
+    "name": "CLPS Incorporation",
+    "sector": null
+  },
+  {
+    "symbol": "CLPT",
+    "name": "ClearPoint Neuro Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CLRB",
+    "name": "Cellectar Biosciences, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CLRO",
+    "name": "ClearOne, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CLS",
+    "name": "Celestica, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CLSK",
+    "name": "CleanSpark, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CLST",
+    "name": "Catalyst Bancorp, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CLVT",
+    "name": "Clarivate Plc Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CLW",
+    "name": "Clearwater Paper Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CLWT",
+    "name": "Euro Tech Holdings Company Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CLX",
+    "name": "Clorox Company (The) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CLYM",
+    "name": "Climb Bio, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CM",
+    "name": "Canadian Imperial Bank of Commerce Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CMBT",
+    "name": "CMB.TECH NV Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CMC",
+    "name": "Commercial Metals Company Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CMCL",
+    "name": "Caledonia Mining Corporation Plc Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CMCO",
+    "name": "Columbus McKinnon Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "CMCSA",
+    "name": "Comcast Corporation - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CMCT",
+    "name": "Creative Media",
+    "sector": null
+  },
+  {
+    "symbol": "CMDB",
+    "name": "Costamare Bulkers Holdings Limited Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CME",
+    "name": "CME Group Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CMG",
+    "name": "Chipotle Mexican Grill, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CMI",
+    "name": "Cummins Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CMII",
+    "name": "Columbus Circle Capital Corp II - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CMND",
+    "name": "Clearmind Medicine Inc. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CMP",
+    "name": "Compass Minerals Intl Inc Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CMPR",
+    "name": "Cimpress plc - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CMPS",
+    "name": "COMPASS Pathways Plc - American Depository Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CMPX",
+    "name": "Compass Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CMRC",
+    "name": "Commerce.com, Inc. - Series 1 Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CMRE",
+    "name": "Costamare Inc. Common Stock $0.0001 par value",
+    "sector": null
+  },
+  {
+    "symbol": "CMS",
+    "name": "CMS Energy Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CMT",
+    "name": "Core Molding Technologies Inc Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CMTG",
+    "name": "Claros Mortgage Trust, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CMTL",
+    "name": "Comtech Telecommunications Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "CNA",
+    "name": "CNA Financial Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CNC",
+    "name": "Centene Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CNCK",
+    "name": "Coincheck Group N.V. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CNDT",
+    "name": "Conduent Incorporated",
+    "sector": null
+  },
+  {
+    "symbol": "CNET",
+    "name": "ZW Data Action Technologies Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CNEY",
+    "name": "CN Energy Group Inc. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CNH",
+    "name": "CNH Industrial N.V. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CNI",
+    "name": "Canadian National Railway Company Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CNK",
+    "name": "Cinemark Holdings Inc Cinemark Holdings, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CNL",
+    "name": "Collective Mining Ltd. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CNM",
+    "name": "Core & Main, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CNMD",
+    "name": "CONMED Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CNNE",
+    "name": "Cannae Holdings, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CNO",
+    "name": "CNO Financial Group, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CNOB",
+    "name": "ConnectOne Bancorp, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CNP",
+    "name": "CenterPoint Energy, Inc (Holding Co) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CNQ",
+    "name": "Canadian Natural Resources Limited Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CNR",
+    "name": "Core Natural Resources, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CNS",
+    "name": "Cohen & Steers Inc Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CNSP",
+    "name": "CNS Pharmaceuticals, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CNTB",
+    "name": "Connect Biopharma Holdings Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CNTN",
+    "name": "Canton Strategic Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CNTX",
+    "name": "Context Therapeutics Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CNTY",
+    "name": "Century Casinos, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CNVS",
+    "name": "Cineverse Corp. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CNX",
+    "name": "CNX Resources Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CNXC",
+    "name": "Concentrix Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "CNXN",
+    "name": "PC Connection, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CNXU",
+    "name": "Conexeu Sciences Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "COAG",
+    "name": "Hemab Therapeutics Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "COCH",
+    "name": "Envoy Medical, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "COCO",
+    "name": "The Vita Coco Company, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "COCP",
+    "name": "Cocrystal Pharma, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CODA",
+    "name": "Coda Octopus Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CODI",
+    "name": "D/B/A Compass Diversified Holdings Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "CODX",
+    "name": "Co-Diagnostics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "COF",
+    "name": "Capital One Financial Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "COFS",
+    "name": "ChoiceOne Financial Services, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "COGT",
+    "name": "Cogent Biosciences, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "COHN",
+    "name": "Cohen & Company Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "COHR",
+    "name": "Coherent Corp. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "COHU",
+    "name": "Cohu, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "COIN",
+    "name": "Coinbase Global, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "COKE",
+    "name": "Coca-Cola Consolidated, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "COLA",
+    "name": "Columbus Acquisition Corp - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "COLB",
+    "name": "Columbia Banking System, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "COLD",
+    "name": "Americold Realty Trust, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "COLL",
+    "name": "Collegium Pharmaceutical, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "COLM",
+    "name": "Columbia Sportswear Company",
+    "sector": null
+  },
+  {
+    "symbol": "COMP",
+    "name": "Compass, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CON",
+    "name": "Concentra Group Holdings Parent, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "COO",
+    "name": "The Cooper Companies, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "COOK",
+    "name": "Traeger, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "COOT",
+    "name": "Australian Oilseeds Holdings Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "COP",
+    "name": "ConocoPhillips Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "COPL",
+    "name": "Copley Acquisition Corp Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "COR",
+    "name": "Cencora, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CORT",
+    "name": "Corcept Therapeutics Incorporated",
+    "sector": null
+  },
+  {
+    "symbol": "CORZ",
+    "name": "Core Scientific, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "COSM",
+    "name": "Cosmos Health Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "COSO",
+    "name": "CoastalSouth Bancshares, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "COST",
+    "name": "Costco Wholesale Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "COTY",
+    "name": "Coty Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "COUR",
+    "name": "Coursera, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "COYA",
+    "name": "Coya Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CP",
+    "name": "Canadian Pacific Kansas City Limited Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CPA",
+    "name": "Copa Holdings, S.A. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CPAY",
+    "name": "Corpay, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CPB",
+    "name": "The Campbell's Company",
+    "sector": null
+  },
+  {
+    "symbol": "CPBI",
+    "name": "Central Plains Bancshares, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CPF",
+    "name": "Central Pacific Financial Corp New",
+    "sector": null
+  },
+  {
+    "symbol": "CPHC",
+    "name": "Canterbury Park Holding Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "CPHI",
+    "name": "China Pharma Holdings, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CPIX",
+    "name": "Cumberland Pharmaceuticals Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CPK",
+    "name": "Chesapeake Utilities Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CPNG",
+    "name": "Coupang, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CPOP",
+    "name": "Pop Culture Group Co., Ltd - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CPRI",
+    "name": "Capri Holdings Limited Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CPRT",
+    "name": "Copart, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CPRX",
+    "name": "Catalyst Pharmaceuticals, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CPS",
+    "name": "Cooper-Standard Holdings Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CPSH",
+    "name": "CPS Technologies Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "CPSS",
+    "name": "Consumer Portfolio Services, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CPT",
+    "name": "Camden Property Trust Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CPZ",
+    "name": "Calamos Long/Short Equity & Dynamic Income Trust - Closed End Fund",
+    "sector": null
+  },
+  {
+    "symbol": "CR",
+    "name": "Crane Company Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CRAC",
+    "name": "Crown Reserve Acquisition Corp. I - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CRAI",
+    "name": "CRA International,Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CRAN",
+    "name": "Crane Harbor Acquisition Corp. II - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CRAQ",
+    "name": "Cal Redwood Acquisition Corp. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CRBG",
+    "name": "Corebridge Financial Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CRBP",
+    "name": "Corbus Pharmaceuticals Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CRBU",
+    "name": "Caribou Biosciences, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CRC",
+    "name": "California Resources Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CRCL",
+    "name": "Circle Internet Group, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CRCT",
+    "name": "Cricut, Inc. - Class A common stock",
+    "sector": null
+  },
+  {
+    "symbol": "CRD.A",
+    "name": "Crawford & Company Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CRD.B",
+    "name": "Crawford & Company Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CRDF",
+    "name": "Cardiff Oncology, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CRDL",
+    "name": "Cardiol Therapeutics Inc. - Class A Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CRDO",
+    "name": "Credo Technology Group Holding Ltd - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CRE",
+    "name": "Cre8 Enterprise Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CREG",
+    "name": "Smart Powerr Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "CREX",
+    "name": "Creative Realities, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CRF",
+    "name": "Cornerstone Total Return Fund, Inc. (The) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CRGO",
+    "name": "Freightos Limited - Ordinary shares",
+    "sector": null
+  },
+  {
+    "symbol": "CRGY",
+    "name": "Crescent Energy Company Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CRH",
+    "name": "CRH PLC Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CRI",
+    "name": "Carter's, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CRIS",
+    "name": "Curis, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CRK",
+    "name": "Comstock Resources, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CRL",
+    "name": "Charles River Laboratories International, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CRM",
+    "name": "Salesforce, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CRMD",
+    "name": "CorMedix Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CRML",
+    "name": "Critical Metals Corp. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CRMT",
+    "name": "America's Car-Mart, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CRNC",
+    "name": "Cerence Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CRNT",
+    "name": "Ceragon Networks Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CRNX",
+    "name": "Crinetics Pharmaceuticals, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CRON",
+    "name": "Cronos Group Inc. - Common Share",
+    "sector": null
+  },
+  {
+    "symbol": "CROX",
+    "name": "Crocs, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CRS",
+    "name": "Carpenter Technology Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CRSP",
+    "name": "CRISPR Therapeutics AG - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CRSR",
+    "name": "Corsair Gaming, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CRT",
+    "name": "Cross Timbers Royalty Trust Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CRUS",
+    "name": "Cirrus Logic, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CRVL",
+    "name": "CorVel Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "CRVO",
+    "name": "CervoMed Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CRVS",
+    "name": "Corvus Pharmaceuticals, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CRWD",
+    "name": "CrowdStrike Holdings, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CRWS",
+    "name": "Crown Crafts, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CRWV",
+    "name": "CoreWeave, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CSAI",
+    "name": "Cloudastructure, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CSAN",
+    "name": "Cosan S.A. ADS",
+    "sector": null
+  },
+  {
+    "symbol": "CSBR",
+    "name": "Champions Oncology, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CSCO",
+    "name": "Cisco Systems, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CSGP",
+    "name": "CoStar Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CSHR",
+    "name": "CoinShares PLC - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CSIQ",
+    "name": "Canadian Solar Inc. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CSL",
+    "name": "Carlisle Companies Incorporated Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CSPI",
+    "name": "CSP Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CSQ",
+    "name": "Calamos Strategic Total Return Fund - Closed End Fund",
+    "sector": null
+  },
+  {
+    "symbol": "CSR",
+    "name": "D/B/A Centerspace Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CSTE",
+    "name": "Caesarstone Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CSTL",
+    "name": "Castle Biosciences, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CSTM",
+    "name": "Constellium SE Ordinary Shares (France)",
+    "sector": null
+  },
+  {
+    "symbol": "CSV",
+    "name": "Carriage Services, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CSW",
+    "name": "CSW Industrials, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CSWC",
+    "name": "Capital Southwest Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "CSX",
+    "name": "CSX Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "CTAA",
+    "name": "ClearThink 1 Acquisition Corp. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CTAS",
+    "name": "Cintas Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "CTEV",
+    "name": "Claritev Corporation Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CTGO",
+    "name": "Contango Silver & Gold Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CTKB",
+    "name": "Cytek Biosciences, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CTM",
+    "name": "Castellum, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CTMX",
+    "name": "CytomX Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CTNM",
+    "name": "Contineum Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CTNT",
+    "name": "Cheetah Net Supply Chain Service Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CTO",
+    "name": "CTO Realty Growth, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CTOR",
+    "name": "Citius Oncology, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CTOS",
+    "name": "Custom Truck One Source, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CTRE",
+    "name": "CareTrust REIT, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CTRI",
+    "name": "Centuri Holdings, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CTRM",
+    "name": "Castor Maritime Inc. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CTRN",
+    "name": "Citi Trends, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CTS",
+    "name": "CTS Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CTSH",
+    "name": "Cognizant Technology Solutions Corporation - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CTSO",
+    "name": "Cytosorbents Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "CTVA",
+    "name": "Corteva, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CTW",
+    "name": "CTW - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CTXR",
+    "name": "Citius Pharmaceuticals, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CUB",
+    "name": "Lionheart Holdings - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CUBE",
+    "name": "CubeSmart Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CUBI",
+    "name": "Customers Bancorp, Inc Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CUE",
+    "name": "Cue Biopharma, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CULP",
+    "name": "Culp, Inc. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CUPR",
+    "name": "Cuprina Holdings (Cayman) Limited - Class A Ordinary shares",
+    "sector": null
+  },
+  {
+    "symbol": "CURB",
+    "name": "Curbline Properties Corp. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CURI",
+    "name": "CuriosityStream Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CURR",
+    "name": "Currenc Group Inc. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CURV",
+    "name": "Torrid Holdings Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CURX",
+    "name": "Curanex Pharmaceuticals Inc",
+    "sector": null
+  },
+  {
+    "symbol": "CUZ",
+    "name": "Cousins Properties Incorporated Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CV",
+    "name": "CapsoVision, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CVBF",
+    "name": "CVB Financial Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "CVCO",
+    "name": "Cavco Industries, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CVE",
+    "name": "Cenovus Energy Inc Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CVEO",
+    "name": "Civeo Corporation (Canada) Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CVGI",
+    "name": "Commercial Vehicle Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CVI",
+    "name": "CVR Energy Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CVKD",
+    "name": "Cadrenal Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CVLG",
+    "name": "Covenant Logistics Group, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CVLT",
+    "name": "Commvault Systems, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CVM",
+    "name": "Cel-Sci Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CVNA",
+    "name": "Carvana Co. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CVR",
+    "name": "Chicago Rivet & Machine Co. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CVRX",
+    "name": "CVRx, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CVS",
+    "name": "CVS Health Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CVSA",
+    "name": "Covista Inc. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CVU",
+    "name": "CPI Aerostructures, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CVV",
+    "name": "CVD Equipment Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "CVX",
+    "name": "Chevron Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CWAN",
+    "name": "Clearwater Analytics Holdings, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CWCO",
+    "name": "Consolidated Water Co. Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CWD",
+    "name": "CaliberCos Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CWEN",
+    "name": "Clearway Energy, Inc. Class C Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CWH",
+    "name": "Camping World Holdings, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CWK",
+    "name": "Cushman & Wakefield Ltd. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "CWST",
+    "name": "Casella Waste Systems, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CWT",
+    "name": "California Water Service Group Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CX",
+    "name": "Cemex, S.A.B. de C.V. Sponsored ADR",
+    "sector": null
+  },
+  {
+    "symbol": "CXAI",
+    "name": "CXApp Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CXDO",
+    "name": "Crexendo, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CXM",
+    "name": "Sprinklr, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CXT",
+    "name": "Crane NXT, Co. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CXW",
+    "name": "CoreCivic, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CYAB",
+    "name": "Cyabra, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CYCN",
+    "name": "Cyclerion Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CYCU",
+    "name": "Cycurion, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CYD",
+    "name": "China Yuchai International Limited Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "CYN",
+    "name": "Cyngn Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CYPH",
+    "name": "Cypherpunk Technologies Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CYRX",
+    "name": "CryoPort, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CYTK",
+    "name": "Cytokinetics, Incorporated",
+    "sector": null
+  },
+  {
+    "symbol": "CZFS",
+    "name": "Citizens Financial Services, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "CZNC",
+    "name": "Citizens & Northern Corp",
+    "sector": null
+  },
+  {
+    "symbol": "CZR",
+    "name": "Caesars Entertainment, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "D",
+    "name": "Dominion Energy, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DAAQ",
+    "name": "Digital Asset Acquisition Corp. - Class A Ordinary shares",
+    "sector": null
+  },
+  {
+    "symbol": "DAC",
+    "name": "Danaos Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DAIC",
+    "name": "CID HoldCo, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "DAIO",
+    "name": "Data I/O Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "DAKT",
+    "name": "Daktronics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "DAL",
+    "name": "Delta Air Lines, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DAN",
+    "name": "Dana Incorporated Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DAR",
+    "name": "Darling Ingredients Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DARE",
+    "name": "Dare Bioscience, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "DASH",
+    "name": "DoorDash, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "DAVE",
+    "name": "Dave Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DB",
+    "name": "Deutsche Bank AG Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DBCA",
+    "name": "D. Boral Acquisition I Corp. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "DBD",
+    "name": "Diebold Nixdorf Incorporated Common stock",
+    "sector": null
+  },
+  {
+    "symbol": "DBGI",
+    "name": "Digital Brands Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "DBI",
+    "name": "Designer Brands Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DBL",
+    "name": "DoubleLine Opportunistic Credit Fund Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "DBRG",
+    "name": "DigitalBridge Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "DBX",
+    "name": "Dropbox, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DC",
+    "name": "Dakota Gold Corp. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DCBO",
+    "name": "Docebo Inc. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "DCGO",
+    "name": "DocGo Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "DCH",
+    "name": "Dauch Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DCI",
+    "name": "Donaldson Company, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DCO",
+    "name": "Ducommun Incorporated Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DCOM",
+    "name": "Dime Commercial Bancshares, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DCOY",
+    "name": "Decoy Therapeutics Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "DCTH",
+    "name": "Delcath Systems, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "DCX",
+    "name": "Digital Currency X Technology Inc. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "DD",
+    "name": "DuPont de Nemours, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DDC",
+    "name": "DDC Enterprise Limited Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "DDD",
+    "name": "3D Systems Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DDI",
+    "name": "DoubleDown Interactive Co., Ltd. - American Depository Shares",
+    "sector": null
+  },
+  {
+    "symbol": "DDOG",
+    "name": "Datadog, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DDS",
+    "name": "Dillard's, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DDT",
+    "name": "Dillard's Capital Trust I",
+    "sector": null
+  },
+  {
+    "symbol": "DE",
+    "name": "Deere & Company Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DEA",
+    "name": "Easterly Government Properties, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DEC",
+    "name": "Diversified Energy Company Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DECK",
+    "name": "Deckers Outdoor Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DEFT",
+    "name": "Defi Technologies, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "DEI",
+    "name": "Douglas Emmett, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DELL",
+    "name": "Dell Technologies Inc. Class C Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DEO",
+    "name": "Diageo plc Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DERM",
+    "name": "Journey Medical Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "DETX",
+    "name": "Liberty Defense Holdings, Ltd. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "DEVS",
+    "name": "DevvStream Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "DFDV",
+    "name": "DeFi Development Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "DFH",
+    "name": "Dream Finders Homes, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DFIN",
+    "name": "Donnelley Financial Solutions, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DFLI",
+    "name": "Dragonfly Energy Holdings Corp",
+    "sector": null
+  },
+  {
+    "symbol": "DFNS",
+    "name": "T3 Defense Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "DFSC",
+    "name": "DEFSEC Technologies Inc. - common stock, no R/S concurrent with offering",
+    "sector": null
+  },
+  {
+    "symbol": "DFTX",
+    "name": "Definium Therapeutics, Inc. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "DG",
+    "name": "Dollar General Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DGICA",
+    "name": "Donegal Group, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DGICB",
+    "name": "Donegal Group, Inc. - Class B Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DGII",
+    "name": "Digi International Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "DGNX",
+    "name": "Diginex Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "DGP",
+    "name": "DB Gold Double Long ETN due February 15, 2038",
+    "sector": null
+  },
+  {
+    "symbol": "DGX",
+    "name": "Quest Diagnostics Incorporated Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DGXX",
+    "name": "Digi Power X Inc. - Common Subordinate Voting Shares",
+    "sector": null
+  },
+  {
+    "symbol": "DGZ",
+    "name": "DB Gold Short ETN due February 15, 2038",
+    "sector": null
+  },
+  {
+    "symbol": "DH",
+    "name": "Definitive Healthcare Corp. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DHC",
+    "name": "Diversified Healthcare Trust - Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "DHF",
+    "name": "BNY Mellon High Yield Strategies Fund Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DHI",
+    "name": "D.R. Horton, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DHR",
+    "name": "Danaher Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DHT",
+    "name": "DHT Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "DHX",
+    "name": "DHI Group, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DHY",
+    "name": "Credit Suisse High Yield Credit Fund Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DIBS",
+    "name": "1stdibs.com, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "DIN",
+    "name": "Dine Brands Global, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DINO",
+    "name": "HF Sinclair Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DIOD",
+    "name": "Diodes Incorporated",
+    "sector": null
+  },
+  {
+    "symbol": "DIS",
+    "name": "Walt Disney Company (The) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DIT",
+    "name": "AMCON Distributing Company Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DJCO",
+    "name": "Daily Journal Corp. (S.C.)",
+    "sector": null
+  },
+  {
+    "symbol": "DJP",
+    "name": "iPath Bloomberg Commodity Index Total Return ETN",
+    "sector": null
+  },
+  {
+    "symbol": "DJT",
+    "name": "Trump Media & Technology Group Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "DK",
+    "name": "Delek US Holdings, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DKI",
+    "name": "DarkIris Inc. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "DKNG",
+    "name": "DraftKings Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DKS",
+    "name": "Dick's Sporting Goods Inc Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DLB",
+    "name": "Dolby Laboratories Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DLHC",
+    "name": "DLH Holdings Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "DLO",
+    "name": "DLocal Limited - Class A Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "DLPN",
+    "name": "Dolphin Entertainment, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "DLR",
+    "name": "Digital Realty Trust, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DLTH",
+    "name": "Duluth Holdings Inc. - Class B Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DLTR",
+    "name": "Dollar Tree, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "DLX",
+    "name": "Deluxe Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DLXY",
+    "name": "Delixy Holdings Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "DMA",
+    "name": "Destra Multi-Alternative Fund Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DMAA",
+    "name": "Drugs Made In America Acquisition Corp. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "DMAC",
+    "name": "DiaMedica Therapeutics Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "DMII",
+    "name": "Drugs Made In America Acquisition II Corp. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "DMRA",
+    "name": "Damora Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "DMRC",
+    "name": "Digimarc Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "DNA",
+    "name": "Ginkgo Bioworks Holdings, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DNLI",
+    "name": "Denali Therapeutics Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "DNMX",
+    "name": "Dynamix Corporation III - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "DNN",
+    "name": "Denison Mines Corp Ordinary Shares (Canada)",
+    "sector": null
+  },
+  {
+    "symbol": "DNOW",
+    "name": "DNOW Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DNP",
+    "name": "DNP Select Income Fund, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DNTH",
+    "name": "Dianthus Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "DNUT",
+    "name": "Krispy Kreme, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "DOC",
+    "name": "Healthpeak Properties, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DOCN",
+    "name": "DigitalOcean Holdings, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DOCS",
+    "name": "Doximity, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DOCU",
+    "name": "DocuSign, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "DOGZ",
+    "name": "Dogness (International) Corporation - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DOLE",
+    "name": "Dole plc Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "DOMH",
+    "name": "Dominari Holdings Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "DOMO",
+    "name": "Domo, Inc. - Class B Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DOO",
+    "name": "BRP Inc. - Common Subordinate Voting Shares",
+    "sector": null
+  },
+  {
+    "symbol": "DORM",
+    "name": "Dorman Products, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "DOUG",
+    "name": "Douglas Elliman Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DOV",
+    "name": "Dover Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DOW",
+    "name": "Dow Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DOX",
+    "name": "Amdocs Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "DPG",
+    "name": "Duff & Phelps Utility and Infrastructure Fund Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "DPRO",
+    "name": "Draganfly Inc. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "DPZ",
+    "name": "Domino's Pizza Inc",
+    "sector": null
+  },
+  {
+    "symbol": "DRCT",
+    "name": "Direct Digital Holdings, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DRDB",
+    "name": "Roman DBDR Acquisition Corp. II - Ordinary shares",
+    "sector": null
+  },
+  {
+    "symbol": "DRH",
+    "name": "Diamondrock Hospitality Company",
+    "sector": null
+  },
+  {
+    "symbol": "DRI",
+    "name": "Darden Restaurants, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DRIO",
+    "name": "DarioHealth Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "DRMA",
+    "name": "Dermata Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "DRS",
+    "name": "Leonardo DRS, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "DRTS",
+    "name": "Alpha Tau Medical Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "DRVN",
+    "name": "Driven Brands Holdings Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "DSAC",
+    "name": "Daedalus Special Acquisition Corp. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "DSGN",
+    "name": "Design Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "DSGR",
+    "name": "Distribution Solutions Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "DSGX",
+    "name": "The Descartes Systems Group Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "DSL",
+    "name": "DoubleLine Income Solutions Fund Common Shares of Beneficial Interests",
+    "sector": null
+  },
+  {
+    "symbol": "DSP",
+    "name": "Viant Technology Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "DSS",
+    "name": "DSS, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DSU",
+    "name": "Blackrock Debt Strategies Fund, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DSWL",
+    "name": "Deswell Industries, Inc. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "DSX",
+    "name": "Diana Shipping inc. common stock",
+    "sector": null
+  },
+  {
+    "symbol": "DSY",
+    "name": "Big Tree Cloud Holdings Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "DT",
+    "name": "Dynatrace, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DTCX",
+    "name": "Datacentrex, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "DTE",
+    "name": "DTE Energy Company Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DTF",
+    "name": "DTF Tax-Free Income 2028 Term Fund Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DTI",
+    "name": "Drilling Tools International Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "DTIL",
+    "name": "Precision BioSciences, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "DTM",
+    "name": "DT Midstream, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DTSQ",
+    "name": "DT Cloud Star Acquisition Corporation - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "DTSS",
+    "name": "Datasea Intelligent Technology Ltd. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "DTST",
+    "name": "Data Storage Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "DUK",
+    "name": "Duke Energy Corporation (Holding Company) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DUKR",
+    "name": "DUKE Robotics Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "DUO",
+    "name": "Fangdd Network Group Ltd. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "DUOL",
+    "name": "Duolingo, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DUOT",
+    "name": "Duos Technologies Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "DV",
+    "name": "DoubleVerify Holdings, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DVA",
+    "name": "DaVita Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DVLT",
+    "name": "Datavault AI Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "DVN",
+    "name": "Devon Energy Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DWSN",
+    "name": "Dawson Geophysical Company",
+    "sector": null
+  },
+  {
+    "symbol": "DWTX",
+    "name": "Dogwood Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "DX",
+    "name": "Dynex Capital, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DXC",
+    "name": "DXC Technology Company Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DXCM",
+    "name": "DexCom, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "DXLG",
+    "name": "Destination XL Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "DXPE",
+    "name": "DXP Enterprises, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "DXR",
+    "name": "Daxor Corporation - Closed End Fund",
+    "sector": null
+  },
+  {
+    "symbol": "DXST",
+    "name": "Decent Holding Inc. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "DXYZ",
+    "name": "Destiny Tech100 Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DY",
+    "name": "Dycom Industries, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "DYAI",
+    "name": "Dyadic International, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "DYN",
+    "name": "Dyne Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "DYNC",
+    "name": "Dynamix Corporation - Class A Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "DYOR",
+    "name": "Insight Digital Partners II - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "DZZ",
+    "name": "DB Gold Double Short ETN due February 15, 2038",
+    "sector": null
+  },
+  {
+    "symbol": "E",
+    "name": "ENI S.p.A. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EA",
+    "name": "Electronic Arts Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "EAF",
+    "name": "GrafTech International Ltd. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EARN",
+    "name": "Ellington Credit Company Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "EAT",
+    "name": "Brinker International, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EBAY",
+    "name": "eBay Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "EBC",
+    "name": "Eastern Bankshares, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "EBF",
+    "name": "Ennis, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EBMT",
+    "name": "Eagle Bancorp Montana, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "EBON",
+    "name": "Ebang International Holdings Inc. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "EBS",
+    "name": "Emergent BioSolutions Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ECAT",
+    "name": "BlackRock ESG Capital Allocation Term Trust Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "ECBK",
+    "name": "ECB Bancorp, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ECC",
+    "name": "Eagle Point Credit Company Common Share of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "ECF",
+    "name": "Ellsworth Growth and Income Fund Ltd.",
+    "sector": null
+  },
+  {
+    "symbol": "ECG",
+    "name": "Everus Construction Group, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ECL",
+    "name": "Ecolab Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ECO",
+    "name": "Okeanis Eco Tankers Corp. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ECOR",
+    "name": "electroCore, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ECPG",
+    "name": "Encore Capital Group Inc",
+    "sector": null
+  },
+  {
+    "symbol": "ECVT",
+    "name": "Ecovyst Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ECX",
+    "name": "ECARX Holdings Inc. - Class A Ordinary shares",
+    "sector": null
+  },
+  {
+    "symbol": "ED",
+    "name": "Consolidated Edison, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EDBL",
+    "name": "Edible Garden AG Incorporated",
+    "sector": null
+  },
+  {
+    "symbol": "EDD",
+    "name": "Morgan Stanley Emerging Markets Domestic Debt Fund, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EDF",
+    "name": "Virtus Stone Harbor Emerging Markets Income Fund Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "EDIT",
+    "name": "Editas Medicine, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "EDRY",
+    "name": "EuroDry Ltd. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "EDSA",
+    "name": "Edesa Biotech, Inc. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "EDTK",
+    "name": "Skillful Craftsman Education Technology Limited - Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "EDU",
+    "name": "New Oriental Education & Technology Group, Inc. Sponsored ADR representing 10 Ordinary Share (Cayman Islands)",
+    "sector": null
+  },
+  {
+    "symbol": "EDUC",
+    "name": "Educational Development Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "EE",
+    "name": "Excelerate Energy, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EEA",
+    "name": "The European Equity Fund, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EEFT",
+    "name": "Euronet Worldwide, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "EEIQ",
+    "name": "EpicQuest Education Group International Limited",
+    "sector": null
+  },
+  {
+    "symbol": "EEX",
+    "name": "Emerald Holding, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EFC",
+    "name": "Ellington Financial Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EFOI",
+    "name": "Energy Focus, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "EFOR",
+    "name": "Everforth, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EFR",
+    "name": "Eaton Vance Senior Floating-Rate Fund Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "EFSC",
+    "name": "Enterprise Financial Services Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "EFSI",
+    "name": "Eagle Financial Services Inc",
+    "sector": null
+  },
+  {
+    "symbol": "EFT",
+    "name": "Eaton Vance Floating Rate Income Trust Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "EFTY",
+    "name": "Etoiles Capital Group Co., Ltd. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "EFX",
+    "name": "Equifax, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EFXT",
+    "name": "Enerflex Ltd Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "EG",
+    "name": "Everest Group, Ltd. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EGAN",
+    "name": "eGain Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "EGBN",
+    "name": "Eagle Bancorp, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "EGG",
+    "name": "Enigmatig Limited Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "EGHA",
+    "name": "EGH Acquisition Corp. - Class A ordinary shares",
+    "sector": null
+  },
+  {
+    "symbol": "EGHT",
+    "name": "8x8 Inc",
+    "sector": null
+  },
+  {
+    "symbol": "EGO",
+    "name": "Eldorado Gold Corporation Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "EGP",
+    "name": "EastGroup Properties, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EGY",
+    "name": "VAALCO Energy, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EH",
+    "name": "EHang Holdings Limited - ADS",
+    "sector": null
+  },
+  {
+    "symbol": "EHC",
+    "name": "Encompass Health Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EHGO",
+    "name": "Eshallgo Inc. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "EHI",
+    "name": "Western Asset Global High Income Fund Inc Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EHLD",
+    "name": "Euroholdings Ltd.",
+    "sector": null
+  },
+  {
+    "symbol": "EHTH",
+    "name": "eHealth, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "EIC",
+    "name": "Eagle Point Income Company Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EIG",
+    "name": "Employers Holdings Inc Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EIKN",
+    "name": "Eikon Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "EIX",
+    "name": "Edison International Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EJH",
+    "name": "E-Home Household Service Holdings Limited - Ordinary shares",
+    "sector": null
+  },
+  {
+    "symbol": "EL",
+    "name": "Estee Lauder Companies, Inc. (The) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ELA",
+    "name": "Envela Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ELAB",
+    "name": "PMGC Holdings Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ELAN",
+    "name": "Elanco Animal Health Incorporated Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ELBM",
+    "name": "Electra Battery Materials Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "ELDN",
+    "name": "Eledon Pharmaceuticals, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ELE",
+    "name": "Elemental Royalty Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "ELF",
+    "name": "e.l.f. Beauty, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ELLO",
+    "name": "Ellomay Capital Ltd Ordinary Shares (Israel)",
+    "sector": null
+  },
+  {
+    "symbol": "ELMD",
+    "name": "Electromed, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ELMT",
+    "name": "The Elmet Group Co.",
+    "sector": null
+  },
+  {
+    "symbol": "ELOG",
+    "name": "Eastern International Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ELOX",
+    "name": "Eloxx Pharmaceuticals, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ELPW",
+    "name": "Elong Power Holding Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ELS",
+    "name": "Equity Lifestyle Properties, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ELSE",
+    "name": "Electro-Sensors, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ELTK",
+    "name": "Eltek Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ELTX",
+    "name": "Elicio Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ELUT",
+    "name": "Elutia, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ELV",
+    "name": "Elevance Health, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ELVA",
+    "name": "Electrovaya Inc. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ELVN",
+    "name": "Enliven Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ELVR",
+    "name": "Elevra Lithium Limited - American Depository Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ELWT",
+    "name": "Elauwit Connection, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "EMA",
+    "name": "Emera Incorporated Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "EMAT",
+    "name": "Evolution Metals & Technologies Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "EMBC",
+    "name": "Embecta Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "EMBJ",
+    "name": "Embraer S.A. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EMD",
+    "name": "Western Asset Emerging Markets Debt Fund Inc Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EME",
+    "name": "EMCOR Group, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EMF",
+    "name": "Templeton Emerging Markets Fund Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EMIS",
+    "name": "Emmis Acquisition Corp. - Class A Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "EML",
+    "name": "Eastern Company (The)",
+    "sector": null
+  },
+  {
+    "symbol": "EMN",
+    "name": "Eastman Chemical Company Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EMPD",
+    "name": "Empery Digital Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "EMPG",
+    "name": "Empro Group Inc. - Ordinary shares",
+    "sector": null
+  },
+  {
+    "symbol": "EMR",
+    "name": "Emerson Electric Company Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ENB",
+    "name": "Enbridge Inc Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ENGN",
+    "name": "enGene Therapeutics Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ENGS",
+    "name": "Energys Group Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ENHA",
+    "name": "Enhanced Group Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ENLT",
+    "name": "Enlight Renewable Energy Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ENLV",
+    "name": "Enlivex Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ENOV",
+    "name": "Enovis Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ENPH",
+    "name": "Enphase Energy, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ENR",
+    "name": "Energizer Holdings, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ENS",
+    "name": "EnerSys Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ENSC",
+    "name": "Ensysce Biosciences, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ENSG",
+    "name": "The Ensign Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ENTA",
+    "name": "Enanta Pharmaceuticals, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ENTG",
+    "name": "Entegris, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ENTX",
+    "name": "Entera Bio Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ENVA",
+    "name": "Enova International, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ENVB",
+    "name": "Enveric Biosciences, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ENVX",
+    "name": "Enovix Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "EOG",
+    "name": "EOG Resources, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EOI",
+    "name": "Eaton Vance Enhance Equity Income Fund Eaton Vance Enhanced Equity Income Fund Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "EOLS",
+    "name": "Evolus, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "EONR",
+    "name": "EON Resources Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EOS",
+    "name": "Eaton Vance Enhance Equity Income Fund II Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EOSE",
+    "name": "Eos Energy Enterprises, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "EP",
+    "name": "Empire Petroleum Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EPAC",
+    "name": "Enerpac Tool Group Corp. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EPAM",
+    "name": "EPAM Systems, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EPC",
+    "name": "Edgewell Personal Care Company Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EPD",
+    "name": "Enterprise Products Partners L.P. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EPM",
+    "name": "Evolution Petroleum Corporation, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EPOW",
+    "name": "E-Power Inc. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "EPR",
+    "name": "EPR Properties Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EPRT",
+    "name": "Essential Properties Realty Trust, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EPRX",
+    "name": "Eupraxia Pharmaceuticals Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "EPSM",
+    "name": "Epsium Enterprise Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "EPSN",
+    "name": "Epsilon Energy Ltd. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "EQ",
+    "name": "Equillium, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "EQBK",
+    "name": "Equity Bancshares, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EQH",
+    "name": "Equitable Holdings, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EQIX",
+    "name": "Equinix, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "EQNR",
+    "name": "Equinor ASA",
+    "sector": null
+  },
+  {
+    "symbol": "EQPT",
+    "name": "EquipmentShare.com Inc - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EQR",
+    "name": "Equity Residential Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "EQS",
+    "name": "Equus Total Return, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EQT",
+    "name": "EQT Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EQX",
+    "name": "Equinox Gold Corp. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ERAS",
+    "name": "Erasca, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ERC",
+    "name": "Allspring Multi-Sector Income Fund Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ERH",
+    "name": "Allspring Utilities and High Income Fund Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ERIE",
+    "name": "Erie Indemnity Company - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ERII",
+    "name": "Energy Recovery, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ERNA",
+    "name": "Ernexa Therapeutics Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ERO",
+    "name": "Ero Copper Corp. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "EROC",
+    "name": "ERock, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EROK",
+    "name": "EagleRock Land, LLC Class A shares representing limited liability company interests",
+    "sector": null
+  },
+  {
+    "symbol": "ES",
+    "name": "Eversource Energy (D/B/A) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ESAB",
+    "name": "ESAB Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ESCA",
+    "name": "Escalade, Incorporated",
+    "sector": null
+  },
+  {
+    "symbol": "ESE",
+    "name": "ESCO Technologies Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ESEA",
+    "name": "Euroseas Ltd.",
+    "sector": null
+  },
+  {
+    "symbol": "ESI",
+    "name": "Element Solutions Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ESLA",
+    "name": "Estrella Immunopharma, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ESLT",
+    "name": "Elbit Systems Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ESNT",
+    "name": "Essent Group Ltd. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ESOA",
+    "name": "Energy Services of America Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "ESP",
+    "name": "Espey Mfg. & Electronics Corp. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ESPR",
+    "name": "Esperion Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ESQ",
+    "name": "Esquire Financial Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ESRT",
+    "name": "Empire State Realty Trust, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ESS",
+    "name": "Essex Property Trust, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ESTA",
+    "name": "Establishment Labs Holdings Inc. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ESTC",
+    "name": "Elastic N.V. Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ETB",
+    "name": "Eaton Vance Tax-Managed Buy-Write Income Fund Eaton Vance Tax-Managed Buy-Write Income Fund Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "ETD",
+    "name": "Ethan Allen Interiors Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ETG",
+    "name": "Eaton Vance Tax-Advantaged Global Dividend Income Fund Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "ETJ",
+    "name": "Eaton Vance Risk-Managed Diversified Equity Income Fund Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "ETN",
+    "name": "Eaton Corporation, PLC Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ETO",
+    "name": "Eaton Vance Tax-Advantage Global Dividend Opp Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ETON",
+    "name": "Eton Pharmaceuticals, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ETOR",
+    "name": "eToro Group Ltd. - Class A Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ETR",
+    "name": "Entergy Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ETS",
+    "name": "Elite Express Holding Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ETSY",
+    "name": "Etsy, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ETX",
+    "name": "Eaton Vance Municipal Income 2028 Term Trust Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "ETY",
+    "name": "Eaton Vance Tax-Managed Diversified Equity Income Fund Common Shares of Beneficial Interest,",
+    "sector": null
+  },
+  {
+    "symbol": "EU",
+    "name": "enCore Energy Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "EUDA",
+    "name": "Euda Health Holdings Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "EURK",
+    "name": "Eureka Acquisition Corp - Class A Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "EVAC",
+    "name": "EQV Ventures Acquisition Corp. II Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "EVC",
+    "name": "Entravision Communications Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EVCM",
+    "name": "EverCommerce Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "EVER",
+    "name": "EverQuote, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EVEX",
+    "name": "Eve Holding, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EVF",
+    "name": "Eaton Vance Senior Income Trust Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EVG",
+    "name": "Eaton Vance Short Diversified Income Fund Eaton Vance Short Duration Diversified Income Fund Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "EVGN",
+    "name": "Evogene Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "EVGO",
+    "name": "EVgo Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "EVH",
+    "name": "Evolent Health, Inc Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EVI",
+    "name": "EVI Industries, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EVLV",
+    "name": "Evolv Technologies Holdings, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EVMN",
+    "name": "Evommune, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EVN",
+    "name": "Eaton Vance Municipal Income Trust Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EVOX",
+    "name": "Evolution Global Acquisition Corp - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "EVR",
+    "name": "Evercore Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EVRG",
+    "name": "Evergy, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "EVT",
+    "name": "Eaton Vance Tax Advantaged Dividend Income Fund Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "EVTC",
+    "name": "Evertec, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EVTL",
+    "name": "Vertical Aerospace Ltd. Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "EVTV",
+    "name": "Envirotech Vehicles, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "EVV",
+    "name": "Eaton Vance Limited Duration Income Fund Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "EW",
+    "name": "Edwards Lifesciences Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EWBC",
+    "name": "East West Bancorp, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "EWTX",
+    "name": "Edgewise Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "EXC",
+    "name": "Exelon Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "EXE",
+    "name": "Expand Energy Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "EXEL",
+    "name": "Exelixis, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "EXFY",
+    "name": "Expensify, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EXG",
+    "name": "Eaton Vance Tax-Managed Global Diversified Equity Income Fund Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "EXK",
+    "name": "Endeavour Silver Corporation Ordinary Shares (Canada)",
+    "sector": null
+  },
+  {
+    "symbol": "EXLS",
+    "name": "ExlService Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "EXOD",
+    "name": "Exodus Movement, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EXOZ",
+    "name": "eXoZymes Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "EXP",
+    "name": "Eagle Materials Inc Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EXPD",
+    "name": "Expeditors International of Washington, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EXPE",
+    "name": "Expedia Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "EXPO",
+    "name": "Exponent, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "EXR",
+    "name": "Extra Space Storage Inc Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EXTR",
+    "name": "Extreme Networks, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "EXYN",
+    "name": "Exyn Technologies, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "EYE",
+    "name": "National Vision Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "EYPT",
+    "name": "EyePoint, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "EZGO",
+    "name": "EZGO Technologies Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "EZPW",
+    "name": "EZCORP, Inc. - Class A Non-Voting Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "EZRA",
+    "name": "Reliance Global Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "F",
+    "name": "Ford Motor Company Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FA",
+    "name": "First Advantage Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "FABC",
+    "name": "Fabric.AI, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FAC",
+    "name": "Factorial Energy Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FACT",
+    "name": "FACT II Acquisition Corp. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "FAF",
+    "name": "First American Corporation (New) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FAMI",
+    "name": "Farmmi, Inc. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "FANG",
+    "name": "Diamondback Energy, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FAST",
+    "name": "Fastenal Company",
+    "sector": null
+  },
+  {
+    "symbol": "FATE",
+    "name": "Fate Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FATN",
+    "name": "FatPipe, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FAX",
+    "name": "abrdn Asia-Pacific Income Fund, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FBGL",
+    "name": "FBS Global Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "FBIN",
+    "name": "Fortune Brands Innovations, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FBIO",
+    "name": "Fortress Biotech, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FBIZ",
+    "name": "First Business Financial Services, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FBK",
+    "name": "FB Financial Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FBLA",
+    "name": "FB Bancorp, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FBLG",
+    "name": "FibroBiologics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FBNC",
+    "name": "First Bancorp",
+    "sector": null
+  },
+  {
+    "symbol": "FBP",
+    "name": "First BanCorp. New Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FBRT",
+    "name": "Franklin BSP Realty Trust, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FBRX",
+    "name": "Forte Biosciences, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FBYD",
+    "name": "Falcon's Beyond Global, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FC",
+    "name": "Franklin Covey Company Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FCAP",
+    "name": "First Capital, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FCEL",
+    "name": "FuelCell Energy, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FCF",
+    "name": "First Commonwealth Financial Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FCFS",
+    "name": "FirstCash Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FCHL",
+    "name": "Fitness Champs Holdings Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "FCN",
+    "name": "FTI Consulting, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FCNCA",
+    "name": "First Citizens BancShares, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FCPT",
+    "name": "Four Corners Property Trust, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FCRS",
+    "name": "FutureCrest Acquisition Corp. Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "FCT",
+    "name": "First Trust Senior Floating Rate Income Fund II Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "FCUV",
+    "name": "Focus Universal Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FCX",
+    "name": "Freeport-McMoRan, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FDBC",
+    "name": "Fidelity D & D Bancorp, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FDMT",
+    "name": "4D Molecular Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FDP",
+    "name": "Del Monte Corporation Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "FDS",
+    "name": "FactSet Research Systems Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FDSB",
+    "name": "Fifth District Bancorp, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FDUS",
+    "name": "Fidus Investment Corporation - Closed End Fund",
+    "sector": null
+  },
+  {
+    "symbol": "FDX",
+    "name": "FedEx Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FDXF",
+    "name": "FedEx Freight Holding Company, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FE",
+    "name": "FirstEnergy Corp. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FEAM",
+    "name": "5E Advanced Materials, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FEBO",
+    "name": "Fenbo Holdings Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "FEED",
+    "name": "ENvue Medical, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FEIM",
+    "name": "Frequency Electronics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FELE",
+    "name": "Franklin Electric Co., Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FEMY",
+    "name": "Femasys Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FENC",
+    "name": "Fennec Pharmaceuticals Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FER",
+    "name": "Ferrovial N.V. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "FERA",
+    "name": "Fifth Era Acquisition Corp I - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "FERG",
+    "name": "Ferguson Enterprises Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FET",
+    "name": "Forum Energy Technologies, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FF",
+    "name": "FutureFuel Corp. Common shares",
+    "sector": null
+  },
+  {
+    "symbol": "FFA",
+    "name": "First Trust Enhanced Equity Income Fund Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "FFAI",
+    "name": "Faraday Future Intelligent Electric Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FFBC",
+    "name": "First Financial Bancorp.",
+    "sector": null
+  },
+  {
+    "symbol": "FFIN",
+    "name": "First Financial Bankshares, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FFIV",
+    "name": "F5, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FG",
+    "name": "F&G Annuities & Life, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FGBI",
+    "name": "First Guaranty Bancshares, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FGI",
+    "name": "FGI Industries Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "FGII",
+    "name": "FG Imperii Acquisition Corp. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "FGL",
+    "name": "Founder Group Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "FGMC",
+    "name": "FG Merger II Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "FGNX",
+    "name": "FG Nexus Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FHB",
+    "name": "First Hawaiian, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FHI",
+    "name": "Federated Hermes, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FHN",
+    "name": "First Horizon Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FHTX",
+    "name": "Foghorn Therapeutics Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FIBK",
+    "name": "First Interstate BancSystem, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FICO",
+    "name": "Fair Isaac Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FIEE",
+    "name": "FiEE, Inc",
+    "sector": null
+  },
+  {
+    "symbol": "FIG",
+    "name": "Figma, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FIGR",
+    "name": "Figure Technology Solutions, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FIGS",
+    "name": "FIGS, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FIGX",
+    "name": "FIGX Capital Acquisition Corp. - Class A ordinary share",
+    "sector": null
+  },
+  {
+    "symbol": "FINS",
+    "name": "Angel Oak Financial Strategies Income Term Trust Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "FINW",
+    "name": "FinWise Bancorp",
+    "sector": null
+  },
+  {
+    "symbol": "FIP",
+    "name": "FTAI Infrastructure Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FIS",
+    "name": "Fidelity National Information Services, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FISI",
+    "name": "Financial Institutions, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FISV",
+    "name": "Fiserv, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FITB",
+    "name": "Fifth Third Bancorp Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FIVE",
+    "name": "Five Below, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FIVN",
+    "name": "Five9, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FIX",
+    "name": "Comfort Systems USA, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FIZZ",
+    "name": "National Beverage Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "FJET",
+    "name": "Starfighters Space, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FKWL",
+    "name": "Franklin Wireless Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "FLC",
+    "name": "Flaherty & Crumrine Total Return Fund Inc Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FLD",
+    "name": "Fold Holdings, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FLEX",
+    "name": "Flex Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "FLG",
+    "name": "Flagstar Bank, N.A. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FLGT",
+    "name": "Fulgent Genetics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FLL",
+    "name": "Full House Resorts, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FLNA",
+    "name": "Filana Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FLNC",
+    "name": "Fluence Energy, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FLNG",
+    "name": "FLEX LNG Ltd. Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "FLNT",
+    "name": "Fluent, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FLO",
+    "name": "Flowers Foods, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FLOC",
+    "name": "Flowco Holdings Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FLR",
+    "name": "Fluor Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FLS",
+    "name": "Flowserve Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FLUT",
+    "name": "Flutter Entertainment plc Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "FLUX",
+    "name": "Flux Power Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FLWS",
+    "name": "1-800-FLOWERS.COM, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FLXS",
+    "name": "Flexsteel Industries, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FLY",
+    "name": "Firefly Aerospace Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FLYE",
+    "name": "Fly-E Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FLYW",
+    "name": "Flywire Corporation - Voting Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FLYX",
+    "name": "flyExclusive, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FMAC",
+    "name": "Future Money Acquisition Corporation - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "FMAO",
+    "name": "Farmers & Merchants Bancorp, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FMBH",
+    "name": "First Mid Bancshares, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FMC",
+    "name": "FMC Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FMFC",
+    "name": "Kandal M Venture Limited - Class A ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "FMN",
+    "name": "Federated Hermes Premier Municipal Income Fund",
+    "sector": null
+  },
+  {
+    "symbol": "FMNB",
+    "name": "Farmers National Banc Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "FMST",
+    "name": "Foremost Clean Energy Ltd. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "FMX",
+    "name": "Fomento Economico Mexicano S.A.B. de C.V. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FMY",
+    "name": "First Trust Mortgage Income Fund Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "FN",
+    "name": "Fabrinet Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "FNB",
+    "name": "F.N.B. Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FND",
+    "name": "Floor & Decor Holdings, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FNF",
+    "name": "Fidelity National Financial, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FNGD",
+    "name": "MicroSectors FANG Index -3X Inverse Leveraged ETNs due January 8, 2038",
+    "sector": null
+  },
+  {
+    "symbol": "FNGO",
+    "name": "MicroSectors FANG Index 2X Leveraged ETNs due January 8, 2038",
+    "sector": null
+  },
+  {
+    "symbol": "FNGR",
+    "name": "FingerMotion, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FNKO",
+    "name": "Funko, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FNLC",
+    "name": "First Bancorp, Inc (ME)",
+    "sector": null
+  },
+  {
+    "symbol": "FNUC",
+    "name": "Frontier Nuclear and Minerals Inc. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "FNV",
+    "name": "Franco-Nevada Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "FNWB",
+    "name": "First Northwest Bancorp",
+    "sector": null
+  },
+  {
+    "symbol": "FNWD",
+    "name": "Finward Bancorp",
+    "sector": null
+  },
+  {
+    "symbol": "FOA",
+    "name": "Finance of America Companies Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FOFO",
+    "name": "Hang Feng Technology Innovation Co., Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "FOR",
+    "name": "Forestar Group Inc Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FORM",
+    "name": "FormFactor, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FORR",
+    "name": "Forrester Research, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FOSL",
+    "name": "Fossil Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FOUR",
+    "name": "Shift4 Payments, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FOX",
+    "name": "Fox Corporation - Class B Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FOXA",
+    "name": "Fox Corporation - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FOXF",
+    "name": "Fox Factory Holding Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "FOXX",
+    "name": "Foxx Development Holdings Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FPH",
+    "name": "Five Point Holdings, LLC Class A Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "FPI",
+    "name": "Farmland Partners Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FPS",
+    "name": "Forgent Power Solutions, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FR",
+    "name": "First Industrial Realty Trust, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FRA",
+    "name": "Blackrock Floating Rate Income Strategies Fund Inc Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FRAF",
+    "name": "Franklin Financial Services Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "FRBA",
+    "name": "First Bank",
+    "sector": null
+  },
+  {
+    "symbol": "FRD",
+    "name": "Friedman Industries Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FRGT",
+    "name": "Freight Technologies, Inc. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "FRHC",
+    "name": "Freedom Holding Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "FRME",
+    "name": "First Merchants Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "FRMI",
+    "name": "Fermi Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FRMM",
+    "name": "Forum Markets, Incorporated",
+    "sector": null
+  },
+  {
+    "symbol": "FRO",
+    "name": "Frontline Plc Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "FROG",
+    "name": "JFrog Ltd. - Ordinary shares",
+    "sector": null
+  },
+  {
+    "symbol": "FRPH",
+    "name": "FRP Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FRPT",
+    "name": "Freshpet, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FRSH",
+    "name": "Freshworks Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FRST",
+    "name": "Primis Financial Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "FRT",
+    "name": "Federal Realty Investment Trust Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FRTT",
+    "name": "Fort Technology Inc. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "FRVO",
+    "name": "Fervo Energy Company - Class A common stock",
+    "sector": null
+  },
+  {
+    "symbol": "FSBC",
+    "name": "Five Star Bancorp",
+    "sector": null
+  },
+  {
+    "symbol": "FSBW",
+    "name": "FS Bancorp, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FSEA",
+    "name": "First Seacoast Bancorp, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FSHP",
+    "name": "Flag Ship Acquisition Corp. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "FSI",
+    "name": "Flexible Solutions International Inc. Common Stock (CDA)",
+    "sector": null
+  },
+  {
+    "symbol": "FSK",
+    "name": "FS KKR Capital Corp. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FSLR",
+    "name": "First Solar, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FSLY",
+    "name": "Fastly, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FSM",
+    "name": "Fortuna Mining Corp. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "FSP",
+    "name": "Franklin Street Properties Corp. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FSS",
+    "name": "Federal Signal Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FSSL",
+    "name": "FS Specialty Lending Fund Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "FSTR",
+    "name": "L.B. Foster Company",
+    "sector": null
+  },
+  {
+    "symbol": "FSUN",
+    "name": "FirstSun Capital Bancorp",
+    "sector": null
+  },
+  {
+    "symbol": "FSV",
+    "name": "FirstService Corporation - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "FT",
+    "name": "Franklin Universal Trust Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FTAI",
+    "name": "FTAI Aviation Ltd.",
+    "sector": null
+  },
+  {
+    "symbol": "FTCI",
+    "name": "FTC Solar, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FTDR",
+    "name": "Frontdoor, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FTEK",
+    "name": "Fuel Tech, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FTF",
+    "name": "Franklin Limited Duration Income Trust Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "FTFT",
+    "name": "Future FinTech Group Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FTHM",
+    "name": "Fathom Holdings Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FTI",
+    "name": "TechnipFMC plc Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "FTK",
+    "name": "Flotek Industries, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FTLF",
+    "name": "FitLife Brands, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FTNT",
+    "name": "Fortinet, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FTRE",
+    "name": "Fortrea Holdings Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FTRK",
+    "name": "FAST TRACK GROUP - Ordinary shares",
+    "sector": null
+  },
+  {
+    "symbol": "FTS",
+    "name": "Fortis Inc. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "FTV",
+    "name": "Fortive Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FTW",
+    "name": "Presidio Production Company Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FUBO",
+    "name": "FuboTV Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FUFU",
+    "name": "BitFuFu Inc. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "FUL",
+    "name": "H. B. Fuller Company Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FULC",
+    "name": "Fulcrum Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FULT",
+    "name": "Fulton Financial Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "FUN",
+    "name": "Six Flags Entertainment Corporation Common Stock New",
+    "sector": null
+  },
+  {
+    "symbol": "FUND",
+    "name": "Sprott Focus Trust, Inc. - Closed End Fund",
+    "sector": null
+  },
+  {
+    "symbol": "FURY",
+    "name": "Fury Gold Mines Limited Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "FUSB",
+    "name": "First US Bancshares, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FUSE",
+    "name": "Fusemachines Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FVAV",
+    "name": "Fortress Value Acquisition Corp. V - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "FVCB",
+    "name": "FVCBankcorp, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FVN",
+    "name": "Future Vision II Acquisition Corporation - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "FVR",
+    "name": "FrontView REIT, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FVRR",
+    "name": "Fiverr International Ltd. Ordinary Shares, no par value",
+    "sector": null
+  },
+  {
+    "symbol": "FWDI",
+    "name": "Forward Industries, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FWONA",
+    "name": "Liberty Media Corporation - Series A Liberty Formula One Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FWONK",
+    "name": "Liberty Media Corporation - Series C Liberty Formula One Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "FWRD",
+    "name": "Forward Air Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "FWRG",
+    "name": "First Watch Restaurant Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "FXNC",
+    "name": "First National Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "G",
+    "name": "Genpact Limited Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GAB",
+    "name": "Gabelli Equity Trust, Inc. (The) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GABC",
+    "name": "German American Bancorp, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "GAIA",
+    "name": "Gaia, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GAIN",
+    "name": "Gladstone Investment Corporation - Business Development Company",
+    "sector": null
+  },
+  {
+    "symbol": "GALT",
+    "name": "Galectin Therapeutics Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "GAM",
+    "name": "General American Investors, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GAMB",
+    "name": "Gambling.com Group Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "GAME",
+    "name": "GameSquare Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "GANX",
+    "name": "Gain Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "GAP",
+    "name": "Gap, Inc. (The) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GASS",
+    "name": "StealthGas, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "GATX",
+    "name": "GATX Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GAU",
+    "name": "Galiano Gold Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "GAUZ",
+    "name": "Gauzy Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "GBCI",
+    "name": "Glacier Bancorp, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GBDC",
+    "name": "Golub Capital BDC, Inc. - Closed End Fund",
+    "sector": null
+  },
+  {
+    "symbol": "GBFH",
+    "name": "GBank Financial Holdings Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "GBLI",
+    "name": "Global Indemnity Group, LLC - Class A Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "GBR",
+    "name": "New Concept Energy, Inc Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GBTG",
+    "name": "Global Business Travel Group, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GBX",
+    "name": "Greenbrier Companies, Inc. (The) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GCBC",
+    "name": "Greene County Bancorp, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "GCDT",
+    "name": "Green Circle Decarbonize Technology Limited Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "GCL",
+    "name": "GCL Global Holdings Ltd - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "GCMG",
+    "name": "GCM Grosvenor Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GCO",
+    "name": "Genesco Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GCT",
+    "name": "GigaCloud Technology Inc - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "GCTK",
+    "name": "GlucoTrack, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "GCTS",
+    "name": "GCT Semiconductor Holding, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GCV",
+    "name": "Gabelli Convertible and Income Securities Fund, Inc. (The) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GD",
+    "name": "General Dynamics Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GDC",
+    "name": "GD Culture Group Limited",
+    "sector": null
+  },
+  {
+    "symbol": "GDDY",
+    "name": "GoDaddy Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GDEV",
+    "name": "GDEV Inc. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "GDHG",
+    "name": "Golden Heaven Group Holdings Ltd. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "GDL",
+    "name": "GDL Fund, The Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "GDOT",
+    "name": "Green Dot Corporation Class A Common Stock, $0.001 par value",
+    "sector": null
+  },
+  {
+    "symbol": "GDRX",
+    "name": "GoodRx Holdings, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GDTC",
+    "name": "CytoMed Therapeutics Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "GDV",
+    "name": "Gabelli Dividend & Income Trust Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "GDYN",
+    "name": "Grid Dynamics Holdings, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GE",
+    "name": "GE Aerospace Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GECC",
+    "name": "Great Elm Capital Corp. - Closed End Fund",
+    "sector": null
+  },
+  {
+    "symbol": "GEF",
+    "name": "Greif Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GEF.B",
+    "name": "Greif, Inc. Corporation Class B Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GEG",
+    "name": "Great Elm Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "GEHC",
+    "name": "GE HealthCare Technologies Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "GELS",
+    "name": "Gelteq Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "GEMI",
+    "name": "Gemini Space Station, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GEN",
+    "name": "Gen Digital Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "GENB",
+    "name": "Generate Biomedicines, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "GENC",
+    "name": "Gencor Industries, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GENI",
+    "name": "Genius Sports Limited Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "GENK",
+    "name": "GEN Restaurant Group, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GEO",
+    "name": "Geo Group Inc (The) REIT",
+    "sector": null
+  },
+  {
+    "symbol": "GEOS",
+    "name": "Geospace Technologies Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "GERN",
+    "name": "Geron Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "GETY",
+    "name": "Getty Images Holdings, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GEV",
+    "name": "GE Vernova Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GEVO",
+    "name": "Gevo, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "GF",
+    "name": "New Germany Fund, Inc. (The) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GFAI",
+    "name": "Guardforce AI Co., Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "GFF",
+    "name": "Griffon Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GFL",
+    "name": "GFL Environmental Inc. Subordinate voting shares, no par value",
+    "sector": null
+  },
+  {
+    "symbol": "GFR",
+    "name": "Greenfire Resources Ltd. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "GFS",
+    "name": "GlobalFoundries Inc. - Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "GGB",
+    "name": "Gerdau S.A. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GGG",
+    "name": "Graco Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GGN",
+    "name": "GAMCO Global Gold, Natural Resources & Income Trust",
+    "sector": null
+  },
+  {
+    "symbol": "GGR",
+    "name": "Gogoro Inc. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "GGRP",
+    "name": "The Glimpse Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "GGT",
+    "name": "Gabelli Multi-Media Trust, Inc. (The) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GGZ",
+    "name": "Gabelli Global Small and Mid Cap Value Trust (The) Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "GH",
+    "name": "Guardant Health, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "GHC",
+    "name": "Graham Holdings Company Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GHM",
+    "name": "Graham Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GHRS",
+    "name": "GH Research PLC - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "GHY",
+    "name": "PGIM Global High Yield Fund, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "GIB",
+    "name": "CGI Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GIBO",
+    "name": "GIBO Holdings Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "GIC",
+    "name": "Global Industrial Company Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GIFT",
+    "name": "Giftify, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "GIGM",
+    "name": "GigaMedia Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "GIII",
+    "name": "G-III Apparel Group, LTD.",
+    "sector": null
+  },
+  {
+    "symbol": "GIL",
+    "name": "Gildan Activewear, Inc. Class A Sub. Vot. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GILD",
+    "name": "Gilead Sciences, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "GILT",
+    "name": "Gilat Satellite Networks Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "GIPR",
+    "name": "Generation Income Properties Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "GIS",
+    "name": "General Mills, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GITS",
+    "name": "Global Interactive Technologies, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GIW",
+    "name": "GigCapital8 Corp. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "GIX",
+    "name": "GigCapital9 Corp. - Class A Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "GJH",
+    "name": "Synthetic Fixed-Income Securities Inc 6.375% (STRATS) Cl A-1",
+    "sector": null
+  },
+  {
+    "symbol": "GJO",
+    "name": "Synthetic Fixed-Income Securities, Inc. on behalf of STRATS(SM) Trust for Wal-Mart Stores, Inc. Securities, Series 2004-5",
+    "sector": null
+  },
+  {
+    "symbol": "GJP",
+    "name": "Synthetic Fixed-Income Securities, Inc. on behalf of STRATS (SM) Trust for Dominion Resources, Inc. Securities, Series 2005-6, Floating Rate Structured Repackaged Asset-Backed Trust Securities (STRATS) Certificates",
+    "sector": null
+  },
+  {
+    "symbol": "GJR",
+    "name": "Synthetic Fixed-Income Securities, Inc. STRATS Trust for Procter&Gamble Securities, Series 2006-1",
+    "sector": null
+  },
+  {
+    "symbol": "GJS",
+    "name": "Goldman Sachs Group Securities STRATS Trust for Goldman Sachs Group Securities, Series 2006-2",
+    "sector": null
+  },
+  {
+    "symbol": "GJT",
+    "name": "Synthetic Fixed-Income Securities, Inc. Floating Rate Structured Repackaged Asset-Backed Trust Securities Certificates, Series 2006-3",
+    "sector": null
+  },
+  {
+    "symbol": "GKOS",
+    "name": "Glaukos Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GL",
+    "name": "Globe Life Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GLAD",
+    "name": "Gladstone Capital Corporation - Closed End Fund",
+    "sector": null
+  },
+  {
+    "symbol": "GLBE",
+    "name": "Global-E Online Ltd. - ordinary shares",
+    "sector": null
+  },
+  {
+    "symbol": "GLBS",
+    "name": "Globus Maritime Limited",
+    "sector": null
+  },
+  {
+    "symbol": "GLDG",
+    "name": "GoldMining Inc. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "GLE",
+    "name": "Global Engine Group Holding Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "GLED",
+    "name": "GalaxyEdge Acquisition Corporation Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "GLIBA",
+    "name": "Liberty Capital Corporation - Series A GCI Group Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GLIBK",
+    "name": "Liberty Capital Corporation - Series C GCI Group Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GLMD",
+    "name": "Galmed Pharmaceuticals Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "GLND",
+    "name": "Greenland Energy Company",
+    "sector": null
+  },
+  {
+    "symbol": "GLNG",
+    "name": "Golar LNG Limited - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "GLOB",
+    "name": "Globant S.A. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "GLOO",
+    "name": "Gloo Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "GLPI",
+    "name": "Gaming and Leisure Properties, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "GLQ",
+    "name": "Clough Global Equity Fund Clough Global Equity Fund Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "GLRE",
+    "name": "Greenlight Reinsurance, Ltd. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "GLSI",
+    "name": "Greenwich LifeSciences, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "GLU",
+    "name": "Gabelli Global Utility Common Shares of Beneficial Ownership",
+    "sector": null
+  },
+  {
+    "symbol": "GLUE",
+    "name": "Monte Rosa Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "GLV",
+    "name": "Clough Global Dividend and Income Fund Common Shares of beneficial interest",
+    "sector": null
+  },
+  {
+    "symbol": "GLW",
+    "name": "Corning Incorporated Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GLXG",
+    "name": "Galaxy Payroll Group Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "GLXY",
+    "name": "Galaxy Digital Inc. - Class A common stock",
+    "sector": null
+  },
+  {
+    "symbol": "GM",
+    "name": "General Motors Company Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GME",
+    "name": "GameStop Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GMED",
+    "name": "Globus Medical, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GMEX",
+    "name": "GMEX ROBOTICS CORPORATION - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "GMHS",
+    "name": "Gamehaus Holdings Inc. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "GMM",
+    "name": "Global Mofy AI Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "GMRS",
+    "name": "GMR Solutions Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GMTL",
+    "name": "Guardian Metal Resources PLC ADS",
+    "sector": null
+  },
+  {
+    "symbol": "GNE",
+    "name": "Genie Energy Ltd. Class B Common Stock Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GNK",
+    "name": "Genco Shipping & Trading Limited Ordinary Shares New (Marshall Islands)",
+    "sector": null
+  },
+  {
+    "symbol": "GNL",
+    "name": "Global Net Lease, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GNLN",
+    "name": "Greenlane Holdings, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GNLX",
+    "name": "Genelux Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "GNPX",
+    "name": "Genprex, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "GNRC",
+    "name": "Generac Holdlings Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GNS",
+    "name": "Genius Group Limited Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "GNSS",
+    "name": "Genasys Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "GNT",
+    "name": "GAMCO Natural Resources, Gold & Income Trust",
+    "sector": null
+  },
+  {
+    "symbol": "GNTX",
+    "name": "Gentex Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "GNW",
+    "name": "Genworth Financial Inc Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GO",
+    "name": "Grocery Outlet Holding Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "GOAI",
+    "name": "Eva Live Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "GOCO",
+    "name": "GoHealth, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GOGO",
+    "name": "Gogo Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "GOLD",
+    "name": "Gold.com, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GOLF",
+    "name": "Acushnet Holdings Corp. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GOOD",
+    "name": "Gladstone Commercial Corporation - Real Estate Investment Trust",
+    "sector": null
+  },
+  {
+    "symbol": "GOOG",
+    "name": "Alphabet Inc. - Class C Capital Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GOOGL",
+    "name": "Alphabet Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GOOS",
+    "name": "Canada Goose Holdings Inc. Subordinate Voting Shares",
+    "sector": null
+  },
+  {
+    "symbol": "GORO",
+    "name": "Gold Resource Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GOSS",
+    "name": "Gossamer Bio, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "GOVX",
+    "name": "GeoVax Labs, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "GP",
+    "name": "GreenPower Motor Company Inc. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "GPAC",
+    "name": "General Purpose Acquisition Corp. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "GPAT",
+    "name": "GP-Act III Acquisition Corp. - Class A Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "GPC",
+    "name": "Genuine Parts Company Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GPGI",
+    "name": "GPGI, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GPI",
+    "name": "Group 1 Automotive, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GPK",
+    "name": "Graphic Packaging Holding Company",
+    "sector": null
+  },
+  {
+    "symbol": "GPMT",
+    "name": "Granite Point Mortgage Trust Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GPN",
+    "name": "Global Payments Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GPOR",
+    "name": "Gulfport Energy Corporation Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "GPRE",
+    "name": "Green Plains, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "GPRK",
+    "name": "Geopark Ltd Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "GPRO",
+    "name": "GoPro, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GPUS",
+    "name": "Hyperscale Data, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GRAB",
+    "name": "Grab Holdings Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "GRAF",
+    "name": "Graf Global Corp. Class A ordinary shares",
+    "sector": null
+  },
+  {
+    "symbol": "GRAL",
+    "name": "GRAIL, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "GRAN",
+    "name": "Grande Group Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "GRBK",
+    "name": "Green Brick Partners, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GRC",
+    "name": "Gorman-Rupp Company (The) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GRCE",
+    "name": "Grace Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "GRDN",
+    "name": "Guardian Pharmacy Services, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GRDX",
+    "name": "GridAI Technologies Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "GREE",
+    "name": "Greenidge Generation Holdings Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GRF",
+    "name": "Eagle Capital Growth Fund, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GRI",
+    "name": "GRI Bio, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "GRML",
+    "name": "Greenland Mines Ltd",
+    "sector": null
+  },
+  {
+    "symbol": "GRMN",
+    "name": "Garmin Ltd. Common Stock (Switzerland)",
+    "sector": null
+  },
+  {
+    "symbol": "GRND",
+    "name": "Grindr Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GRNQ",
+    "name": "Greenpro Capital Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "GRNT",
+    "name": "Granite Ridge Resources, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GRO",
+    "name": "Brazil Potash Corp. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "GROV",
+    "name": "Grove Collaborative Holdings, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GROW",
+    "name": "U.S. Global Investors, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GROY",
+    "name": "Gold Royalty Corp. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "GRPN",
+    "name": "Groupon, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "GRRR",
+    "name": "Gorilla Technology Group Inc. - Ordinary shares",
+    "sector": null
+  },
+  {
+    "symbol": "GRWG",
+    "name": "GrowGeneration Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "GRX",
+    "name": "The Gabelli Healthcare & Wellness Trust Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "GS",
+    "name": "Goldman Sachs Group, Inc. (The) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GSAT",
+    "name": "Globalstar, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "GSBC",
+    "name": "Great Southern Bancorp, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "GSBD",
+    "name": "Goldman Sachs BDC, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GSHD",
+    "name": "Goosehead Insurance, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GSHR",
+    "name": "Gesher Acquisition Corp. II - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "GSIT",
+    "name": "GSI Technology, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "GSIW",
+    "name": "Garden Stage Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "GSL",
+    "name": "Global Ship Lease Inc New Class A Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "GSM",
+    "name": "Ferroglobe PLC - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "GSRF",
+    "name": "GSR IV Acquisition Corp. - Class A ordinary share",
+    "sector": null
+  },
+  {
+    "symbol": "GSUN",
+    "name": "Golden Sun Technology Group Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "GT",
+    "name": "The Goodyear Tire & Rubber Company",
+    "sector": null
+  },
+  {
+    "symbol": "GTBP",
+    "name": "GT Biopharma, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "GTE",
+    "name": "Gran Tierra Energy Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GTEC",
+    "name": "Greenland Technologies Holding Corporation - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "GTEN",
+    "name": "Gores Holdings X, Inc. - Class A ordinary shares",
+    "sector": null
+  },
+  {
+    "symbol": "GTERA",
+    "name": "Globa Terra Acquisition Corporation - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "GTES",
+    "name": "Gates Industrial Corporation plc Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "GTIM",
+    "name": "Good Times Restaurants Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "GTLB",
+    "name": "GitLab Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GTLS",
+    "name": "Chart Industries, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GTM",
+    "name": "ZoomInfo Technologies Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "GTN",
+    "name": "Gray Media, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GTN.A",
+    "name": "Gray Media, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GTX",
+    "name": "Garrett Motion Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "GTY",
+    "name": "Getty Realty Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GUG",
+    "name": "Guggenheim Active Allocation Fund Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "GURE",
+    "name": "Gulf Resources, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "GUT",
+    "name": "Gabelli Utility Trust (The) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GUTS",
+    "name": "Fractyl Health, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "GV",
+    "name": "Visionary Holdings Inc. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "GVA",
+    "name": "Granite Construction Incorporated Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GVH",
+    "name": "Globavend Holdings Limited - Ord Shares",
+    "sector": null
+  },
+  {
+    "symbol": "GWAV",
+    "name": "Greenwave Technology Solutions, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "GWH",
+    "name": "ESS Tech, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GWRE",
+    "name": "Guidewire Software, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GWRS",
+    "name": "Global Water Resources, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "GWW",
+    "name": "W.W. Grainger, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GXAI",
+    "name": "Gaxos.ai Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "GXO",
+    "name": "GXO Logistics, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "GYRE",
+    "name": "Gyre Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "GYRO",
+    "name": "Gyrodyne , LLC",
+    "sector": null
+  },
+  {
+    "symbol": "H",
+    "name": "Hyatt Hotels Corporation Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HACQ",
+    "name": "HCM IV Acquisition Corp. - Class A Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "HAE",
+    "name": "Haemonetics Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HAFC",
+    "name": "Hanmi Financial Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "HAFN",
+    "name": "Hafnia Limited Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "HAIN",
+    "name": "The Hain Celestial Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "HAL",
+    "name": "Halliburton Company Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HALO",
+    "name": "Halozyme Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "HAO",
+    "name": "Haoxi Health Technology Limited - Class A Ord Share",
+    "sector": null
+  },
+  {
+    "symbol": "HAS",
+    "name": "Hasbro, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "HASI",
+    "name": "HA Sustainable Infrastructure Capital, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HAVA",
+    "name": "Harvard Ave Acquisition Corporation - Class A Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "HAWK",
+    "name": "HawkEye 360, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HAYW",
+    "name": "Hayward Holdings, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HBAN",
+    "name": "Huntington Bancshares Incorporated",
+    "sector": null
+  },
+  {
+    "symbol": "HBB",
+    "name": "Hamilton Beach Brands Holding Company Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HBCP",
+    "name": "Home Bancorp, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "HBIO",
+    "name": "Harvard Bioscience, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "HBM",
+    "name": "Hudbay Minerals Inc. Ordinary Shares (Canada)",
+    "sector": null
+  },
+  {
+    "symbol": "HBNB",
+    "name": "Hotel101 Global Holdings Corp. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "HBNC",
+    "name": "Horizon Bancorp, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "HBT",
+    "name": "HBT Financial, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "HCA",
+    "name": "HCA Healthcare, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HCAC",
+    "name": "Hall Chadwick Acquisition Corp. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "HCAI",
+    "name": "Huachen AI Parking Management Technology Holding Co., Ltd. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "HCAT",
+    "name": "Health Catalyst, Inc",
+    "sector": null
+  },
+  {
+    "symbol": "HCC",
+    "name": "Warrior Met Coal, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HCHL",
+    "name": "Happy City Holdings Limited - Class A Ordinary shares",
+    "sector": null
+  },
+  {
+    "symbol": "HCI",
+    "name": "HCI Group, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HCIC",
+    "name": "Hennessy Capital Investment Corp. VIII - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "HCKT",
+    "name": "The Hackett Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "HCMA",
+    "name": "HCM III Acquisition Corp. - Class A Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "HCSG",
+    "name": "Healthcare Services Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "HCTI",
+    "name": "Healthcare Triangle, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "HCWB",
+    "name": "HCW Biologics Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "HCWC",
+    "name": "Healthy Choice Wellness Corp. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HD",
+    "name": "Home Depot, Inc. (The) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HDB",
+    "name": "HDFC Bank Limited Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HDRN",
+    "name": "Hadron Energy, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "HDSN",
+    "name": "Hudson Technologies, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "HE",
+    "name": "Hawaiian Electric Industries, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HEI",
+    "name": "Heico Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HEI.A",
+    "name": "Heico Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HELE",
+    "name": "Helen of Troy Limited",
+    "sector": null
+  },
+  {
+    "symbol": "HELP",
+    "name": "Cybin Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "HEQ",
+    "name": "John Hancock Diversified Income Fund Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "HERZ",
+    "name": "Herzfeld Credit Income Fund, Inc. - Closed End Fund",
+    "sector": null
+  },
+  {
+    "symbol": "HESM",
+    "name": "Hess Midstream LP Class A Representing Limited Partner Interests",
+    "sector": null
+  },
+  {
+    "symbol": "HFBL",
+    "name": "Home Federal Bancorp, Inc. of Louisiana",
+    "sector": null
+  },
+  {
+    "symbol": "HFFG",
+    "name": "HF Foods Group Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "HFWA",
+    "name": "Heritage Financial Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "HG",
+    "name": "Hamilton Insurance Group, Ltd. Class B Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "HGBL",
+    "name": "Heritage Global Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "HGLB",
+    "name": "Highland Global Allocation Fund Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HGTY",
+    "name": "Hagerty, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HGV",
+    "name": "Hilton Grand Vacations Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HHH",
+    "name": "Howard Hughes Holdings Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HHS",
+    "name": "Harte Hanks, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "HIFS",
+    "name": "Hingham Institution for Savings",
+    "sector": null
+  },
+  {
+    "symbol": "HIG",
+    "name": "The Hartford Insurance Group, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HIHO",
+    "name": "Highway Holdings Limited",
+    "sector": null
+  },
+  {
+    "symbol": "HII",
+    "name": "Huntington Ingalls Industries, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HIMS",
+    "name": "Hims & Hers Health, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HIND",
+    "name": "Vyome Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "HIPO",
+    "name": "Hippo Holdings Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HIT",
+    "name": "Health In Tech, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HITI",
+    "name": "High Tide Inc. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "HIVE",
+    "name": "HIVE Digital Technologies Ltd - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "HIW",
+    "name": "Highwoods Properties, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HIX",
+    "name": "Western Asset High Income Fund II Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HKIT",
+    "name": "Hitek Global Inc. - Class A Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "HKPD",
+    "name": "Cellyan Biotechnology Co., Ltd - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "HL",
+    "name": "Hecla Mining Company Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HLF",
+    "name": "Herbalife Ltd. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "HLI",
+    "name": "Houlihan Lokey, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HLIO",
+    "name": "Helios Technologies, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HLIT",
+    "name": "Harmonic Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "HLLY",
+    "name": "Holley Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HLMN",
+    "name": "Hillman Solutions Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "HLNE",
+    "name": "Hamilton Lane Incorporated - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HLP",
+    "name": "Hongli Group Inc. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "HLT",
+    "name": "Hilton Worldwide Holdings Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HLX",
+    "name": "Helix Energy Solutions Group, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HLXC",
+    "name": "Helix Acquisition Corp. III - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "HMC",
+    "name": "Honda Motor Company, Ltd. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HMH",
+    "name": "HMH Holding Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "HMN",
+    "name": "Horace Mann Educators Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HMR",
+    "name": "Heidmar Maritime Holdings Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "HMY",
+    "name": "Harmony Gold Mining Company Limited",
+    "sector": null
+  },
+  {
+    "symbol": "HNGE",
+    "name": "Hinge Health, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HNI",
+    "name": "HNI Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HNNA",
+    "name": "Hennessy Advisors, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "HNRG",
+    "name": "Hallador Energy Company",
+    "sector": null
+  },
+  {
+    "symbol": "HNST",
+    "name": "The Honest Company, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "HNVR",
+    "name": "Hanover Bancorp, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "HOFT",
+    "name": "Hooker Furnishings Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "HOG",
+    "name": "Harley-Davidson, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HOLO",
+    "name": "MicroCloud Hologram Inc. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "HOMB",
+    "name": "Home BancShares, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HON",
+    "name": "Honeywell International Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "HOOD",
+    "name": "Robinhood Markets, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HOPE",
+    "name": "Hope Bancorp, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "HOUR",
+    "name": "Hour Loop, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "HOV",
+    "name": "Hovnanian Enterprises, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HOVR",
+    "name": "New Horizon Aircraft Ltd. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "HOWL",
+    "name": "Werewolf Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "HP",
+    "name": "Helmerich & Payne, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HPAI",
+    "name": "Helport AI Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "HPE",
+    "name": "Hewlett Packard Enterprise Company Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HPF",
+    "name": "John Hancock Pfd Income Fund II Pfd Income Fund II",
+    "sector": null
+  },
+  {
+    "symbol": "HPK",
+    "name": "HighPeak Energy, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "HPP",
+    "name": "Hudson Pacific Properties, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HPQ",
+    "name": "HP Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HQ",
+    "name": "Horizon Quantum Holdings Ltd. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "HQH",
+    "name": "abrdn Healthcare Investors Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "HQI",
+    "name": "HireQuest, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "HQL",
+    "name": "abrdn Life Sciences Investors Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "HQY",
+    "name": "HealthEquity, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "HR",
+    "name": "Healthcare Realty Trust Incorporated Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HRB",
+    "name": "H&R Block, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HRI",
+    "name": "Herc Holdings Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HRL",
+    "name": "Hormel Foods Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HRMY",
+    "name": "Harmony Biosciences Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "HROW",
+    "name": "Harrow, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "HRTG",
+    "name": "Heritage Insurance Holdings, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HRTX",
+    "name": "Heron Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "HRZN",
+    "name": "Horizon Technology Finance Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "HSBC",
+    "name": "HSBC Holdings, plc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HSCS",
+    "name": "HeartSciences Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "HSDT",
+    "name": "Solana Company - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HSHP",
+    "name": "Himalaya Shipping Ltd. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "HSIC",
+    "name": "Henry Schein, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "HSLV",
+    "name": "Highlander Silver Corp. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "HSPT",
+    "name": "Horizon Space Acquisition II Corp. - Ordinary share",
+    "sector": null
+  },
+  {
+    "symbol": "HST",
+    "name": "Host Hotels & Resorts, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "HSTM",
+    "name": "HealthStream, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "HSY",
+    "name": "The Hershey Company Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HTB",
+    "name": "HomeTrust Bancshares, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HTCO",
+    "name": "High-Trend International Group - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "HTCR",
+    "name": "Heartcore Enterprises, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "HTD",
+    "name": "John Hancock Tax Advantaged Dividend Income Fund Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "HTFL",
+    "name": "Heartflow, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "HTGC",
+    "name": "Hercules Capital, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HTH",
+    "name": "Hilltop Holdings Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "HTLD",
+    "name": "Heartland Express, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "HTLM",
+    "name": "HomesToLife Ltd - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "HTO",
+    "name": "H2O America",
+    "sector": null
+  },
+  {
+    "symbol": "HTOO",
+    "name": "Fusion Fuel Green PLC - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "HTZ",
+    "name": "Hertz Global Holdings, Inc",
+    "sector": null
+  },
+  {
+    "symbol": "HUBB",
+    "name": "Hubbell Inc Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HUBC",
+    "name": "Hub Cyber Security Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "HUBG",
+    "name": "Hub Group, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HUBS",
+    "name": "HubSpot, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HUDI",
+    "name": "Huadi International Group Co., Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "HUHU",
+    "name": "HUHUTECH International Group Inc. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "HUM",
+    "name": "Humana Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HUMA",
+    "name": "Humacyte, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "HUN",
+    "name": "Huntsman Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HURA",
+    "name": "TuHURA Biosciences, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "HURC",
+    "name": "Hurco Companies, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "HURN",
+    "name": "Huron Consulting Group Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "HUT",
+    "name": "Hut 8 Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "HVII",
+    "name": "Hennessy Capital Investment Corp. VII - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "HVMC",
+    "name": "Highview Merger Corp. - Class A Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "HVT",
+    "name": "Haverty Furniture Companies, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HVT.A",
+    "name": "Haverty Furniture Companies, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HWBK",
+    "name": "Hawthorn Bancshares, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "HWC",
+    "name": "Hancock Whitney Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "HWH",
+    "name": "HWH International Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "HWKN",
+    "name": "Hawkins, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "HWM",
+    "name": "Howmet Aerospace Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HXHX",
+    "name": "Haoxin Holdings Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "HXL",
+    "name": "Hexcel Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HY",
+    "name": "Hyster-Yale, Inc. Class A common stock",
+    "sector": null
+  },
+  {
+    "symbol": "HYFM",
+    "name": "Hydrofarm Holdings Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "HYFT",
+    "name": "MindWalk Holdings Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "HYLN",
+    "name": "Hyliion Holdings Corp. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HYMC",
+    "name": "Hycroft Mining Holding Corporation - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HYNE",
+    "name": "Hoyne Bancorp, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "HYPD",
+    "name": "Hyperion DeFi, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "HYPR",
+    "name": "Hyperfine, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HYT",
+    "name": "Blackrock Corporate High Yield Fund, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "HZO",
+    "name": "MarineMax, Inc. (FL) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "IACO",
+    "name": "Idea Acquisition Corp. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "IAE",
+    "name": "Voya Asia Pacific High Dividend Equity Income Fund ING Asia Pacific High Dividend Equity Income Fund Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "IAF",
+    "name": "abrdn Australia Equity Fund, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "IAG",
+    "name": "Iamgold Corporation Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "IART",
+    "name": "Integra LifeSciences Holdings Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "IAUX",
+    "name": "i-80 Gold Corp. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "IBAC",
+    "name": "IB Acquisition Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "IBCP",
+    "name": "Independent Bank Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "IBEX",
+    "name": "IBEX Limited - Common Share",
+    "sector": null
+  },
+  {
+    "symbol": "IBG",
+    "name": "Innovation Beverage Group Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "IBIO",
+    "name": "iBio, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "IBKR",
+    "name": "Interactive Brokers Group, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "IBM",
+    "name": "International Business Machines Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "IBN",
+    "name": "ICICI Bank Limited Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "IBO",
+    "name": "Impact BioMedical, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "IBOC",
+    "name": "International Bancshares Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "IBP",
+    "name": "Installed Building Products, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "IBTA",
+    "name": "Ibotta, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ICCC",
+    "name": "ImmuCell Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "ICCM",
+    "name": "IceCure Medical Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ICE",
+    "name": "Intercontinental Exchange Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ICFI",
+    "name": "ICF International, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ICHR",
+    "name": "Ichor Holdings - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ICL",
+    "name": "ICL Group Ltd. Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ICLR",
+    "name": "ICON plc - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ICMB",
+    "name": "Investcorp Credit Management BDC, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ICON",
+    "name": "Icon Energy Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "ICU",
+    "name": "SeaStar Medical Holding Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "ICUI",
+    "name": "ICU Medical, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "IDA",
+    "name": "IDACORP, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "IDAI",
+    "name": "T Stamp Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "IDCC",
+    "name": "InterDigital, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "IDE",
+    "name": "Voya Infrastructure, Industrials and Materials Fund Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "IDN",
+    "name": "Intellicheck, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "IDR",
+    "name": "Idaho Strategic Resources, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "IDT",
+    "name": "IDT Corporation Class B Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "IDXX",
+    "name": "IDEXX Laboratories, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "IDYA",
+    "name": "IDEAYA Biosciences, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "IE",
+    "name": "Ivanhoe Electric Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "IEAG",
+    "name": "Infinite Eagle Acquisition Corp. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "IESC",
+    "name": "IES Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "IEX",
+    "name": "IDEX Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "IFBD",
+    "name": "Infobird Co., Ltd - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "IFF",
+    "name": "International Flavors & Fragrances, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "IFN",
+    "name": "Aberdeen India Fund, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "IFRX",
+    "name": "InflaRx N.V.",
+    "sector": null
+  },
+  {
+    "symbol": "IFS",
+    "name": "Intercorp Financial Services Inc. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "IGAC",
+    "name": "Invest Green Acquisition Corporation - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "IGC",
+    "name": "IGC Pharma, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "IGIC",
+    "name": "International General Insurance Holdings Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "IGR",
+    "name": "CBRE Global Real Estate Income Fund Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "IHD",
+    "name": "Voya Emerging Markets High Income Dividend Equity Fund Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "IHRT",
+    "name": "iHeartMedia, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "IHS",
+    "name": "IHS Holding Limited Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "IHT",
+    "name": "InnSuites Hospitality Trust Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "IIF",
+    "name": "Morgan Stanley India Investment Fund, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "III",
+    "name": "Information Services Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "IIIN",
+    "name": "Insteel Industries, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "IIIV",
+    "name": "i3 Verticals, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "IIM",
+    "name": "Invesco Value Municipal Income Trust Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "IIPR",
+    "name": "Innovative Industrial Properties, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "IKT",
+    "name": "Inhibikase Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ILAG",
+    "name": "Intelligent Living Application Group Inc. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ILLR",
+    "name": "Triller Group Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ILLU",
+    "name": "Illumination Acquisition Corp I - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ILMN",
+    "name": "Illumina, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ILPT",
+    "name": "Industrial Logistics Properties Trust - Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "IMA",
+    "name": "ImageneBio, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "IMAX",
+    "name": "Imax Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "IMCC",
+    "name": "IM Cannabis Corp. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "IMDX",
+    "name": "Insight Molecular Diagnostics Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "IMKTA",
+    "name": "Ingles Markets, Incorporated - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "IMMR",
+    "name": "Immersion Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "IMMX",
+    "name": "Immix Biopharma, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "IMNM",
+    "name": "Immunome, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "IMNN",
+    "name": "Imunon, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "IMO",
+    "name": "Imperial Oil Limited Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "IMPP",
+    "name": "Imperial Petroleum Inc. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "IMRX",
+    "name": "Immuneering Corporation - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "IMSR",
+    "name": "Terrestrial Energy Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "IMTE",
+    "name": "Integrated Media Technology Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "IMTX",
+    "name": "Immatics N.V. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "IMUX",
+    "name": "Immunic, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "IMVT",
+    "name": "Immunovant, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "IMXI",
+    "name": "International Money Express, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "INAB",
+    "name": "IN8bio, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "INAC",
+    "name": "Indigo Acquisition Corp. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "INBK",
+    "name": "First Internet Bancorp",
+    "sector": null
+  },
+  {
+    "symbol": "INBS",
+    "name": "Intelligent Bio Solutions Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "INBX",
+    "name": "Inhibrx Biosciences, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "INCR",
+    "name": "Intercure Ltd. - ordinary shares",
+    "sector": null
+  },
+  {
+    "symbol": "INCY",
+    "name": "Incyte Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "INDB",
+    "name": "Independent Bank Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "INDI",
+    "name": "indie Semiconductor, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "INDO",
+    "name": "Indonesia Energy Corporation Limited Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "INDP",
+    "name": "Indaptus Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "INDV",
+    "name": "Indivior Pharmaceuticals, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "INEO",
+    "name": "INNEOVA Holdings Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "INFQ",
+    "name": "Infleqtion, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "INFU",
+    "name": "InfuSystems Holdings, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ING",
+    "name": "ING Group, N.V. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "INGM",
+    "name": "Ingram Micro Holding Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "INGN",
+    "name": "Inogen, Inc",
+    "sector": null
+  },
+  {
+    "symbol": "INGR",
+    "name": "Ingredion Incorporated Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "INHD",
+    "name": "Inno Holdings Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "INIO",
+    "name": "INNIO N.V. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "INKT",
+    "name": "MiNK Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "INLF",
+    "name": "INLIF LIMITED - Class A Ordinary shares",
+    "sector": null
+  },
+  {
+    "symbol": "INLX",
+    "name": "Intellinetics, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "INM",
+    "name": "InMed Pharmaceuticals Inc. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "INMB",
+    "name": "INmune Bio Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "INMD",
+    "name": "InMode Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "INN",
+    "name": "Summit Hotel Properties, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "INNV",
+    "name": "InnovAge Holding Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "INO",
+    "name": "Inovio Pharmaceuticals, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "INOD",
+    "name": "Innodata Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "INR",
+    "name": "Infinity Natural Resources, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "INSE",
+    "name": "Inspired Entertainment, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "INSG",
+    "name": "Inseego Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "INSM",
+    "name": "Insmed Incorporated",
+    "sector": null
+  },
+  {
+    "symbol": "INSP",
+    "name": "Inspire Medical Systems, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "INSW",
+    "name": "International Seaways, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "INTA",
+    "name": "Intapp, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "INTC",
+    "name": "Intel Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "INTG",
+    "name": "The Intergroup Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "INTJ",
+    "name": "Intelligent Group Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "INTR",
+    "name": "Inter & Co. Inc. - Class A Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "INTS",
+    "name": "Intensity Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "INTT",
+    "name": "inTest Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "INTU",
+    "name": "Intuit Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "INTZ",
+    "name": "Intrusion Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "INUV",
+    "name": "Inuvo, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "INV",
+    "name": "Innventure, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "INVA",
+    "name": "Innoviva, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "INVE",
+    "name": "Identiv, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "INVH",
+    "name": "Invitation Homes Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "INVX",
+    "name": "Innovex International, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "INVZ",
+    "name": "Innoviz Technologies Ltd. - Ordinary shares",
+    "sector": null
+  },
+  {
+    "symbol": "IONQ",
+    "name": "IonQ, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "IONS",
+    "name": "Ionis Pharmaceuticals, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "IOSP",
+    "name": "Innospec Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "IOT",
+    "name": "Samsara Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "IOTR",
+    "name": "iOThree Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "IOVA",
+    "name": "Iovance Biotherapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "IP",
+    "name": "International Paper Company Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "IPAR",
+    "name": "Interparfums, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "IPCX",
+    "name": "Inflection Point Acquisition Corp. III - Class A ordinary shares",
+    "sector": null
+  },
+  {
+    "symbol": "IPDN",
+    "name": "Professional Diversity Network, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "IPEX",
+    "name": "Inflection Point Acquisition Corp. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "IPFX",
+    "name": "Inflection Point Acquisition Corp. VI - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "IPGP",
+    "name": "IPG Photonics Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "IPI",
+    "name": "Intrepid Potash, Inc Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "IPM",
+    "name": "Intelligent Protection Management Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "IPSC",
+    "name": "Century Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "IPST",
+    "name": "IP Strategy Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "IPW",
+    "name": "iPower Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "IPWR",
+    "name": "Ideal Power Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "IQI",
+    "name": "Invesco Quality Municipal Income Trust Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "IQST",
+    "name": "iQSTEL Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "IQV",
+    "name": "IQVIA Holdings, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "IR",
+    "name": "Ingersoll Rand Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "IRAB",
+    "name": "Iris Acquisition Corp II Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "IRD",
+    "name": "Opus Genetics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "IRDM",
+    "name": "Iridium Communications Inc",
+    "sector": null
+  },
+  {
+    "symbol": "IREN",
+    "name": "IREN Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "IRHO",
+    "name": "Iron Horse Acquisitions II Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "IRIX",
+    "name": "IRIDEX Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "IRM",
+    "name": "Iron Mountain Incorporated (Delaware)Common Stock REIT",
+    "sector": null
+  },
+  {
+    "symbol": "IRMD",
+    "name": "iRadimed Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "IRON",
+    "name": "Disc Medicine, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "IRT",
+    "name": "Independence Realty Trust, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "IRTC",
+    "name": "iRhythm Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "IRWD",
+    "name": "Ironwood Pharmaceuticals, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ISBA",
+    "name": "Isabella Bank Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "ISOU",
+    "name": "IsoEnergy Ltd. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ISPC",
+    "name": "iSpecimen Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ISPR",
+    "name": "Ispire Technology Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ISRG",
+    "name": "Intuitive Surgical, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ISSC",
+    "name": "Innovative Solutions and Support, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ISTR",
+    "name": "Investar Holding Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "IT",
+    "name": "Gartner, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ITGR",
+    "name": "Integer Holdings Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ITHA",
+    "name": "ITHAX Acquisition Corp III - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ITIC",
+    "name": "Investors Title Company",
+    "sector": null
+  },
+  {
+    "symbol": "ITOC",
+    "name": "iTonic Holdings Ltd - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ITP",
+    "name": "IT Tech Packaging, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ITRG",
+    "name": "Integra Resources Corp. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ITRI",
+    "name": "Itron, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ITRN",
+    "name": "Ituran Location and Control Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ITT",
+    "name": "ITT Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ITW",
+    "name": "Illinois Tool Works Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "IVA",
+    "name": "Inventiva S.A. - American Depository Shares",
+    "sector": null
+  },
+  {
+    "symbol": "IVDA",
+    "name": "Iveda Solutions, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "IVF",
+    "name": "INVO Fertility, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "IVR",
+    "name": "INVESCO MORTGAGE CAPITAL INC Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "IVT",
+    "name": "InvenTrust Properties Corp. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "IVVD",
+    "name": "Invivyd, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "IVZ",
+    "name": "Invesco Ltd Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "IXHL",
+    "name": "Incannex Healthcare Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "IZEA",
+    "name": "IZEA Worldwide, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "IZM",
+    "name": "ICZOOM Group Inc. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "J",
+    "name": "Jacobs Solutions Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "JACK",
+    "name": "Jack In The Box Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "JACS",
+    "name": "Jackson Acquisition Company II Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "JAGU",
+    "name": "Jaguar Uranium Corp. Class A Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "JAGX",
+    "name": "Jaguar Health, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "JAKK",
+    "name": "JAKKS Pacific, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "JAN",
+    "name": "Janus Living, Inc. Class A-1 Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "JANX",
+    "name": "Janux Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "JATT",
+    "name": "JATT II Acquisition Corp - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "JAZZ",
+    "name": "Jazz Pharmaceuticals plc - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "JBDI",
+    "name": "JBDI Holdings Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "JBGS",
+    "name": "JBG SMITH Properties Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "JBHT",
+    "name": "J.B. Hunt Transport Services, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "JBI",
+    "name": "Janus International Group, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "JBIO",
+    "name": "Jade Biosciences, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "JBK",
+    "name": "Lehman ABS 3.50 3.50% Adjustable Corp Backed Tr Certs GS Cap I",
+    "sector": null
+  },
+  {
+    "symbol": "JBL",
+    "name": "Jabil Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "JBLU",
+    "name": "JetBlue Airways Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "JBS",
+    "name": "JBS N.V. Class A Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "JBSS",
+    "name": "John B. Sanfilippo & Son, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "JBTM",
+    "name": "JBT Marel Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "JCAP",
+    "name": "Jefferson Capital, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "JCE",
+    "name": "Nuveen Core Equity Alpha Fund Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "JCI",
+    "name": "Johnson Controls International plc Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "JCSE",
+    "name": "JE Cleantech Holdings Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "JCTC",
+    "name": "Jewett-Cameron Trading Company - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "JDZG",
+    "name": "JIADE LIMITED - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "JEF",
+    "name": "Jefferies Financial Group Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "JELD",
+    "name": "JELD-WEN Holding, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "JEM",
+    "name": "707 Cayman Holdings Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "JENA",
+    "name": "Jena Acquisition Corporation II Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "JFB",
+    "name": "JFB Construction Holdings - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "JFR",
+    "name": "Nuveen Floating Rate Income Fund Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "JGH",
+    "name": "Nuveen Global High Income Fund Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "JHG",
+    "name": "Janus Henderson Group plc Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "JHI",
+    "name": "John Hancock Investors Trust Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "JHS",
+    "name": "John Hancock Income Securities Trust Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "JHX",
+    "name": "James Hardie Industries plc. Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "JILL",
+    "name": "J. Jill, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "JJSF",
+    "name": "J & J Snack Foods Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "JKHY",
+    "name": "Jack Henry & Associates, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "JL",
+    "name": "J-Long Group Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "JLHL",
+    "name": "Julong Holding Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "JLL",
+    "name": "Jones Lang LaSalle Incorporated Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "JLS",
+    "name": "Nuveen Mortgage and Income Fund",
+    "sector": null
+  },
+  {
+    "symbol": "JMG",
+    "name": "JM Group Limited Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "JMM",
+    "name": "Nuveen Multi-Market Income Fund (MA)",
+    "sector": null
+  },
+  {
+    "symbol": "JMSB",
+    "name": "John Marshall Bancorp, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "JNJ",
+    "name": "Johnson & Johnson Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "JOB",
+    "name": "GEE Group Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "JOBY",
+    "name": "Joby Aviation, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "JOE",
+    "name": "St. Joe Company (The) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "JOF",
+    "name": "Japan Smaller Capitalization Fund Inc Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "JOUT",
+    "name": "Johnson Outdoors Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "JPM",
+    "name": "JP Morgan Chase & Co. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "JQC",
+    "name": "Nuveen Credit Strategies Income Fund Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "JRI",
+    "name": "Nuveen Real Asset Income and Growth Fund Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "JRS",
+    "name": "Nuveen Real Estate Income Fund Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "JRSH",
+    "name": "Jerash Holdings (US), Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "JRVR",
+    "name": "James River Group Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "JSPR",
+    "name": "Jasper Therapeutics, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "JTAI",
+    "name": "Jet.AI Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "JUNS",
+    "name": "Jupiter Neurosciences, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "JVA",
+    "name": "Coffee Holding Co., Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "JWEL",
+    "name": "Jowell Global Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "JXG",
+    "name": "JX Luxventure Group Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "JXN",
+    "name": "Jackson Financial Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "JYD",
+    "name": "Jayud Global Logistics Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "JYNT",
+    "name": "The Joint Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "JZXN",
+    "name": "Jiuzi Holdings, Inc. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "KAI",
+    "name": "Kadant Inc Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "KALA",
+    "name": "KALA BIO, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "KALU",
+    "name": "Kaiser Aluminum Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "KAPA",
+    "name": "Kairos Pharma, Ltd. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "KARO",
+    "name": "Karooooo Ltd. - Ordinary shares",
+    "sector": null
+  },
+  {
+    "symbol": "KB",
+    "name": "KB Financial Group Inc",
+    "sector": null
+  },
+  {
+    "symbol": "KBDC",
+    "name": "Kayne Anderson BDC, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "KBH",
+    "name": "KB Home Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "KBON",
+    "name": "Karbon Capital Partners Corp. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "KBR",
+    "name": "KBR, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "KBSX",
+    "name": "FST Corp. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "KCHV",
+    "name": "Kochav Defense Acquisition Corp. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "KD",
+    "name": "Kyndryl Holdings, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "KDK",
+    "name": "Kodiak AI, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "KDP",
+    "name": "Keurig Dr Pepper Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "KE",
+    "name": "Kimball Electronics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "KEEL",
+    "name": "Keel Infrastructure Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "KELYA",
+    "name": "Kelly Services, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "KELYB",
+    "name": "Kelly Services, Inc. - Class B Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "KEN",
+    "name": "Kenon Holdings Ltd. Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "KEP",
+    "name": "Korea Electric Power Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "KEQU",
+    "name": "Kewaunee Scientific Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "KEX",
+    "name": "Kirby Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "KEY",
+    "name": "KeyCorp Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "KEYS",
+    "name": "Keysight Technologies Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "KF",
+    "name": "Korea Fund, Inc. (The) New Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "KFFB",
+    "name": "Kentucky First Federal Bancorp",
+    "sector": null
+  },
+  {
+    "symbol": "KFII",
+    "name": "K&F Growth Acquisition Corp. II - Class A Ordinary shares",
+    "sector": null
+  },
+  {
+    "symbol": "KFRC",
+    "name": "Kforce, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "KFY",
+    "name": "Korn Ferry Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "KG",
+    "name": "Kestrel Group, Ltd.",
+    "sector": null
+  },
+  {
+    "symbol": "KGC",
+    "name": "Kinross Gold Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "KGEI",
+    "name": "Kolibri Global Energy Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "KGS",
+    "name": "Kodiak Gas Services, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "KHC",
+    "name": "The Kraft Heinz Company",
+    "sector": null
+  },
+  {
+    "symbol": "KIDS",
+    "name": "OrthoPediatrics Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "KIDZ",
+    "name": "KIDZ AI Inc. - Class B Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "KIM",
+    "name": "Kimco Realty Corporation (HC) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "KINS",
+    "name": "Kingstone Companies, Inc",
+    "sector": null
+  },
+  {
+    "symbol": "KITT",
+    "name": "Nauticus Robotics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "KKR",
+    "name": "KKR & Co. Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "KLAC",
+    "name": "KLA Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "KLAR",
+    "name": "Klarna Group plc Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "KLC",
+    "name": "KinderCare Learning Companies, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "KLIC",
+    "name": "Kulicke and Soffa Industries, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "KLRA",
+    "name": "Kailera Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "KLRS",
+    "name": "Kalaris Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "KLTR",
+    "name": "Kaltura, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "KLXE",
+    "name": "KLX Energy Services Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "KMB",
+    "name": "Kimberly-Clark Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "KMDA",
+    "name": "Kamada Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "KMI",
+    "name": "Kinder Morgan, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "KMPR",
+    "name": "Kemper Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "KMRK",
+    "name": "K-Tech Solutions Company Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "KMT",
+    "name": "Kennametal Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "KMTS",
+    "name": "Kestra Medical Technologies, Ltd.",
+    "sector": null
+  },
+  {
+    "symbol": "KMX",
+    "name": "CarMax Inc",
+    "sector": null
+  },
+  {
+    "symbol": "KN",
+    "name": "Knowles Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "KNDI",
+    "name": "Kandi Technologies Group, Inc. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "KNF",
+    "name": "Knife Riv Holding Co. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "KNRX",
+    "name": "KNOREX LTD. Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "KNSA",
+    "name": "Kiniksa Pharmaceuticals International, plc - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "KNSL",
+    "name": "Kinsale Capital Group, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "KNTK",
+    "name": "Kinetik Holdings Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "KNX",
+    "name": "Knight-Swift Transportation Holdings Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "KO",
+    "name": "Coca-Cola Company (The) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "KOD",
+    "name": "Kodiak Sciences Inc",
+    "sector": null
+  },
+  {
+    "symbol": "KODK",
+    "name": "Eastman Kodak Company Common New",
+    "sector": null
+  },
+  {
+    "symbol": "KOP",
+    "name": "Koppers Holdings Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "KOPN",
+    "name": "Kopin Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "KORE",
+    "name": "KORE Group Holdings, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "KOS",
+    "name": "Kosmos Energy Ltd. Common Shares (DE)",
+    "sector": null
+  },
+  {
+    "symbol": "KOSS",
+    "name": "Koss Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "KOYN",
+    "name": "CSLM Digital Asset Acquisition Corp III - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "KPET",
+    "name": "KPET Ultra Paceline Corporation Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "KPLT",
+    "name": "Katapult Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "KPRX",
+    "name": "Kiora Pharmaceuticals, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "KPTI",
+    "name": "Karyopharm Therapeutics Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "KR",
+    "name": "Kroger Company (The) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "KRAQ",
+    "name": "KRAKacquisition Corp - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "KRC",
+    "name": "Kilroy Realty Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "KREF",
+    "name": "KKR Real Estate Finance Trust Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "KRG",
+    "name": "Kite Realty Group Trust Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "KRMD",
+    "name": "KORU Medical Systems, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "KRMN",
+    "name": "Karman Holdings Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "KRNT",
+    "name": "Kornit Digital Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "KRNY",
+    "name": "Kearny Financial",
+    "sector": null
+  },
+  {
+    "symbol": "KRO",
+    "name": "Kronos Worldwide Inc Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "KROS",
+    "name": "Keros Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "KRRO",
+    "name": "Korro Bio, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "KRSP",
+    "name": "Rice Acquisition Corporation 3 Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "KRT",
+    "name": "Karat Packaging Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "KRUS",
+    "name": "Kura Sushi USA, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "KRYS",
+    "name": "Krystal Biotech, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "KSCP",
+    "name": "Knightscope, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "KSPI",
+    "name": "Joint Stock Company Kaspi.kz - American Depository Shares",
+    "sector": null
+  },
+  {
+    "symbol": "KSS",
+    "name": "Kohl's Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "KT",
+    "name": "KT Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "KTB",
+    "name": "Kontoor Brands, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "KTCC",
+    "name": "Key Tronic Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "KTF",
+    "name": "DWS Municipal Income Trust",
+    "sector": null
+  },
+  {
+    "symbol": "KTN",
+    "name": "Structured Products Corp 8.205% CorTS 8.205% Corporate Backed Trust Securities (CorTS)",
+    "sector": null
+  },
+  {
+    "symbol": "KTOS",
+    "name": "Kratos Defense & Security Solutions, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "KTTA",
+    "name": "Pasithea Therapeutics Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "KTWO",
+    "name": "K2 Capital Acquisition Corporation - Class A Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "KULR",
+    "name": "KULR Technology Group, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "KURA",
+    "name": "Kura Oncology, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "KUST",
+    "name": "Kustom Entertainment, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "KVAC",
+    "name": "Keen Vision Acquisition Corporation - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "KVHI",
+    "name": "KVH Industries, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "KVUE",
+    "name": "Kenvue Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "KVYO",
+    "name": "Klaviyo, Inc. Series A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "KW",
+    "name": "Kennedy-Wilson Holdings Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "KWM",
+    "name": "K Wave Media, Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "KWR",
+    "name": "Quaker Houghton Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "KWY",
+    "name": "Kingsway Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "KXIN",
+    "name": "Kaixin Holdings - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "KYIV",
+    "name": "Kyivstar Group Ltd. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "KYMR",
+    "name": "Kymera Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "KYN",
+    "name": "Kayne Anderson Energy Infrastructure Fund, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "KYNB",
+    "name": "Kyntra Bio, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "KYTX",
+    "name": "Kyverna Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "L",
+    "name": "Loews Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LAB",
+    "name": "Standard BioTools Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LABT",
+    "name": "Lakewood-Amedex Biotherapeutics Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LAC",
+    "name": "Lithium Americas Corp. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "LAD",
+    "name": "Lithia Motors, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LADR",
+    "name": "Ladder Capital Corp Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LAES",
+    "name": "SEALSQ Corp - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "LAFA",
+    "name": "LaFayette Acquisition Corp. - Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "LAKE",
+    "name": "Lakeland Industries, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LAMR",
+    "name": "Lamar Advertising Company - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LAND",
+    "name": "Gladstone Land Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "LANV",
+    "name": "Lanvin Group Holdings Limited Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "LAR",
+    "name": "Lithium Argentina AG Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "LARK",
+    "name": "Landmark Bancorp Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LASE",
+    "name": "Laser Photonics Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "LASR",
+    "name": "nLIGHT, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LATA",
+    "name": "Galata Acquisition Corp. II - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "LAUR",
+    "name": "Laureate Education, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LAW",
+    "name": "CS Disco, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LAWR",
+    "name": "Robot Consulting Co., Ltd. - ADS",
+    "sector": null
+  },
+  {
+    "symbol": "LAZ",
+    "name": "Lazard, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LB",
+    "name": "LandBridge Company LLC Class A Shares Representing Limited Liability Company Interests",
+    "sector": null
+  },
+  {
+    "symbol": "LBGJ",
+    "name": "Li Bang International Corporation Inc. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "LBRDA",
+    "name": "Liberty Broadband Corporation - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LBRDK",
+    "name": "Liberty Broadband Corporation - Class C Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LBRT",
+    "name": "Liberty Energy Inc. Class A common stock",
+    "sector": null
+  },
+  {
+    "symbol": "LBRX",
+    "name": "LB Pharmaceuticals Inc",
+    "sector": null
+  },
+  {
+    "symbol": "LBTYA",
+    "name": "Liberty Global Ltd. - Class A Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "LBTYB",
+    "name": "Liberty Global Ltd. - Class B Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "LBTYK",
+    "name": "Liberty Global Ltd. - Class C Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "LC",
+    "name": "LendingClub Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LCCC",
+    "name": "Lakeshore Acquisition III Corp. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "LCFY",
+    "name": "Locafy Limited - Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "LCID",
+    "name": "Lucid Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LCII",
+    "name": "LCI Industries",
+    "sector": null
+  },
+  {
+    "symbol": "LCLN",
+    "name": "Lincoln International, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LCNB",
+    "name": "LCNB Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "LCTX",
+    "name": "Lineage Cell Therapeutics, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LCUT",
+    "name": "Lifetime Brands, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LDI",
+    "name": "loanDepot, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LDOS",
+    "name": "Leidos Holdings, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LE",
+    "name": "Lands' End, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LEA",
+    "name": "Lear Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LECO",
+    "name": "Lincoln Electric Holdings, Inc. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "LEDS",
+    "name": "SemiLEDS Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "LEE",
+    "name": "Lee Enterprises, Incorporated",
+    "sector": null
+  },
+  {
+    "symbol": "LEG",
+    "name": "Leggett & Platt, Incorporated Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LEGH",
+    "name": "Legacy Housing Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "LEGO",
+    "name": "Legato Merger Corp. IV Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "LEN",
+    "name": "Lennar Corporation Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LEN.B",
+    "name": "Lennar Corporation Class B",
+    "sector": null
+  },
+  {
+    "symbol": "LENZ",
+    "name": "LENZ Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LEO",
+    "name": "BNY Mellon Strategic Municipals, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LESL",
+    "name": "Leslie's, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LEU",
+    "name": "Centrus Energy Corp. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LEVI",
+    "name": "Levi Strauss & Co Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LEXX",
+    "name": "Lexaria Bioscience Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "LFAC",
+    "name": "Leapfrog Acquisition Corporation - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "LFCR",
+    "name": "Lifecore Biomedical, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LFMD",
+    "name": "LifeMD, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LFST",
+    "name": "LifeStance Health Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LFT",
+    "name": "Lument Finance Trust, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LFTO",
+    "name": "Liftoff Mobile, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LFUS",
+    "name": "Littelfuse, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LFVN",
+    "name": "Lifevantage Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "LFWD",
+    "name": "Lifeward Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "LGCL",
+    "name": "Lucas GC Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "LGCY",
+    "name": "Legacy Education Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LGI",
+    "name": "Lazard Global Total Return and Income Fund Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LGIH",
+    "name": "LGI Homes, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LGL",
+    "name": "LGL Group, Inc. (The) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LGN",
+    "name": "Legence Corp. - Class A Common stock",
+    "sector": null
+  },
+  {
+    "symbol": "LGND",
+    "name": "Ligand Pharmaceuticals Incorporated",
+    "sector": null
+  },
+  {
+    "symbol": "LGO",
+    "name": "Largo Inc. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "LGPS",
+    "name": "LogProstyle Inc. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "LGVN",
+    "name": "Longeveron Inc. - Class A Common stock",
+    "sector": null
+  },
+  {
+    "symbol": "LH",
+    "name": "Labcorp Holdings Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LHAI",
+    "name": "Linkhome Holdings Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LHSW",
+    "name": "Lianhe Sowell International Group Ltd - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "LHX",
+    "name": "L3Harris Technologies, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LICN",
+    "name": "Lichen International Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "LIDR",
+    "name": "AEye, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LIEN",
+    "name": "Chicago Atlantic BDC, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LIF",
+    "name": "Life360, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LIFE",
+    "name": "Ethos Technologies Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LII",
+    "name": "Lennox International, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LILA",
+    "name": "Liberty Latin America Ltd. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LILAK",
+    "name": "Liberty Latin America Ltd. - Class C Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LILAV",
+    "name": "Liberty Latin America Ltd. - Class A Common Stock Ex-Distribution When Issued",
+    "sector": null
+  },
+  {
+    "symbol": "LILKV",
+    "name": "Liberty Latin America Ltd. - Class C Common Stock Ex-Distribution When Issued",
+    "sector": null
+  },
+  {
+    "symbol": "LILPV",
+    "name": "Liberty Latin America Ltd. - 9.0% Fixed Rate Cumulative Perpetual Redeemable Series A Preference Shares",
+    "sector": null
+  },
+  {
+    "symbol": "LIMN",
+    "name": "Liminatus Pharma, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LIN",
+    "name": "Linde plc - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "LINC",
+    "name": "Lincoln Educational Services Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "LIND",
+    "name": "Lindblad Expeditions Holdings Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LINE",
+    "name": "Lineage, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LINK",
+    "name": "Interlink Electronics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LION",
+    "name": "Lionsgate Studios Corp Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "LIQT",
+    "name": "LiqTech International, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LITE",
+    "name": "Lumentum Holdings Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LITS",
+    "name": "Lite Strategy, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LIVE",
+    "name": "Live Ventures Incorporated",
+    "sector": null
+  },
+  {
+    "symbol": "LIVN",
+    "name": "LivaNova PLC - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "LIXT",
+    "name": "Lixte Biotechnology Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LKFN",
+    "name": "Lakeland Financial Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "LKQ",
+    "name": "LKQ Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "LKSP",
+    "name": "Lake Superior Acquisition Corp. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "LLY",
+    "name": "Eli Lilly and Company Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LLYVA",
+    "name": "Liberty Live Holdings, Inc. - Series A Liberty Live Group Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LLYVK",
+    "name": "Liberty Live Holdings, Inc. - Series C Liberty Live Group Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LMAT",
+    "name": "LeMaitre Vascular, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LMB",
+    "name": "Limbach Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LMFA",
+    "name": "LM Funding America, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LMND",
+    "name": "Lemonade, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LMNR",
+    "name": "Limoneira Co",
+    "sector": null
+  },
+  {
+    "symbol": "LMRI",
+    "name": "Lumexa Imaging Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LMT",
+    "name": "Lockheed Martin Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LNAI",
+    "name": "Lunai Bioworks Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LNC",
+    "name": "Lincoln National Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LND",
+    "name": "Brasilagro Brazilian Agric Real Estate Co Sponsored ADR (Brazil)",
+    "sector": null
+  },
+  {
+    "symbol": "LNG",
+    "name": "Cheniere Energy, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LNKS",
+    "name": "Linkers Industries Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "LNN",
+    "name": "Lindsay Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LNSR",
+    "name": "LENSAR, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LNT",
+    "name": "Alliant Energy Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "LNTH",
+    "name": "Lantheus Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LNZA",
+    "name": "LanzaTech Global, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LOAN",
+    "name": "Manhattan Bridge Capital, Inc",
+    "sector": null
+  },
+  {
+    "symbol": "LOAR",
+    "name": "Loar Holdings Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LOB",
+    "name": "Live Oak Bancshares, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LOBO",
+    "name": "LOBO TECHNOLOGIES LTD. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "LOCL",
+    "name": "Local Bounti Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LOCO",
+    "name": "El Pollo Loco Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LODE",
+    "name": "Comstock Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LOGI",
+    "name": "Logitech International S.A. - Registered Shares",
+    "sector": null
+  },
+  {
+    "symbol": "LOKV",
+    "name": "Live Oak Acquisition Corp. V - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "LOMA",
+    "name": "Loma Negra Compania Industrial Argentina Sociedad Anonima ADS",
+    "sector": null
+  },
+  {
+    "symbol": "LONA",
+    "name": "LeonaBio, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LOOP",
+    "name": "Loop Industries, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LOPE",
+    "name": "Grand Canyon Education, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LOVE",
+    "name": "The Lovesac Company",
+    "sector": null
+  },
+  {
+    "symbol": "LOW",
+    "name": "Lowe's Companies, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LPA",
+    "name": "Logistic Properties of the Americas Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "LPAA",
+    "name": "Launch One Acquisition Corp. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "LPBB",
+    "name": "Launch Two Acquisition Corp. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "LPCN",
+    "name": "Lipocine Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LPCV",
+    "name": "Launchpad Cadenza Acquisition Corp I - Class A Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "LPG",
+    "name": "Dorian LPG Ltd. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LPL",
+    "name": "LG Display Co, Ltd AMERICAN DEPOSITORY SHARES",
+    "sector": null
+  },
+  {
+    "symbol": "LPLA",
+    "name": "LPL Financial Holdings Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LPRO",
+    "name": "Open Lending Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "LPSN",
+    "name": "LivePerson, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LPTH",
+    "name": "LightPath Technologies, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LPX",
+    "name": "Louisiana-Pacific Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LQDA",
+    "name": "Liquidia Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "LQDT",
+    "name": "Liquidity Services, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LRCX",
+    "name": "Lam Research Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "LRHC",
+    "name": "La Rosa Holdings Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "LRMR",
+    "name": "Larimar Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LRN",
+    "name": "Stride, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LSAK",
+    "name": "Lesaka Technologies, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LSBK",
+    "name": "Lake Shore Bancorp, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LSCC",
+    "name": "Lattice Semiconductor Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "LSE",
+    "name": "Leishen Energy Holding Co., Ltd. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "LSF",
+    "name": "Laird Superfood, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LSH",
+    "name": "Lakeside Holding Limited",
+    "sector": null
+  },
+  {
+    "symbol": "LSPD",
+    "name": "Lightspeed Commerce Inc. Subordinate Voting Shares",
+    "sector": null
+  },
+  {
+    "symbol": "LSTA",
+    "name": "Lisata Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LSTR",
+    "name": "Landstar System, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LTBR",
+    "name": "Lightbridge Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "LTC",
+    "name": "LTC Properties, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LTH",
+    "name": "Life Time Group Holdings, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LTRN",
+    "name": "Lantern Pharma Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LTRX",
+    "name": "Lantronix, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LUCD",
+    "name": "Lucid Diagnostics Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LUCK",
+    "name": "Lucky Strike Entertainment Corporation Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LUCY",
+    "name": "Innovative Eyewear, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LUD",
+    "name": "Luda Technology Group Limited Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "LULU",
+    "name": "lululemon athletica inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LUMN",
+    "name": "Lumen Technologies, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LUNG",
+    "name": "Pulmonx Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "LUNR",
+    "name": "Intuitive Machines, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LUV",
+    "name": "Southwest Airlines Company Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LVLU",
+    "name": "Lulu's Fashion Lounge Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LVO",
+    "name": "LiveOne, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LVS",
+    "name": "Las Vegas Sands Corp. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LVWR",
+    "name": "LiveWire Group, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LW",
+    "name": "Lamb Weston Holdings, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LWAC",
+    "name": "LightWave Acquisition Corp. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "LWAY",
+    "name": "Lifeway Foods, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LWLG",
+    "name": "Lightwave Logic, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LXEO",
+    "name": "Lexeo Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LXFR",
+    "name": "Luxfer Holdings PLC Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "LXP",
+    "name": "LXP Industrial Trust Common Stock (Maryland REIT)",
+    "sector": null
+  },
+  {
+    "symbol": "LXRX",
+    "name": "Lexicon Pharmaceuticals, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LXU",
+    "name": "LSB Industries, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LYB",
+    "name": "LyondellBasell Industries NV Ordinary Shares Class A (Netherlands)",
+    "sector": null
+  },
+  {
+    "symbol": "LYEL",
+    "name": "Lyell Immunopharma, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LYFT",
+    "name": "Lyft, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LYTS",
+    "name": "LSI Industries Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LYV",
+    "name": "Live Nation Entertainment, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LZ",
+    "name": "LegalZoom.com, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "LZB",
+    "name": "La-Z-Boy Incorporated Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "LZM",
+    "name": "Lifezone Metals Limited Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "LZMH",
+    "name": "LZ Technology Holdings Limited - Class B Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "M",
+    "name": "Macy's Inc Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MA",
+    "name": "Mastercard Incorporated Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MAAS",
+    "name": "Maase Inc. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "MAC",
+    "name": "Macerich Company (The) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MACI",
+    "name": "Melar Acquisition Corp. I - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "MAGH",
+    "name": "Magnitude International Ltd - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "MAGN",
+    "name": "Magnera Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MAIA",
+    "name": "MAIA Biotechnology, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MAIN",
+    "name": "Main Street Capital Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MAIR",
+    "name": "Madison Air Solutions Corporation Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MAKO",
+    "name": "Mako Mining Corp",
+    "sector": null
+  },
+  {
+    "symbol": "MAMA",
+    "name": "Mama's Creations, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MAMK",
+    "name": "MaxsMaking Inc. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "MAMO",
+    "name": "Massimo Group",
+    "sector": null
+  },
+  {
+    "symbol": "MAN",
+    "name": "ManpowerGroup Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MANE",
+    "name": "Veradermics, Incorporated Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MANH",
+    "name": "Manhattan Associates, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MAR",
+    "name": "Marriott International - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MARA",
+    "name": "MARA Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MAS",
+    "name": "Masco Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MASK",
+    "name": "3 E Network Technology Group Ltd - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "MASS",
+    "name": "908 Devices Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MAT",
+    "name": "Mattel, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MATH",
+    "name": "Metalpha Technology Holding Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "MATV",
+    "name": "Mativ Holdings, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MATW",
+    "name": "Matthews International Corporation - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MATX",
+    "name": "Matson, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MAX",
+    "name": "MediaAlpha, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MAYS",
+    "name": "J. W. Mays, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MAZE",
+    "name": "Maze Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MB",
+    "name": "MasterBeef Group - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "MBAI",
+    "name": "Check-Cap Ltd. - Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "MBAV",
+    "name": "M3-Brigade Acquisition V Corp. - Class A Ordinary shares",
+    "sector": null
+  },
+  {
+    "symbol": "MBBC",
+    "name": "Marathon Bancorp, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MBC",
+    "name": "MasterBrand, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MBI",
+    "name": "MBIA Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MBIN",
+    "name": "Merchants Bancorp",
+    "sector": null
+  },
+  {
+    "symbol": "MBIO",
+    "name": "Mustang Bio, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MBLY",
+    "name": "Mobileye Global Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MBOT",
+    "name": "Microbot Medical Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MBRX",
+    "name": "Moleculin Biotech, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MBUU",
+    "name": "Malibu Boats, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MBVI",
+    "name": "M3-Brigade Acquisition VI Corp. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "MBWM",
+    "name": "Mercantile Bank Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "MBX",
+    "name": "MBX Biosciences, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MC",
+    "name": "Moelis & Company Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MCB",
+    "name": "Metropolitan Bank Holding Corp. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MCBS",
+    "name": "MetroCity Bankshares, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MCD",
+    "name": "McDonald's Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MCFT",
+    "name": "MasterCraft Boat Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MCGA",
+    "name": "Yorkville Acquisition Corp. - Class A Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "MCHB",
+    "name": "Mechanics Bancorp - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MCHP",
+    "name": "Microchip Technology Incorporated",
+    "sector": null
+  },
+  {
+    "symbol": "MCHX",
+    "name": "Marchex, Inc. - Class B Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MCI",
+    "name": "Barings Corporate Investors Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MCK",
+    "name": "McKesson Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MCN",
+    "name": "XAI Madison Equity Premium Income Fund Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "MCO",
+    "name": "Moody's Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MCR",
+    "name": "MFS Charter Income Trust Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MCRB",
+    "name": "Seres Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MCRI",
+    "name": "Monarch Casino & Resort, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MCRP",
+    "name": "Micropolis AI Robotics Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "MCS",
+    "name": "Marcus Corporation (The) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MCTA",
+    "name": "Charming Medical Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "MCY",
+    "name": "Mercury General Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MD",
+    "name": "Pediatrix Medical Group, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MDA",
+    "name": "MDA Space Ltd. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "MDAI",
+    "name": "Spectral AI, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MDB",
+    "name": "MongoDB, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MDBH",
+    "name": "MDB Capital Holdings, LLC - Class A common",
+    "sector": null
+  },
+  {
+    "symbol": "MDCX",
+    "name": "Medicus Pharma Ltd.",
+    "sector": null
+  },
+  {
+    "symbol": "MDGL",
+    "name": "Madrigal Pharmaceuticals, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MDIA",
+    "name": "Mediaco Holding Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MDLN",
+    "name": "Medline Inc. - Class A common stock",
+    "sector": null
+  },
+  {
+    "symbol": "MDLZ",
+    "name": "Mondelez International, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MDRR",
+    "name": "Medalist Diversified, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MDT",
+    "name": "Medtronic plc. Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "MDU",
+    "name": "MDU Resources Group, Inc. Common Stock (Holding Company)",
+    "sector": null
+  },
+  {
+    "symbol": "MDV",
+    "name": "Modiv Industrial, Inc. Class C Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MDWD",
+    "name": "MediWound Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "MDXG",
+    "name": "MiMedx Group, Inc",
+    "sector": null
+  },
+  {
+    "symbol": "MDXH",
+    "name": "MDxHealth SA - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "MEC",
+    "name": "Mayville Engineering Company, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MED",
+    "name": "MEDIFAST INC Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MEDP",
+    "name": "Medpace Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MEGI",
+    "name": "NYLI CBRE Global Infrastructure Megatrends Term Fund Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "MEGL",
+    "name": "Magic Empire Global Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "MEHA",
+    "name": "Functional Brands, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MEI",
+    "name": "Methode Electronics, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MELI",
+    "name": "MercadoLibre, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MENS",
+    "name": "Jyong Biotech Ltd. - Ordinary shares",
+    "sector": null
+  },
+  {
+    "symbol": "MEOH",
+    "name": "Methanex Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "MERC",
+    "name": "Mercer International Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MESH",
+    "name": "Meshflow Acquisition Corp. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "MET",
+    "name": "MetLife, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "META",
+    "name": "Meta Platforms, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "METC",
+    "name": "Ramaco Resources, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "METCB",
+    "name": "Ramaco Resources, Inc. - Class B Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MEVO",
+    "name": "M Evo Global Acquisition Corp II - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "MFA",
+    "name": "MFA Financial, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MFC",
+    "name": "Manulife Financial Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MFG",
+    "name": "Mizuho Financial Group, Inc. Sponosred ADR (Japan)",
+    "sector": null
+  },
+  {
+    "symbol": "MFI",
+    "name": "mF International Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "MFIC",
+    "name": "MidCap Financial Investment Corporation - Closed End Fund",
+    "sector": null
+  },
+  {
+    "symbol": "MFIN",
+    "name": "Medallion Financial Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "MFM",
+    "name": "Aberdeen Municipal Income Fund Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "MG",
+    "name": "Mistras Group Inc Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MGA",
+    "name": "Magna International, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MGEE",
+    "name": "MGE Energy Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MGF",
+    "name": "MFS Government Markets Income Trust Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MGIH",
+    "name": "Millennium Group International Holdings Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "MGLD",
+    "name": "The Marygold Companies, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MGM",
+    "name": "MGM Resorts International Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MGN",
+    "name": "Megan Holdings Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "MGNI",
+    "name": "Magnite, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MGNX",
+    "name": "MacroGenics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MGPI",
+    "name": "MGP Ingredients, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MGRC",
+    "name": "McGrath RentCorp",
+    "sector": null
+  },
+  {
+    "symbol": "MGRT",
+    "name": "Mega Fortune Company Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "MGRX",
+    "name": "Mangoceuticals, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MGTX",
+    "name": "MeiraGTx Holdings plc - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "MGX",
+    "name": "Metagenomi Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MGY",
+    "name": "Magnolia Oil & Gas Corporation Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MGYR",
+    "name": "Magyar Bancorp, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MH",
+    "name": "McGraw Hill, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MHD",
+    "name": "Blackrock MuniHoldings Fund, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MHF",
+    "name": "Western Asset Municipal High Income Fund, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MHH",
+    "name": "Mastech Digital, Inc Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MHK",
+    "name": "Mohawk Industries, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MHO",
+    "name": "M/I Homes, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MI",
+    "name": "NFT Limited Class A Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "MIAX",
+    "name": "Miami International Holdings, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MICC",
+    "name": "The Magnum Ice Cream Company N.V. Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "MIDD",
+    "name": "The Middleby Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "MIMI",
+    "name": "Mint Incorporation Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "MIN",
+    "name": "MFS Intermediate Income Trust Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MIND",
+    "name": "MIND Technology, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MINE",
+    "name": "Mayfair Gold Corp. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "MIR",
+    "name": "Mirion Technologies, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MIRA",
+    "name": "MIRA Pharmaceuticals, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MIRM",
+    "name": "Mirum Pharmaceuticals, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MIST",
+    "name": "Milestone Pharmaceuticals Inc. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "MITK",
+    "name": "Mitek Systems, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MITQ",
+    "name": "Moving iMage Technologies, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MITT",
+    "name": "TPG Mortgage Investment Trust, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MIY",
+    "name": "Blackrock MuniYield Michigan Quality Fund, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MKC",
+    "name": "McCormick & Company, Incorporated Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MKC.V",
+    "name": "McCormick & Company, Incorporated Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MKDW",
+    "name": "MKDWELL Tech Inc. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "MKL",
+    "name": "Markel Group Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MKLY",
+    "name": "McKinley Acquisition Corporation - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "MKSI",
+    "name": "MKS Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MKTW",
+    "name": "MarketWise, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MKTX",
+    "name": "MarketAxess Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MKZR",
+    "name": "MacKenzie Realty Capital, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MLAA",
+    "name": "Mountain Lake Acquisition Corp. II - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "MLAB",
+    "name": "Mesa Laboratories, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MLCI",
+    "name": "Mount Logan Capital Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MLEC",
+    "name": "Moolec Science SA - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "MLGO",
+    "name": "MicroAlgo, Inc. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "MLI",
+    "name": "Mueller Industries, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MLKN",
+    "name": "MillerKnoll, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MLM",
+    "name": "Martin Marietta Materials, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MLP",
+    "name": "Maui Land & Pineapple Company, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MLPB",
+    "name": "ETRACS Alerian MLP Infrastructure Index ETN Series B due April 2, 2040",
+    "sector": null
+  },
+  {
+    "symbol": "MLR",
+    "name": "Miller Industries, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MLSS",
+    "name": "Milestone Scientific, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MLTX",
+    "name": "MoonLake Immunotherapeutics - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "MLYS",
+    "name": "Mineralys Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MMA",
+    "name": "Mixed Martial Arts Group Limited Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "MMED",
+    "name": "MiniMed Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MMI",
+    "name": "Marcus & Millichap, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MMM",
+    "name": "3M Company Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MMS",
+    "name": "Maximus, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MMSI",
+    "name": "Merit Medical Systems, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MMT",
+    "name": "MFS Multimarket Income Trust Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MMTX",
+    "name": "Miluna Acquisition Corp - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "MMU",
+    "name": "Western Asset Managed Municipals Fund, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MMYT",
+    "name": "MakeMyTrip Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "MNDO",
+    "name": "MIND C.T.I. Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "MNDR",
+    "name": "Mobile-health Network Solutions - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "MNDY",
+    "name": "monday.com Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "MNKD",
+    "name": "MannKind Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "MNOV",
+    "name": "MediciNova, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MNPR",
+    "name": "Monopar Therapeutics Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MNRO",
+    "name": "Monro, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MNSB",
+    "name": "MainStreet Bancshares, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MNST",
+    "name": "Monster Beverage Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "MNTK",
+    "name": "Montauk Renewables, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MNTN",
+    "name": "MNTN, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MNTS",
+    "name": "Momentus Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MNY",
+    "name": "MoneyHero Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "MO",
+    "name": "Altria Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MOB",
+    "name": "Mobilicom Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "MOBI",
+    "name": "Mobia Medical, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MOBX",
+    "name": "Mobix Labs, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MOD",
+    "name": "Modine Manufacturing Company Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MODD",
+    "name": "Modular Medical, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MOG.A",
+    "name": "Moog Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MOG.B",
+    "name": "Moog Inc. Class B Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MOH",
+    "name": "Molina Healthcare Inc Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MORN",
+    "name": "Morningstar, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MOS",
+    "name": "Mosaic Company (The) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MOV",
+    "name": "Movado Group Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MOVE",
+    "name": "Corvex, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MP",
+    "name": "MP Materials Corp. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MPA",
+    "name": "Blackrock MuniYield Pennsylvania Quality Fund Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MPAA",
+    "name": "Motorcar Parts of America, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MPB",
+    "name": "Mid Penn Bancorp",
+    "sector": null
+  },
+  {
+    "symbol": "MPC",
+    "name": "Marathon Petroleum Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MPLT",
+    "name": "MapLight Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MPT",
+    "name": "Medical Properties Trust, Inc. common stock",
+    "sector": null
+  },
+  {
+    "symbol": "MPTI",
+    "name": "M-tron Industries, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MPU",
+    "name": "Mega Matrix Inc. Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "MPV",
+    "name": "Barings Participation Investors Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MPWR",
+    "name": "Monolithic Power Systems, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MQ",
+    "name": "Marqeta, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MQY",
+    "name": "Blackrock MuniYield Quality Fund, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MRAM",
+    "name": "Everspin Technologies, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MRBK",
+    "name": "Meridian Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "MRCY",
+    "name": "Mercury Systems Inc",
+    "sector": null
+  },
+  {
+    "symbol": "MRDN",
+    "name": "Meridian Holdings Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MRK",
+    "name": "Merck & Company, Inc. Common Stock (new)",
+    "sector": null
+  },
+  {
+    "symbol": "MRKR",
+    "name": "Marker Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MRLN",
+    "name": "Merlin, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MRNA",
+    "name": "Moderna, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MRNO",
+    "name": "Murano Global Investments PLC - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "MRP",
+    "name": "Millrose Properties, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MRSH",
+    "name": "Marsh Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MRT",
+    "name": "Marti Technologies, Inc. Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "MRTN",
+    "name": "Marten Transport, Ltd.",
+    "sector": null
+  },
+  {
+    "symbol": "MRVI",
+    "name": "Maravai LifeSciences Holdings, Inc. - Class A common stock",
+    "sector": null
+  },
+  {
+    "symbol": "MRVL",
+    "name": "Marvell Technology, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MRX",
+    "name": "Marex Group plc - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "MS",
+    "name": "Morgan Stanley Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MSA",
+    "name": "MSA Safety Incorporated Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MSAI",
+    "name": "MultiSensor AI Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MSB",
+    "name": "Mesabi Trust Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MSBI",
+    "name": "Midland States Bancorp, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MSCI",
+    "name": "MSCI Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MSD",
+    "name": "Morgan Stanley Emerging Markets Debt Fund, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MSDL",
+    "name": "Morgan Stanley Direct Lending Fund Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MSEX",
+    "name": "Middlesex Water Company",
+    "sector": null
+  },
+  {
+    "symbol": "MSFT",
+    "name": "Microsoft Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "MSGE",
+    "name": "Madison Square Garden Entertainment Corp. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MSGM",
+    "name": "Motorsport Games Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MSGS",
+    "name": "Madison Square Garden Sports Corp. Class A Common Stock (New)",
+    "sector": null
+  },
+  {
+    "symbol": "MSGY",
+    "name": "Masonglory Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "MSI",
+    "name": "Motorola Solutions, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MSIF",
+    "name": "MSC Income Fund, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MSLE",
+    "name": "Satellos Bioscience Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MSM",
+    "name": "MSC Industrial Direct Company, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MSN",
+    "name": "Emerson Radio Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MSS",
+    "name": "Maison Solutions Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MSTR",
+    "name": "Strategy Inc - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MSW",
+    "name": "Ming Shing Group Holdings Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "MT",
+    "name": "Arcelor Mittal NY Registry Shares NEW",
+    "sector": null
+  },
+  {
+    "symbol": "MTA",
+    "name": "Metalla Royalty & Streaming Ltd. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "MTAL",
+    "name": "Metals Acquisition Corp. II Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "MTB",
+    "name": "M&T Bank Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MTC",
+    "name": "MMTec, Inc. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "MTCH",
+    "name": "Match Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MTD",
+    "name": "Mettler-Toledo International, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MTDR",
+    "name": "Matador Resources Company Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MTEK",
+    "name": "Maris-Tech Ltd. - ordinary shares",
+    "sector": null
+  },
+  {
+    "symbol": "MTEN",
+    "name": "Mingteng International Corporation Inc. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "MTEX",
+    "name": "Mannatech, Incorporated",
+    "sector": null
+  },
+  {
+    "symbol": "MTG",
+    "name": "MGIC Investment Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MTH",
+    "name": "Meritage Homes Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MTN",
+    "name": "Vail Resorts, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MTNB",
+    "name": "Matinas Biopharma Holdings, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MTR",
+    "name": "Mesa Royalty Trust Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MTRN",
+    "name": "Materion Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "MTRX",
+    "name": "Matrix Service Company",
+    "sector": null
+  },
+  {
+    "symbol": "MTSI",
+    "name": "MACOM Technology Solutions Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MTUS",
+    "name": "Metallus Inc. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "MTVA",
+    "name": "MetaVia Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MTW",
+    "name": "Manitowoc Company, Inc. (The) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MTX",
+    "name": "Minerals Technologies Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MTZ",
+    "name": "MasTec, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MU",
+    "name": "Micron Technology, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MUA",
+    "name": "Blackrock MuniAssets Fund, Inc Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MUC",
+    "name": "Blackrock MuniHoldings California Quality Fund, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MUFG",
+    "name": "Mitsubishi UFJ Financial Group, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MUJ",
+    "name": "Blackrock MuniHoldings New Jersey Quality Fund, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MUR",
+    "name": "Murphy Oil Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MUSA",
+    "name": "Murphy USA Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MUX",
+    "name": "McEwen Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MUZE",
+    "name": "Muzero Acquisition Corp - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "MVBF",
+    "name": "MVB Financial Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "MVIS",
+    "name": "MicroVision, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MVST",
+    "name": "Microvast Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MWA",
+    "name": "MUELLER WATER PRODUCTS Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MWG",
+    "name": "Multi Ways Holdings Limited Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "MWH",
+    "name": "SOLV Energy, Inc. - Class A common stock",
+    "sector": null
+  },
+  {
+    "symbol": "MWYN",
+    "name": "Marwynn Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MX",
+    "name": "Magnachip Semiconductor Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MXC",
+    "name": "Mexco Energy Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MXCT",
+    "name": "MaxCyte, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MXE",
+    "name": "Mexico Equity and Income Fund, Inc. (The) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MXF",
+    "name": "Mexico Fund, Inc. (The) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MXL",
+    "name": "MaxLinear, Inc",
+    "sector": null
+  },
+  {
+    "symbol": "MYE",
+    "name": "Myers Industries, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MYFW",
+    "name": "First Western Financial, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MYGN",
+    "name": "Myriad Genetics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MYI",
+    "name": "Blackrock MuniYield Quality Fund III, Inc Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MYN",
+    "name": "Blackrock MuniYield New York Quality Fund, Inc.Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MYO",
+    "name": "Myomo Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MYPS",
+    "name": "PLAYSTUDIOS, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "MYRG",
+    "name": "MYR Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MYSE",
+    "name": "Myseum.AI, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MYSZ",
+    "name": "My Size, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "MYX",
+    "name": "Maywood Acquisition Corp. 2 - Class A Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "MZTI",
+    "name": "The Marzetti Company",
+    "sector": null
+  },
+  {
+    "symbol": "MZYX",
+    "name": "MOZAYYX Acquisition Corp. Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "NA",
+    "name": "Nano Labs Ltd - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "NABL",
+    "name": "N-able, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NAC",
+    "name": "Nuveen California Quality Municipal Income Fund",
+    "sector": null
+  },
+  {
+    "symbol": "NAD",
+    "name": "Nuveen Quality Municipal Income Fund Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NAGE",
+    "name": "Niagen Bioscience, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NAII",
+    "name": "Natural Alternatives International, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NAK",
+    "name": "Northern Dynasty Minerals, Ltd. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NAKA",
+    "name": "Nakamoto Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NAMM",
+    "name": "Namib Minerals - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "NAMS",
+    "name": "NewAmsterdam Pharma Company N.V. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "NAN",
+    "name": "Nuveen New York Quality Municipal Income Fund Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NAT",
+    "name": "Nordic American Tankers Limited Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NATH",
+    "name": "Nathan's Famous, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NATL",
+    "name": "NCR Atleos Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NATR",
+    "name": "Nature's Sunshine Products, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NAUT",
+    "name": "Nautilus Biotechnology, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NAVI",
+    "name": "Navient Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "NAVN",
+    "name": "Navan, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NAZ",
+    "name": "Nuveen Arizona Quality Municipal Income Fund Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NB",
+    "name": "NioCorp Developments Ltd.",
+    "sector": null
+  },
+  {
+    "symbol": "NBB",
+    "name": "Nuveen Taxable Municipal Income Fund Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "NBBK",
+    "name": "NB Bancorp, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NBH",
+    "name": "Neuberger Municipal Fund Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NBHC",
+    "name": "National Bank Holdings Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NBIS",
+    "name": "Nebius Group N.V. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "NBIX",
+    "name": "Neurocrine Biosciences, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NBN",
+    "name": "Northeast Bank",
+    "sector": null
+  },
+  {
+    "symbol": "NBR",
+    "name": "Nabors Industries Ltd.",
+    "sector": null
+  },
+  {
+    "symbol": "NBRG",
+    "name": "Newbridge Acquisition Limited - Class A Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "NBTB",
+    "name": "NBT Bancorp Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NBTX",
+    "name": "Nanobiotix S.A. - ADSs",
+    "sector": null
+  },
+  {
+    "symbol": "NBXG",
+    "name": "Neuberger Next Generation Connectivity Fund Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NC",
+    "name": "NACCO Industries, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NCA",
+    "name": "Nuveen California Municipal Value Fund",
+    "sector": null
+  },
+  {
+    "symbol": "NCDL",
+    "name": "Nuveen Churchill Direct Lending Corp. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NCEL",
+    "name": "NewcelX Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "NCEW",
+    "name": "New Century Logistics (BVI) Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "NCI",
+    "name": "Neo-Concept International Group Holdings Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "NCL",
+    "name": "Northann Corp. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NCLH",
+    "name": "Norwegian Cruise Line Holdings Ltd. Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "NCMI",
+    "name": "National CineMedia, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NCNO",
+    "name": "nCino, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NCPL",
+    "name": "Netcapital Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NCRA",
+    "name": "Nocera, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NCSM",
+    "name": "NCS Multistage Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NCT",
+    "name": "Intercont (Cayman) Limited - Class A Ordinary shares",
+    "sector": null
+  },
+  {
+    "symbol": "NCTY",
+    "name": "The9 Limited - American Depository Shares",
+    "sector": null
+  },
+  {
+    "symbol": "NCV",
+    "name": "Virtus Convertible & Income Fund Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "NCZ",
+    "name": "Virtus Convertible & Income Fund II Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "NDAQ",
+    "name": "Nasdaq, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NDLS",
+    "name": "Noodles & Company - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NDRA",
+    "name": "ENDRA Life Sciences Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NDSN",
+    "name": "Nordson Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "NE",
+    "name": "Noble Corporation plc A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "NEA",
+    "name": "Nuveen AMT-Free Quality Municipal Income Fund Common Shares of Beneficial Interest Par Value $.01",
+    "sector": null
+  },
+  {
+    "symbol": "NEE",
+    "name": "NextEra Energy, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NEGG",
+    "name": "Newegg Commerce, Inc. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "NEM",
+    "name": "Newmont Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "NEO",
+    "name": "NeoGenomics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NEOG",
+    "name": "Neogen Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "NEON",
+    "name": "Neonode Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NEOV",
+    "name": "NeoVolta Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NEPH",
+    "name": "Nephros, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NERV",
+    "name": "Minerva Neurosciences, Inc",
+    "sector": null
+  },
+  {
+    "symbol": "NET",
+    "name": "Cloudflare, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NEU",
+    "name": "NewMarket Corp Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NEUP",
+    "name": "Neuphoria Therapeutics Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NEWP",
+    "name": "New Pacific Metals Corp. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "NEWT",
+    "name": "NewtekOne, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NEXA",
+    "name": "Nexa Resources S.A. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "NEXM",
+    "name": "NexMetals Mining Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "NEXN",
+    "name": "Nexxen International Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "NEXR",
+    "name": "Nexera Technologies Ltd - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "NEXT",
+    "name": "NextDecade Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "NFBK",
+    "name": "Northfield Bancorp, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NFE",
+    "name": "New Fortress Energy Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NFG",
+    "name": "National Fuel Gas Company Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NFGC",
+    "name": "New Found Gold Corp Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "NFJ",
+    "name": "Virtus Dividend, Interest & Premium Strategy Fund Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "NFLX",
+    "name": "Netflix, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NG",
+    "name": "Novagold Resources Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NGEN",
+    "name": "NervGen Pharma Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "NGNE",
+    "name": "Neurogene Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NGS",
+    "name": "Natural Gas Services Group, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NGVC",
+    "name": "Natural Grocers by Vitamin Cottage, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NGVT",
+    "name": "Ingevity Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NHC",
+    "name": "National HealthCare Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NHI",
+    "name": "National Health Investors, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NHIC",
+    "name": "NewHold Investment Corp III - Class A Ordinary shares",
+    "sector": null
+  },
+  {
+    "symbol": "NHIV",
+    "name": "NewHold Investment Corp IV - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "NHP",
+    "name": "National Healthcare Properties, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NHS",
+    "name": "Neuberger High Yield Strategies Fund Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NHTC",
+    "name": "Natural Health Trends Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "NI",
+    "name": "NiSource Inc Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NIC",
+    "name": "Nicolet Bankshares Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NIE",
+    "name": "Virtus Equity & Convertible Income Fund Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "NIM",
+    "name": "Nuveen Select Maturities Municipal Fund Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NINE",
+    "name": "Nine Energy Service, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NIQ",
+    "name": "NIQ Global Intelligence plc Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "NIVF",
+    "name": "NewGenIvf Group Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "NIXX",
+    "name": "Nixxy, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NJR",
+    "name": "NewJersey Resources Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NKE",
+    "name": "Nike, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NKLR",
+    "name": "Terra Innovatum Global N.V. - Ordinary shares",
+    "sector": null
+  },
+  {
+    "symbol": "NKSH",
+    "name": "National Bankshares, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NKTR",
+    "name": "Nektar Therapeutics",
+    "sector": null
+  },
+  {
+    "symbol": "NKTX",
+    "name": "Nkarta, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NKX",
+    "name": "Nuveen California AMT-Free Quality Municipal Income Fund",
+    "sector": null
+  },
+  {
+    "symbol": "NL",
+    "name": "NLI Holdings, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NLOP",
+    "name": "Net Lease Office Properties Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "NLY",
+    "name": "Annaly Capital Management Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NMAI",
+    "name": "Nuveen Multi-Asset Income Fund Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "NMAX",
+    "name": "Newsmax, Inc. Class B Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NMFC",
+    "name": "New Mountain Finance Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "NMG",
+    "name": "Nouveau Monde Graphite Inc. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "NMI",
+    "name": "Nuveen Municipal Income Fund, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NMIH",
+    "name": "NMI Holdings Inc",
+    "sector": null
+  },
+  {
+    "symbol": "NML",
+    "name": "Neuberger Energy Infrastructure and Income Fund Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NMP",
+    "name": "NMP Acquisition Corp. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "NMRA",
+    "name": "Neumora Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NMRK",
+    "name": "Newmark Group, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NMS",
+    "name": "Nuveen Minnesota Quality Municipal Income Fund",
+    "sector": null
+  },
+  {
+    "symbol": "NMT",
+    "name": "Nuveen Massachusetts Quality Municipal Income Fund Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NMTC",
+    "name": "NeuroOne Medical Technologies Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "NN",
+    "name": "NextNav Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NNBR",
+    "name": "NN, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NNE",
+    "name": "Nano Nuclear Energy Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NNI",
+    "name": "Nelnet, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NNN",
+    "name": "NNN REIT, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NNNN",
+    "name": "Anbio Biotechnology - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "NNOX",
+    "name": "NANO-X IMAGING LTD - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "NNVC",
+    "name": "NanoViricides, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NNY",
+    "name": "Nuveen New York Municipal Value Fund Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NOA",
+    "name": "North American Construction Group Ltd. Common Shares (no par)",
+    "sector": null
+  },
+  {
+    "symbol": "NOC",
+    "name": "Northrop Grumman Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NODK",
+    "name": "NI Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NOEM",
+    "name": "CO2 Energy Transition Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "NOG",
+    "name": "Northern Oil and Gas, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NOMA",
+    "name": "NOMADAR Corp. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NOMD",
+    "name": "Nomad Foods Limited Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "NOV",
+    "name": "NOV Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NOVT",
+    "name": "Novanta Inc. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "NOW",
+    "name": "ServiceNow, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NP",
+    "name": "Neptune Insurance Holdings Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NPAC",
+    "name": "New Providence Acquisition Corp. III - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "NPB",
+    "name": "Northpointe Bancshares, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NPCE",
+    "name": "Neuropace, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NPCT",
+    "name": "Nuveen Core Plus Impact Fund Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "NPK",
+    "name": "National Presto Industries, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NPKI",
+    "name": "NPK International Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NPO",
+    "name": "Enpro Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NPT",
+    "name": "Texxon Holding Limited - Ordinary shares",
+    "sector": null
+  },
+  {
+    "symbol": "NPV",
+    "name": "Nuveen Virginia Quality Municipal Income Fund Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NPWR",
+    "name": "NET Power Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NRC",
+    "name": "NRC Health",
+    "sector": null
+  },
+  {
+    "symbol": "NRDS",
+    "name": "NerdWallet, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NRDY",
+    "name": "Nerdy Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NREF",
+    "name": "NexPoint Real Estate Finance, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NRG",
+    "name": "NRG Energy, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NRGV",
+    "name": "Energy Vault Holdings, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NRIM",
+    "name": "Northrim BanCorp Inc",
+    "sector": null
+  },
+  {
+    "symbol": "NRIX",
+    "name": "Nurix Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NRK",
+    "name": "Nuveen New York AMT-Free Quality Municipal Income Fund",
+    "sector": null
+  },
+  {
+    "symbol": "NRO",
+    "name": "Neuberger Real Estate Securities Income Fund Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NRP",
+    "name": "Natural Resource Partners LP Limited Partnership",
+    "sector": null
+  },
+  {
+    "symbol": "NRSN",
+    "name": "NeuroSense Therapeutics Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "NRT",
+    "name": "North European Oil Royality Trust Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NRXP",
+    "name": "NRX Pharmaceuticals, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NRXS",
+    "name": "Neuraxis, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NSA",
+    "name": "National Storage Affiliates Trust Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "NSC",
+    "name": "Norfolk Southern Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NSIT",
+    "name": "Insight Enterprises, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NSP",
+    "name": "Insperity, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NSPR",
+    "name": "InspireMD Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NSRX",
+    "name": "Nasus Pharma Ltd. Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "NSSC",
+    "name": "NAPCO Security Technologies, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NSTS",
+    "name": "NSTS Bancorp, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NSYS",
+    "name": "Nortech Systems Incorporated",
+    "sector": null
+  },
+  {
+    "symbol": "NTAP",
+    "name": "NetApp, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NTB",
+    "name": "Bank of N.T. Butterfield & Son Limited (The) Voting Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "NTCL",
+    "name": "NETCLASS TECHNOLOGY INC - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "NTCT",
+    "name": "NetScout Systems, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NTGR",
+    "name": "NETGEAR, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NTHI",
+    "name": "NeOnc Technologies Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NTIC",
+    "name": "Northern Technologies International Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "NTIP",
+    "name": "Network-1 Technologies, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NTLA",
+    "name": "Intellia Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NTNX",
+    "name": "Nutanix, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NTR",
+    "name": "Nutrien Ltd. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "NTRA",
+    "name": "Natera, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NTRB",
+    "name": "Nutriband Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NTRP",
+    "name": "NextTrip, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NTRS",
+    "name": "Northern Trust Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "NTSK",
+    "name": "Netskope, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NTST",
+    "name": "NetSTREIT Corp. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NTWK",
+    "name": "NETSOL Technologies Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NTWO",
+    "name": "Newbury Street II Acquisition Corp - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "NTZ",
+    "name": "Natuzzi, S.p.A.",
+    "sector": null
+  },
+  {
+    "symbol": "NU",
+    "name": "Nu Holdings Ltd. Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "NUAI",
+    "name": "New Era Energy & Digital, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NUCL",
+    "name": "Eagle Nuclear Energy Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "NUE",
+    "name": "Nucor Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NUS",
+    "name": "Nu Skin Enterprises, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NUTR",
+    "name": "Nusatrip Incorporated",
+    "sector": null
+  },
+  {
+    "symbol": "NUTX",
+    "name": "Nutex Health Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NUV",
+    "name": "Nuveen Municipal Value Fund, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NUVB",
+    "name": "Nuvation Bio Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NUVL",
+    "name": "Nuvalent, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NUW",
+    "name": "Nuveen AMT-Free Municipal Value Fund",
+    "sector": null
+  },
+  {
+    "symbol": "NUWE",
+    "name": "Nuwellis, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NVAX",
+    "name": "Novavax, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NVCR",
+    "name": "NovoCure Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "NVCT",
+    "name": "Nuvectis Pharma, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NVDA",
+    "name": "NVIDIA Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "NVEC",
+    "name": "NVE Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "NVG",
+    "name": "Nuveen AMT-Free Municipal Credit Income Fund",
+    "sector": null
+  },
+  {
+    "symbol": "NVGS",
+    "name": "Navigator Holdings Ltd. Ordinary Shares (Marshall Islands)",
+    "sector": null
+  },
+  {
+    "symbol": "NVMI",
+    "name": "Nova Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "NVNI",
+    "name": "Nvni Group Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "NVNO",
+    "name": "enVVeno Medical Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "NVO",
+    "name": "Novo Nordisk A/S Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NVR",
+    "name": "NVR, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NVRI",
+    "name": "Enviri Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NVS",
+    "name": "Novartis AG Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NVST",
+    "name": "Envista Holdings Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NVT",
+    "name": "nVent Electric plc Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "NVTS",
+    "name": "Navitas Semiconductor Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "NVVE",
+    "name": "Nuvve Holding Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "NVX",
+    "name": "NOVONIX Limited - American Depository Shares",
+    "sector": null
+  },
+  {
+    "symbol": "NWAX",
+    "name": "New America Acquisition I Corp. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NWBI",
+    "name": "Northwest Bancshares, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NWE",
+    "name": "NorthWestern Energy Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NWFL",
+    "name": "Norwood Financial Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "NWL",
+    "name": "Newell Brands Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NWN",
+    "name": "Northwest Natural Holding Company Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NWPX",
+    "name": "NWPX Infrastructure, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NWS",
+    "name": "News Corporation - Class B Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NWSA",
+    "name": "News Corporation - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NWTG",
+    "name": "Newton Golf Company, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NX",
+    "name": "Quanex Building Products Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NXB",
+    "name": "NextBoat Inc. Common Stcok",
+    "sector": null
+  },
+  {
+    "symbol": "NXDR",
+    "name": "Nextdoor Holdings, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NXDT",
+    "name": "NexPoint Diversified Real Estate Trust Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NXE",
+    "name": "Nexgen Energy Ltd. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "NXG",
+    "name": "NXG NextGen Infrastructure Income Fund Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "NXGL",
+    "name": "NexGel, Inc",
+    "sector": null
+  },
+  {
+    "symbol": "NXL",
+    "name": "Nexalin Technology, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NXP",
+    "name": "Nuveen Select Tax Free Income Portfolio Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NXPI",
+    "name": "NXP Semiconductors N.V.",
+    "sector": null
+  },
+  {
+    "symbol": "NXPL",
+    "name": "NextPlat Corp",
+    "sector": null
+  },
+  {
+    "symbol": "NXRT",
+    "name": "NexPoint Residential Trust, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NXST",
+    "name": "Nexstar Media Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NXT",
+    "name": "Nextpower Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NXTC",
+    "name": "NextCure, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NXTS",
+    "name": "Nexentis Technologies Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NXTT",
+    "name": "Next Technology Holding Inc. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "NXXT",
+    "name": "NextNRG, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NYAX",
+    "name": "Nayax Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "NYC",
+    "name": "American Strategic Investment Co. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NYT",
+    "name": "New York Times Company (The) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "NYXH",
+    "name": "Nyxoah SA - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "NZF",
+    "name": "Nuveen Municipal Credit Income Fund",
+    "sector": null
+  },
+  {
+    "symbol": "O",
+    "name": "Realty Income Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "OABI",
+    "name": "OmniAb, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "OACC",
+    "name": "Oaktree Acquisition Corp. III Life Sciences - Class A Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "OBA",
+    "name": "Oxley Bridge Acquisition Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "OBDC",
+    "name": "Blue Owl Capital Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "OBE",
+    "name": "Obsidian Energy Ltd. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "OBIO",
+    "name": "Orchestra BioMed Holdings, Inc. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "OBK",
+    "name": "Origin Bancorp, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "OBT",
+    "name": "Orange County Bancorp, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "OC",
+    "name": "Owens Corning Inc Common Stock New",
+    "sector": null
+  },
+  {
+    "symbol": "OCC",
+    "name": "Optical Cable Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "OCCI",
+    "name": "OFS Credit Company, Inc. - Closed End Fund",
+    "sector": null
+  },
+  {
+    "symbol": "OCFC",
+    "name": "OceanFirst Financial Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "OCG",
+    "name": "Oriental Culture Holding LTD - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "OCGN",
+    "name": "Ocugen, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "OCS",
+    "name": "Oculis Holding AG - Ordinary shares",
+    "sector": null
+  },
+  {
+    "symbol": "OCSL",
+    "name": "Oaktree Specialty Lending Corporation - Closed End Fund",
+    "sector": null
+  },
+  {
+    "symbol": "OCTV",
+    "name": "Octave Intelligence plc - Class B Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "OCUL",
+    "name": "Ocular Therapeutix, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ODC",
+    "name": "Oil-Dri Corporation Of America Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ODD",
+    "name": "ODDITY Tech Ltd. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ODFL",
+    "name": "Old Dominion Freight Line, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ODTX",
+    "name": "Odyssey Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ODV",
+    "name": "Osisko Development Corp. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ODYS",
+    "name": "Odysight.ai Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "OEC",
+    "name": "Orion S.A. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "OESX",
+    "name": "Orion Energy Systems, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "OFAL",
+    "name": "OFA Group - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "OFG",
+    "name": "OFG Bancorp Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "OFIX",
+    "name": "Orthofix Medical Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "OFLX",
+    "name": "Omega Flex, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "OFRM",
+    "name": "Once Upon a Farm, PBC Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "OFS",
+    "name": "OFS Capital Corporation - Closed End Fund",
+    "sector": null
+  },
+  {
+    "symbol": "OGC",
+    "name": "OceanaGold Corporation Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "OGE",
+    "name": "OGE Energy Corp Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "OGEN",
+    "name": "Oragenics Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "OGI",
+    "name": "Organigram Global Inc. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "OGN",
+    "name": "Organon & Co. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "OGS",
+    "name": "ONE Gas, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "OHAC",
+    "name": "Oceanhawk Acquisition Corp. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "OHI",
+    "name": "Omega Healthcare Investors, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "OI",
+    "name": "O-I Glass, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "OII",
+    "name": "Oceaneering International, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "OIM",
+    "name": "OneIM Acquisition Corp. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "OIO",
+    "name": "OIO Group - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "OIS",
+    "name": "Oil States International, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "OKE",
+    "name": "ONEOK, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "OKLO",
+    "name": "Oklo Inc. Class A common stock",
+    "sector": null
+  },
+  {
+    "symbol": "OKTA",
+    "name": "Okta, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "OKUR",
+    "name": "OnKure Therapeutics, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "OKYO",
+    "name": "OKYO Pharma Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "OLB",
+    "name": "The OLB Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "OLED",
+    "name": "Universal Display Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "OLLI",
+    "name": "Ollie's Bargain Outlet Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "OLMA",
+    "name": "Olema Pharmaceuticals, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "OLN",
+    "name": "Olin Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "OLOX",
+    "name": "Olenox Industries Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "OLP",
+    "name": "One Liberty Properties, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "OLPX",
+    "name": "Olaplex Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "OM",
+    "name": "Outset Medical, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "OMC",
+    "name": "Omnicom Group Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "OMCL",
+    "name": "Omnicell, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "OMDA",
+    "name": "Omada Health, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "OMER",
+    "name": "Omeros Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "OMEX",
+    "name": "Odyssey Marine Exploration, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "OMF",
+    "name": "OneMain Holdings, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "OMH",
+    "name": "Ohmyhome Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "OMSE",
+    "name": "OMS Energy Technologies Inc. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ON",
+    "name": "ON Semiconductor Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "ONB",
+    "name": "Old National Bancorp",
+    "sector": null
+  },
+  {
+    "symbol": "ONCH",
+    "name": "1RT Acquisition Corp. - Class A Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "ONCO",
+    "name": "Onconetix, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ONCY",
+    "name": "Oncolytics Biotech Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ONDS",
+    "name": "Ondas Inc",
+    "sector": null
+  },
+  {
+    "symbol": "ONEG",
+    "name": "OneConstruction Group Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ONEW",
+    "name": "OneWater Marine Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ONFO",
+    "name": "Onfolio Holdings Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ONIT",
+    "name": "Onity Group Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ONL",
+    "name": "Orion Properties Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ONMD",
+    "name": "OneMedNet Corp - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ONON",
+    "name": "On Holding AG Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ONT",
+    "name": "Onterris, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ONTO",
+    "name": "Onto Innovation Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "OOMA",
+    "name": "Ooma, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "OPAD",
+    "name": "Offerpad Solutions Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "OPAL",
+    "name": "OPAL Fuels Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "OPBK",
+    "name": "OP Bancorp",
+    "sector": null
+  },
+  {
+    "symbol": "OPCH",
+    "name": "Option Care Health, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "OPEN",
+    "name": "Opendoor Technologies Inc",
+    "sector": null
+  },
+  {
+    "symbol": "OPFI",
+    "name": "OppFi Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "OPHC",
+    "name": "OptimumBank Holdings, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "OPK",
+    "name": "Opko Health, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "OPLN",
+    "name": "OPENLANE, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "OPRT",
+    "name": "Oportun Financial Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "OPRX",
+    "name": "OptimizeRx Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "OPTH",
+    "name": "Optimi Health Corp. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "OPTT",
+    "name": "Ocean Power Technologies, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "OPTU",
+    "name": "Optimum Communications, Inc. Class A common stock",
+    "sector": null
+  },
+  {
+    "symbol": "OPTX",
+    "name": "Syntec Optics Holdings, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "OPXS",
+    "name": "Optex Systems Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "OPY",
+    "name": "Oppenheimer Holdings, Inc. Class A Common Stock (DE)",
+    "sector": null
+  },
+  {
+    "symbol": "OR",
+    "name": "OR Royalties Inc. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ORA",
+    "name": "Ormat Technologies, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ORBS",
+    "name": "Eightco Holdings Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ORC",
+    "name": "Orchid Island Capital, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ORCL",
+    "name": "Oracle Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ORGN",
+    "name": "Origin Materials, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ORGO",
+    "name": "Organogenesis Holdings Inc. - Class A",
+    "sector": null
+  },
+  {
+    "symbol": "ORI",
+    "name": "Old Republic International Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ORIC",
+    "name": "Oric Pharmaceuticals, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ORIO",
+    "name": "Orion Digital Corp. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ORIQ",
+    "name": "Origin Investment Corp I - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ORIS",
+    "name": "Oriental Rise Holdings Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ORKA",
+    "name": "Oruka Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ORKT",
+    "name": "Orangekloud Technology Inc. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ORLA",
+    "name": "Orla Mining Ltd. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ORLY",
+    "name": "O'Reilly Automotive, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ORMP",
+    "name": "Oramed Pharmaceuticals Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ORN",
+    "name": "Orion Group Holdings, Inc. Common",
+    "sector": null
+  },
+  {
+    "symbol": "ORRF",
+    "name": "Orrstown Financial Services, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "OSBC",
+    "name": "Old Second Bancorp, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "OSCR",
+    "name": "Oscar Health, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "OSG",
+    "name": "Octave Specialty Group, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "OSIS",
+    "name": "OSI Systems, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "OSK",
+    "name": "Oshkosh Corporation (Holding Company)Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "OSPN",
+    "name": "OneSpan Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "OSRH",
+    "name": "OSR Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "OSS",
+    "name": "One Stop Systems, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "OST",
+    "name": "Ostin Technology Group Co., Ltd. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "OSTX",
+    "name": "OS Therapies Incorporated Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "OSUR",
+    "name": "OraSure Technologies, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "OSW",
+    "name": "OneSpaWorld Holdings Limited - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "OTEX",
+    "name": "Open Text Corporation - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "OTF",
+    "name": "Blue Owl Technology Finance Corp. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "OTGA",
+    "name": "OTG Acquisition Corp. I - Class A Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "OTIS",
+    "name": "Otis Worldwide Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "OTLK",
+    "name": "Outlook Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "OTTR",
+    "name": "Otter Tail Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "OUST",
+    "name": "Ouster, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "OUT",
+    "name": "OUTFRONT Media Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "OVBC",
+    "name": "Ohio Valley Banc Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "OVID",
+    "name": "Ovid Therapeutics Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "OVLY",
+    "name": "Oak Valley Bancorp (CA)",
+    "sector": null
+  },
+  {
+    "symbol": "OVV",
+    "name": "Ovintiv Inc. (DE)",
+    "sector": null
+  },
+  {
+    "symbol": "OWL",
+    "name": "Blue Owl Capital Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "OWLS",
+    "name": "OBOOK Holdings Inc. - Class A Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "OWLT",
+    "name": "Owlet, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "OXBR",
+    "name": "Oxbridge Re Holdings Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "OXLC",
+    "name": "Oxford Lane Capital Corp. - Closed End Fund",
+    "sector": null
+  },
+  {
+    "symbol": "OXM",
+    "name": "Oxford Industries, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "OXSQ",
+    "name": "Oxford Square Capital Corp. - Closed End Fund",
+    "sector": null
+  },
+  {
+    "symbol": "OXY",
+    "name": "Occidental Petroleum Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "OYSE",
+    "name": "Oyster Enterprises II Acquisition Corp - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "OZK",
+    "name": "Bank OZK",
+    "sector": null
+  },
+  {
+    "symbol": "P",
+    "name": "Everpure, Inc. Class A common stock",
+    "sector": null
+  },
+  {
+    "symbol": "PAAC",
+    "name": "Proem Acquisition Corp I - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "PAAS",
+    "name": "Pan American Silver Corp. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PAC",
+    "name": "Grupo Aeroportuario Del Pacifico, S.A. B. de C.V. Grupo Aeroportuario Del Pacifico, S.A. de C.V. (each representing 10 Series B shares)",
+    "sector": null
+  },
+  {
+    "symbol": "PACB",
+    "name": "Pacific Biosciences of California, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PACH",
+    "name": "Pioneer Acquisition I Corp - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "PACK",
+    "name": "Ranpak Holdings Corp Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PACS",
+    "name": "PACS Group, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PAG",
+    "name": "Penske Automotive Group, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PAGP",
+    "name": "Plains GP Holdings, L.P. - Class A Shares representing limited partner interests",
+    "sector": null
+  },
+  {
+    "symbol": "PAGS",
+    "name": "PagSeguro Digital Ltd. Class A Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "PAHC",
+    "name": "Phibro Animal Health Corporation - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PAI",
+    "name": "Western Asset Investment Grade Income Fund Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PAII",
+    "name": "Pyrophyte Acquisition Corp. II Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "PAL",
+    "name": "Proficient Auto Logistics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PALI",
+    "name": "Palisade Bio, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PALO",
+    "name": "Paloma Acquisition Corp I - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "PAM",
+    "name": "Pampa Energia S.A.",
+    "sector": null
+  },
+  {
+    "symbol": "PAMT",
+    "name": "PAMT CORP",
+    "sector": null
+  },
+  {
+    "symbol": "PANL",
+    "name": "Pangaea Logistics Solutions Ltd.",
+    "sector": null
+  },
+  {
+    "symbol": "PANW",
+    "name": "Palo Alto Networks, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PAPL",
+    "name": "Pineapple Financial Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PAR",
+    "name": "PAR Technology Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PARK",
+    "name": "Park Dental Partners, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PARR",
+    "name": "Par Pacific Holdings, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PASG",
+    "name": "Passage Bio, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PASW",
+    "name": "Ping An Biomedical Co., Ltd. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "PATH",
+    "name": "UiPath, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PATK",
+    "name": "Patrick Industries, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PAVM",
+    "name": "PAVmed Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PAVS",
+    "name": "Paranovus Entertainment Technology Ltd. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "PAX",
+    "name": "Patria Investments Limited - Class A Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "PAXS",
+    "name": "PIMCO Access Income Fund Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "PAY",
+    "name": "Paymentus Holdings, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PAYC",
+    "name": "Paycom Software, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PAYO",
+    "name": "Payoneer Global Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PAYP",
+    "name": "PayPay Corporation - American Depository Shares",
+    "sector": null
+  },
+  {
+    "symbol": "PAYS",
+    "name": "Paysign, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PAYX",
+    "name": "Paychex, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PB",
+    "name": "Prosperity Bancshares, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PBA",
+    "name": "Pembina Pipeline Corp. Ordinary Shares (Canada)",
+    "sector": null
+  },
+  {
+    "symbol": "PBF",
+    "name": "PBF Energy Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PBFS",
+    "name": "Pioneer Bancorp, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PBH",
+    "name": "Prestige Consumer Healthcare Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PBHC",
+    "name": "Pathfinder Bancorp, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PBI",
+    "name": "Pitney Bowes Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PBK",
+    "name": "PowerBank Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "PBLS",
+    "name": "Parabilis Medicines, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PBM",
+    "name": "Psyence Biomedical Ltd. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "PBR",
+    "name": "Petroleo Brasileiro S.A. Petrobras ADS",
+    "sector": null
+  },
+  {
+    "symbol": "PBT",
+    "name": "Permian Basin Royalty Trust Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PBYI",
+    "name": "Puma Biotechnology Inc",
+    "sector": null
+  },
+  {
+    "symbol": "PC",
+    "name": "Premium Catering (Holdings) Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "PCAP",
+    "name": "ProCap Acquisition Corp - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "PCAR",
+    "name": "PACCAR Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PCB",
+    "name": "PCB Bancorp",
+    "sector": null
+  },
+  {
+    "symbol": "PCF",
+    "name": "High Income Securities Fund Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PCG",
+    "name": "Pacific Gas & Electric Co. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PCM",
+    "name": "PCM Fund, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PCN",
+    "name": "Pimco Corporate & Income Strategy Fund Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PCOR",
+    "name": "Procore Technologies, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PCQ",
+    "name": "PIMCO California Municipal Income Fund Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PCRX",
+    "name": "Pacira BioSciences, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PCSA",
+    "name": "Processa Pharmaceuticals, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PCSC",
+    "name": "Perceptive Capital Solutions Corp - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "PCT",
+    "name": "PureCycle Technologies, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PCTY",
+    "name": "Paylocity Holding Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "PCVX",
+    "name": "Vaxcyte, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PCYO",
+    "name": "Pure Cycle Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "PD",
+    "name": "PagerDuty, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PDCC",
+    "name": "Pearl Diver Credit Company Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PDEX",
+    "name": "Pro-Dex, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PDFS",
+    "name": "PDF Solutions, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PDI",
+    "name": "PIMCO Dynamic Income Fund Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PDLB",
+    "name": "Ponce Financial Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PDM",
+    "name": "Piedmont Realty Trust, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PDS",
+    "name": "Precision Drilling Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PDSB",
+    "name": "PDS Biotechnology Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "PDT",
+    "name": "John Hancock Premium Dividend Fund",
+    "sector": null
+  },
+  {
+    "symbol": "PDX",
+    "name": "PIMCO Dynamic Income Strategy Fund Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "PDYN",
+    "name": "Palladyne AI Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "PEB",
+    "name": "Pebblebrook Hotel Trust Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "PEBK",
+    "name": "Peoples Bancorp of North Carolina, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PEBO",
+    "name": "Peoples Bancorp Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PECE",
+    "name": "Peace Acquisition Corp - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "PECO",
+    "name": "Phillips Edison & Company, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PED",
+    "name": "Pedevco Corp. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PEG",
+    "name": "Public Service Enterprise Group Incorporated Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PEGA",
+    "name": "Pegasystems Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PEN",
+    "name": "Penumbra, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PENG",
+    "name": "Penguin Solutions, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PENN",
+    "name": "PENN Entertainment, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PEO",
+    "name": "Adams Natural Resources Fund, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PEP",
+    "name": "PepsiCo, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PEPG",
+    "name": "PepGen Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PERF",
+    "name": "Perfect Corp. Class A Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "PERI",
+    "name": "Perion Network Ltd - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "PESI",
+    "name": "Perma-Fix Environmental Services, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PETS",
+    "name": "PetMed Express, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PETZ",
+    "name": "TDH Holdings, Inc. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "PEW",
+    "name": "GrabAGun Digital Holdings Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PFAI",
+    "name": "Pinnacle Food Group Limited - Class A Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "PFE",
+    "name": "Pfizer, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PFG",
+    "name": "Principal Financial Group Inc",
+    "sector": null
+  },
+  {
+    "symbol": "PFGC",
+    "name": "Performance Food Group Company Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PFIS",
+    "name": "Peoples Financial Services Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "PFL",
+    "name": "PIMCO Income Strategy Fund Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "PFLT",
+    "name": "PennantPark Floating Rate Capital Ltd. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PFN",
+    "name": "PIMCO Income Strategy Fund II",
+    "sector": null
+  },
+  {
+    "symbol": "PFS",
+    "name": "Provident Financial Services, Inc Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PFSA",
+    "name": "Profusa, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PFSI",
+    "name": "PennyMac Financial Services, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PFX",
+    "name": "PhenixFIN Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "PG",
+    "name": "Procter & Gamble Company (The) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PGAC",
+    "name": "Pantages Capital Acquisition Corporation - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "PGC",
+    "name": "Peapack-Gladstone Financial Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "PGEN",
+    "name": "Precigen, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PGNY",
+    "name": "Progyny, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PGP",
+    "name": "Pimco Global StocksPlus & Income Fund Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "PGR",
+    "name": "Progressive Corporation (The) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PGY",
+    "name": "Pagaya Technologies Ltd. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "PGZ",
+    "name": "Principal Real Estate Income Fund Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "PH",
+    "name": "Parker-Hannifin Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PHAR",
+    "name": "Pharming Group N.V. - ADS, each representing 10 ordinary shares",
+    "sector": null
+  },
+  {
+    "symbol": "PHAT",
+    "name": "Phathom Pharmaceuticals, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PHG",
+    "name": "Koninklijke Philips N.V. NY Registry Shares",
+    "sector": null
+  },
+  {
+    "symbol": "PHGE",
+    "name": "BiomX Inc. COmmon Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PHI",
+    "name": "PLDT Inc. Sponsored ADR",
+    "sector": null
+  },
+  {
+    "symbol": "PHIN",
+    "name": "PHINIA Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PHIO",
+    "name": "Phio Pharmaceuticals Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "PHK",
+    "name": "Pimco High Income Fund",
+    "sector": null
+  },
+  {
+    "symbol": "PHM",
+    "name": "PulteGroup, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PHOE",
+    "name": "Phoenix Asia Holdings Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "PHR",
+    "name": "Phreesia, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PHUN",
+    "name": "Phunware, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PHVS",
+    "name": "Pharvaris N.V. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "PI",
+    "name": "Impinj, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PICS",
+    "name": "PicS N.V. - Class A Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "PII",
+    "name": "Polaris Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PIII",
+    "name": "P3 Health Partners Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PIM",
+    "name": "Putnam Master Intermediate Income Trust Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PINE",
+    "name": "Alpine Income Property Trust, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PINS",
+    "name": "Pinterest, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PIPR",
+    "name": "Piper Sandler Companies Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PJT",
+    "name": "PJT Partners Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PK",
+    "name": "Park Hotels & Resorts Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PKBK",
+    "name": "Parke Bancorp, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PKE",
+    "name": "Park Aerospace Corp. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PKG",
+    "name": "Packaging Corporation of America Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PKOH",
+    "name": "Park-Ohio Holdings Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "PL",
+    "name": "Planet Labs PBC Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PLAB",
+    "name": "Photronics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PLAG",
+    "name": "Planet Green Holdings Corp. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PLAY",
+    "name": "Dave & Buster's Entertainment, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PLBC",
+    "name": "Plumas Bancorp",
+    "sector": null
+  },
+  {
+    "symbol": "PLBL",
+    "name": "Polibeli Group Ltd - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "PLBY",
+    "name": "Playboy, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PLCE",
+    "name": "Children's Place, Inc. (The)",
+    "sector": null
+  },
+  {
+    "symbol": "PLD",
+    "name": "Prologis, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PLG",
+    "name": "Platinum Group Metals Ltd. Ordinary Shares (Canada)",
+    "sector": null
+  },
+  {
+    "symbol": "PLGO",
+    "name": "Pelagos Insurance Capital Limited Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "PLMK",
+    "name": "Plum Acquisition Corp. IV - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "PLMR",
+    "name": "Palomar Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PLNT",
+    "name": "Planet Fitness, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PLOW",
+    "name": "Douglas Dynamics, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PLPC",
+    "name": "Preformed Line Products Company",
+    "sector": null
+  },
+  {
+    "symbol": "PLRX",
+    "name": "Pliant Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PLRZ",
+    "name": "Polyrizon Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "PLSE",
+    "name": "Pulse Biosciences, Inc",
+    "sector": null
+  },
+  {
+    "symbol": "PLSM",
+    "name": "Pulsenmore Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "PLTK",
+    "name": "Playtika Holding Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "PLTR",
+    "name": "Palantir Technologies Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PLTS",
+    "name": "Platinum Analytics Cayman Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "PLUG",
+    "name": "Plug Power, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PLUR",
+    "name": "Pluri Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PLUS",
+    "name": "ePlus inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PLUT",
+    "name": "Plutus Financial Group Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "PLX",
+    "name": "Protalix BioTherapeutics, Inc. (DE) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PLXS",
+    "name": "Plexus Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "PLYX",
+    "name": "Polaryx Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PM",
+    "name": "Philip Morris International Inc Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PMAX",
+    "name": "Powell Max Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "PMCB",
+    "name": "PharmaCyte Biotech, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PMEC",
+    "name": "Primech Holdings Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "PMI",
+    "name": "Picard Medical, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PML",
+    "name": "Pimco Municipal Income Fund II Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "PMM",
+    "name": "Putnam Managed Municipal Income Trust Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PMN",
+    "name": "ProMIS Neurosciences Inc. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "PMNT",
+    "name": "Perfect Moment Ltd. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PMT",
+    "name": "PennyMac Mortgage Investment Trust Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "PMTR",
+    "name": "Perimeter Acquisition Corp. I - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "PMTS",
+    "name": "CPI Card Group Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PMVP",
+    "name": "PMV Pharmaceuticals, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PN",
+    "name": "Skycorp Solar Group Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "PNBK",
+    "name": "Patriot National Bancorp Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PNC",
+    "name": "PNC Financial Services Group, Inc. (The) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PNFP",
+    "name": "Pinnacle Financial Partners, Inc. Common stock",
+    "sector": null
+  },
+  {
+    "symbol": "PNI",
+    "name": "Pimco New York Municipal Income Fund II Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "PNNT",
+    "name": "PennantPark Investment Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PNR",
+    "name": "Pentair plc. Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "PNRG",
+    "name": "PrimeEnergy Resources Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "PNTG",
+    "name": "The Pennant Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PNW",
+    "name": "Pinnacle West Capital Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "POAS",
+    "name": "Phaos Technology Holdings (Cayman) Limited Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "POCI",
+    "name": "Precision Optics Corporation, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PODC",
+    "name": "PodcastOne, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PODD",
+    "name": "Insulet Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "POET",
+    "name": "POET Technologies Inc. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "POLA",
+    "name": "Polar Power, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "POLE",
+    "name": "Andretti Acquisition Corp. II - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "PONO",
+    "name": "Pono Capital Four, Inc. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "POOL",
+    "name": "Pool Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "POR",
+    "name": "Portland General Electric Co Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "POST",
+    "name": "Post Holdings, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "POWI",
+    "name": "Power Integrations, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "POWL",
+    "name": "Powell Industries, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "POWW",
+    "name": "Outdoor Holding Company",
+    "sector": null
+  },
+  {
+    "symbol": "PPC",
+    "name": "Pilgrim's Pride Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "PPCB",
+    "name": "Propanc Biopharma, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PPG",
+    "name": "PPG Industries, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PPHC",
+    "name": "Public Policy Holding Company, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PPIH",
+    "name": "Perma-Pipe International Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PPL",
+    "name": "PPL Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PPLI",
+    "name": "People Incorporated",
+    "sector": null
+  },
+  {
+    "symbol": "PPSI",
+    "name": "Pioneer Power Solutions, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PPT",
+    "name": "Putnam Premier Income Trust Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PPTA",
+    "name": "Perpetua Resources Corp. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "PR",
+    "name": "Permian Resources Corporation Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PRA",
+    "name": "ProAssurance Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PRAA",
+    "name": "PRA Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PRAX",
+    "name": "Praxis Precision Medicines, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PRCH",
+    "name": "Porch Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PRCT",
+    "name": "PROCEPT BioRobotics Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "PRDO",
+    "name": "Perdoceo Education Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "PRE",
+    "name": "Prenetics Global Limited - Class A Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "PRFX",
+    "name": "PRF Technologies Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "PRG",
+    "name": "PROG Holdings, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PRGO",
+    "name": "Perrigo Company plc Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "PRGS",
+    "name": "Progress Software Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "PRHI",
+    "name": "Presurance Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PRI",
+    "name": "Primerica, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PRIM",
+    "name": "Primoris Services Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PRK",
+    "name": "Park National Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PRLB",
+    "name": "Proto Labs, Inc. Common stock",
+    "sector": null
+  },
+  {
+    "symbol": "PRLD",
+    "name": "Prelude Therapeutics Incorporated",
+    "sector": null
+  },
+  {
+    "symbol": "PRM",
+    "name": "Perimeter Solutions, SA Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PRMB",
+    "name": "Primo Brands Corporation Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PRME",
+    "name": "Prime Medicine, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PROF",
+    "name": "Profound Medical Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "PROK",
+    "name": "ProKidney Corp. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "PROP",
+    "name": "Prairie Operating Co.",
+    "sector": null
+  },
+  {
+    "symbol": "PROV",
+    "name": "Provident Financial Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PRPL",
+    "name": "Purple Innovation, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PRPO",
+    "name": "Precipio, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PRQR",
+    "name": "ProQR Therapeutics N.V. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "PRSO",
+    "name": "Peraso Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PRSU",
+    "name": "Pursuit Attractions and Hospitality, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PRTA",
+    "name": "Prothena Corporation plc - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "PRTH",
+    "name": "Priority Technology Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PRTS",
+    "name": "CarParts.com, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PRU",
+    "name": "Prudential Financial, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PRVA",
+    "name": "Privia Health Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PRZO",
+    "name": "ParaZero Technologies Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "PS",
+    "name": "Pershing Square Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PSA",
+    "name": "Public Storage Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PSBD",
+    "name": "Palmer Square Capital BDC Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PSEC",
+    "name": "Prospect Capital Corporation - Closed End Fund",
+    "sector": null
+  },
+  {
+    "symbol": "PSFE",
+    "name": "Paysafe Limited Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "PSHG",
+    "name": "Performance Shipping Inc. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "PSIG",
+    "name": "PS International Group Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "PSIX",
+    "name": "Power Solutions International, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PSKY",
+    "name": "Paramount Skydance Corporation - Class B Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PSMT",
+    "name": "PriceSmart, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PSN",
+    "name": "Parsons Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PSNL",
+    "name": "Personalis, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PSNY",
+    "name": "Polestar Automotive Holding UK Limited - Class A ADS",
+    "sector": null
+  },
+  {
+    "symbol": "PSNYW",
+    "name": "Polestar Automotive Holding UK Limited - Class C-1 ADS (ADW)",
+    "sector": null
+  },
+  {
+    "symbol": "PSO",
+    "name": "Pearson, Plc Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PSQH",
+    "name": "PSQ Holdings, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PSTL",
+    "name": "Postal Realty Trust, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PSTV",
+    "name": "PLUS THERAPEUTICS, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PSUS",
+    "name": "Pershing Square USA, Ltd. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "PSX",
+    "name": "Phillips 66 Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PTC",
+    "name": "PTC Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PTCT",
+    "name": "PTC Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PTEN",
+    "name": "Patterson-UTI Energy, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PTGX",
+    "name": "Protagonist Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PTHS",
+    "name": "Pelthos Therapeutics Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PTLE",
+    "name": "PTL LTD - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "PTLO",
+    "name": "Portillo's Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PTN",
+    "name": "Palatin Technologies, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PTNM",
+    "name": "Pitanium Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "PTON",
+    "name": "Peloton Interactive, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PTOR",
+    "name": "Praetorian Acquisition Corp. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "PTRN",
+    "name": "Pattern Group Inc. - Series A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PUBM",
+    "name": "PubMatic, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PUK",
+    "name": "Prudential Public Limited Company Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PULM",
+    "name": "Pulmatrix, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PUMP",
+    "name": "ProPetro Holding Corp. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PURR",
+    "name": "Hyperliquid Strategies Inc",
+    "sector": null
+  },
+  {
+    "symbol": "PUSA",
+    "name": "Aureus Greenway Holdings Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PVH",
+    "name": "PVH Corp. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PVLA",
+    "name": "Palvella Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PW",
+    "name": "Power REIT (MD) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PWP",
+    "name": "Perella Weinberg Partners - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PWR",
+    "name": "Quanta Services, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PWRL",
+    "name": "Powerlaw Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "PXED",
+    "name": "Phoenix Education Partners, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PXLW",
+    "name": "Pixelworks, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PXS",
+    "name": "Pyxis Tankers Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PYPD",
+    "name": "PolyPid Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "PYPL",
+    "name": "PayPal Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PYT",
+    "name": "PPlus Tr GSC-2 Tr Ctf Fltg Rate",
+    "sector": null
+  },
+  {
+    "symbol": "PYXS",
+    "name": "Pyxis Oncology, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "PZG",
+    "name": "Paramount Gold Nevada Corp. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "PZZA",
+    "name": "Papa John's International, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "Q",
+    "name": "Qnity Electronics, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "QADR",
+    "name": "QDRO Acquisition Corp. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "QBTS",
+    "name": "D-Wave Quantum Inc. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "QCLS",
+    "name": "Q/C Technologies, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "QCOM",
+    "name": "QUALCOMM Incorporated",
+    "sector": null
+  },
+  {
+    "symbol": "QCRH",
+    "name": "QCR Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "QDEL",
+    "name": "QuidelOrtho Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "QETA",
+    "name": "Quetta Acquisition Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "QGEN",
+    "name": "Qiagen N.V. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "QH",
+    "name": "Quhuo Limited - American Depository Shares",
+    "sector": null
+  },
+  {
+    "symbol": "QLYS",
+    "name": "Qualys, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "QMCO",
+    "name": "Quantum Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "QMMM",
+    "name": "QMMM Holdings Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "QNC",
+    "name": "Quantum eMotion Corp. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "QNCX",
+    "name": "Quince Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "QNST",
+    "name": "QuinStreet, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "QNT",
+    "name": "Quantinuum Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "QNTM",
+    "name": "Quantum Biopharma Ltd. - Class B Subordinate Voting Shares",
+    "sector": null
+  },
+  {
+    "symbol": "QQQX",
+    "name": "Nuveen NASDAQ 100 Dynamic Overwrite Fund - Closed End Fund",
+    "sector": null
+  },
+  {
+    "symbol": "QRED",
+    "name": "QuasarEdge Acquisition Corporation Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "QRHC",
+    "name": "Quest Resource Holding Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "QRVO",
+    "name": "Qorvo, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "QS",
+    "name": "QuantumScape Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "QSEA",
+    "name": "Quartzsea Acquisition Corporation - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "QSI",
+    "name": "Quantum-Si Incorporated - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "QSR",
+    "name": "Restaurant Brands International Inc. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "QTEX",
+    "name": "QTREX Quantum Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "QTI",
+    "name": "QT Imaging Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "QTRX",
+    "name": "Quanterix Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "QTTB",
+    "name": "Q32 Bio Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "QTWO",
+    "name": "Q2 Holdings, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "QUAD",
+    "name": "Quad Graphics, Inc Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "QUBT",
+    "name": "Quantum Computing Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "QUCY",
+    "name": "Quantum Cyber N.V. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "QUIK",
+    "name": "QuickLogic Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "QUMS",
+    "name": "Quantumsphere Acquisition Corp. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "QURE",
+    "name": "uniQure N.V. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "QXL",
+    "name": "Quantum X Labs Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "QXO",
+    "name": "QXO, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "R",
+    "name": "Ryder System, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RA",
+    "name": "Brookfield Real Assets Income Fund Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RAAQ",
+    "name": "Real Asset Acquisition Corp. - Class A Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "RAC",
+    "name": "Rithm Acquisition Corp. Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "RACC",
+    "name": "Research Alliance Corporation III - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "RACE",
+    "name": "Ferrari N.V. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "RAIL",
+    "name": "Freightcar America, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "RAIN",
+    "name": "Rain Enhancement Technologies Holdco, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RAL",
+    "name": "Ralliant Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RAMP",
+    "name": "LiveRamp Holdings, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RAND",
+    "name": "Rand Capital Corporation - Closed End Fund",
+    "sector": null
+  },
+  {
+    "symbol": "RANG",
+    "name": "Range Capital Acquisition Corp. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "RANI",
+    "name": "Rani Therapeutics Holdings, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RAPP",
+    "name": "Rapport Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "RARE",
+    "name": "Ultragenyx Pharmaceutical Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "RAVE",
+    "name": "Rave Restaurant Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "RAY",
+    "name": "Raytech Holding Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "RAYA",
+    "name": "Erayak Power Solution Group Inc. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "RBA",
+    "name": "RB Global, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RBB",
+    "name": "RBB Bancorp",
+    "sector": null
+  },
+  {
+    "symbol": "RBBN",
+    "name": "Ribbon Communications Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "RBC",
+    "name": "RBC Bearings Incorporated Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RBCAA",
+    "name": "Republic Bancorp, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RBKB",
+    "name": "Rhinebeck Bancorp, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "RBLX",
+    "name": "Roblox Corporation Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RBNE",
+    "name": "Robin Energy Ltd.",
+    "sector": null
+  },
+  {
+    "symbol": "RBRK",
+    "name": "Rubrik, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RC",
+    "name": "Ready Capital Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RCAT",
+    "name": "Red Cat Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "RCEL",
+    "name": "Avita Medical, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "RCG",
+    "name": "RENN Fund, Inc Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RCI",
+    "name": "Rogers Communication, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RCKT",
+    "name": "Rocket Pharmaceuticals, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "RCKY",
+    "name": "Rocky Brands, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "RCL",
+    "name": "Royal Caribbean Cruises Ltd. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RCMT",
+    "name": "RCM Technologies, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "RCON",
+    "name": "Recon Technology, Ltd. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "RCS",
+    "name": "PIMCO Strategic Income Fund, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "RCT",
+    "name": "RedCloud Holdings plc - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "RCUS",
+    "name": "Arcus Biosciences, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RDAC",
+    "name": "Rising Dragon Acquisition Corp. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "RDAG",
+    "name": "Republic Digital Acquisition Company - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "RDCM",
+    "name": "Radcom Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "RDDT",
+    "name": "Reddit, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RDGT",
+    "name": "Ridgetech, Inc. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "RDI",
+    "name": "Reading International Inc - Class A Non-voting Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RDIB",
+    "name": "Reading International Inc - Class B Voting Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RDN",
+    "name": "Radian Group Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RDNT",
+    "name": "RadNet, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "RDNW",
+    "name": "RideNow Group, Inc. - Class B Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RDVT",
+    "name": "Red Violet, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "RDW",
+    "name": "Redwire Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RDWR",
+    "name": "Radware Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "RDY",
+    "name": "Dr. Reddy's Laboratories Ltd Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RDZN",
+    "name": "Roadzen, Inc. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "REA",
+    "name": "Rare Earths Americas, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "REAL",
+    "name": "The RealReal, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "REAX",
+    "name": "The Real Brokerage, Inc. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "REBN",
+    "name": "Reborn Coffee, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "RECT",
+    "name": "Rectitude Holdings Ltd - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "REE",
+    "name": "REE Automotive Ltd. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "REED",
+    "name": "Reed's, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "REFI",
+    "name": "Chicago Atlantic Real Estate Finance, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "REFR",
+    "name": "Research Frontiers Incorporated",
+    "sector": null
+  },
+  {
+    "symbol": "REG",
+    "name": "Regency Centers Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "REGN",
+    "name": "Regeneron Pharmaceuticals, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "REI",
+    "name": "Ring Energy, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "REKR",
+    "name": "Rekor Systems, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "RELL",
+    "name": "Richardson Electronics, Ltd.",
+    "sector": null
+  },
+  {
+    "symbol": "RELY",
+    "name": "Remitly Global, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "RENT",
+    "name": "Rent the Runway, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RENX",
+    "name": "RenX Enterprises Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "REPL",
+    "name": "Replimune Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "REPX",
+    "name": "Riley Exploration Permian, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RES",
+    "name": "RPC, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RETO",
+    "name": "ReTo Eco-Solutions, Inc. - Class A Shares",
+    "sector": null
+  },
+  {
+    "symbol": "REVB",
+    "name": "Revelation Biosciences, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "REX",
+    "name": "REX American Resources Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "REXR",
+    "name": "Rexford Industrial Realty, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "REYN",
+    "name": "Reynolds Consumer Products Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "REZI",
+    "name": "Resideo Technologies, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RF",
+    "name": "Regions Financial Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RFAI",
+    "name": "RF Acquisition Corp II - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "RFAM",
+    "name": "RF Acquisition Corp III - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "RFI",
+    "name": "Cohen & Steers Total Return Realty Fund, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RFIL",
+    "name": "RF Industries, Ltd.",
+    "sector": null
+  },
+  {
+    "symbol": "RFL",
+    "name": "Rafael Holdings, Inc. Class B Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RFM",
+    "name": "RiverNorth Flexible Municipal Income Fund, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RFMZ",
+    "name": "RiverNorth Flexible Municipal Income Fund II, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RGA",
+    "name": "Reinsurance Group of America, Incorporated Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RGC",
+    "name": "Regencell Bioscience Holdings Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "RGCO",
+    "name": "RGC Resources Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "RGEN",
+    "name": "Repligen Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "RGLD",
+    "name": "Royal Gold, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "RGNT",
+    "name": "Regentis Biomaterials Ltd. Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "RGNX",
+    "name": "REGENXBIO Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "RGP",
+    "name": "Resources Connection, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "RGR",
+    "name": "Sturm, Ruger & Company, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RGS",
+    "name": "Regis Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "RGT",
+    "name": "Royce Global Trust, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RGTI",
+    "name": "Rigetti Computing, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "RH",
+    "name": "RH Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RHI",
+    "name": "Robert Half Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RHLD",
+    "name": "Resolute Holdings Management Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RHP",
+    "name": "Ryman Hospitality Properties, Inc. (REIT)",
+    "sector": null
+  },
+  {
+    "symbol": "RIBB",
+    "name": "Ribbon Acquisition Corp - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "RICK",
+    "name": "RCI Hospitality Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "RIG",
+    "name": "Transocean Ltd (Switzerland) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RIGL",
+    "name": "Rigel Pharmaceuticals, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "RILY",
+    "name": "BRC Group Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "RIME",
+    "name": "Algorhythm Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "RIO",
+    "name": "Rio Tinto Plc Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RIOT",
+    "name": "Riot Platforms, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "RITM",
+    "name": "Rithm Capital Corp. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RITR",
+    "name": "Reitar Logtech Holdings Limited - Ordinary shares",
+    "sector": null
+  },
+  {
+    "symbol": "RIVN",
+    "name": "Rivian Automotive, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RJET",
+    "name": "Republic Airways Holdings Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "RJF",
+    "name": "Raymond James Financial, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RKDA",
+    "name": "Arcadia Biosciences, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "RKLB",
+    "name": "Rocket Lab Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "RKT",
+    "name": "Rocket Companies, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RKTO",
+    "name": "Rocket One Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "RL",
+    "name": "Ralph Lauren Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RLAY",
+    "name": "Relay Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "RLGT",
+    "name": "Radiant Logistics, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RLI",
+    "name": "RLI Corp. Common Stock (DE)",
+    "sector": null
+  },
+  {
+    "symbol": "RLJ",
+    "name": "RLJ Lodging Trust Common Shares of Beneficial Interest $0.01 par value",
+    "sector": null
+  },
+  {
+    "symbol": "RLMD",
+    "name": "Relmada Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "RLYB",
+    "name": "Rallybio Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "RM",
+    "name": "Regional Management Corp. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RMAX",
+    "name": "RE/MAX Holdings, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RMBI",
+    "name": "Richmond Mutual Bancorporation, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "RMBS",
+    "name": "Rambus, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "RMCF",
+    "name": "Rocky Mountain Chocolate Factory, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "RMCO",
+    "name": "Royalty Management Holding Corporation - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RMD",
+    "name": "ResMed Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RMI",
+    "name": "RiverNorth Opportunistic Municipal Income Fund, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RMIX",
+    "name": "Suncrete, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RMM",
+    "name": "RiverNorth Managed Duration Municipal Income Fund, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RMMZ",
+    "name": "RiverNorth Managed Duration Municipal Income Fund II, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RMNI",
+    "name": "Rimini Street, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "RMR",
+    "name": "The RMR Group Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RMSG",
+    "name": "Real Messenger Corporation - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "RMT",
+    "name": "Royce Micro-Cap Trust, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RMTI",
+    "name": "Rockwell Medical, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "RNA",
+    "name": "Atrium Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "RNAC",
+    "name": "Cartesian Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "RNAZ",
+    "name": "TransCode Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "RNG",
+    "name": "RingCentral, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RNGR",
+    "name": "Ranger Energy Services, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RNGT",
+    "name": "Range Capital Acquisition Corp II - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "RNR",
+    "name": "RenaissanceRe Holdings Ltd. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RNST",
+    "name": "Renasant Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RNTX",
+    "name": "Rein Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "RNW",
+    "name": "ReNew Energy Global plc - Class A Shares",
+    "sector": null
+  },
+  {
+    "symbol": "RNXT",
+    "name": "RenovoRx, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ROAD",
+    "name": "Construction Partners, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ROC",
+    "name": "Rank One Computing Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "ROCK",
+    "name": "Gibraltar Industries, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ROG",
+    "name": "Rogers Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ROIV",
+    "name": "Roivant Sciences Ltd. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ROK",
+    "name": "Rockwell Automation, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ROKU",
+    "name": "Roku, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ROL",
+    "name": "Rollins, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ROLR",
+    "name": "High Roller Technologies, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ROMA",
+    "name": "Roma Green Finance Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ROOT",
+    "name": "Root, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ROP",
+    "name": "Roper Technologies, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ROST",
+    "name": "Ross Stores, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "RPAY",
+    "name": "Repay Holdings Corporation - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RPC",
+    "name": "Ridgepost Capital, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RPD",
+    "name": "Rapid7, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "RPGL",
+    "name": "Republic Power Group Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "RPID",
+    "name": "Rapid Micro Biosystems, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RPM",
+    "name": "RPM International Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RPRX",
+    "name": "Royalty Pharma plc - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "RPT",
+    "name": "Rithm Property Trust Inc. Common stock",
+    "sector": null
+  },
+  {
+    "symbol": "RQI",
+    "name": "Cohen & Steers Quality Income Realty Fund Inc Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "RR",
+    "name": "Richtech Robotics Inc. - Class B Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RRBI",
+    "name": "Red River Bancshares, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "RRC",
+    "name": "Range Resources Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RREV",
+    "name": "RRE Ventures Acquisition Corp. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "RRGB",
+    "name": "Red Robin Gourmet Burgers, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "RRR",
+    "name": "Red Rock Resorts, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RRX",
+    "name": "Regal Rexnord Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RS",
+    "name": "Reliance, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RSF",
+    "name": "RiverNorth Capital and Income Fund Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RSG",
+    "name": "Republic Services, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RSI",
+    "name": "Rush Street Interactive, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RSKD",
+    "name": "Riskified Ltd. Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "RSSS",
+    "name": "Research Solutions, Inc",
+    "sector": null
+  },
+  {
+    "symbol": "RSVR",
+    "name": "Reservoir Media, Inc..",
+    "sector": null
+  },
+  {
+    "symbol": "RTAC",
+    "name": "Renatus Tactical Acquisition Corp I - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "RTB",
+    "name": "RTB Digital, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "RTX",
+    "name": "RTX Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RUBI",
+    "name": "Rubico Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "RUM",
+    "name": "Rumble Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RUN",
+    "name": "Sunrun Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "RUSHA",
+    "name": "Rush Enterprises, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RUSHB",
+    "name": "Rush Enterprises, Inc. - Class B Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RVI",
+    "name": "Robinhood Ventures Fund I Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "RVLV",
+    "name": "Revolve Group, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RVMD",
+    "name": "Revolution Medicines, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "RVP",
+    "name": "Retractable Technologies, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RVSB",
+    "name": "Riverview Bancorp Inc",
+    "sector": null
+  },
+  {
+    "symbol": "RVSN",
+    "name": "Rail Vision Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "RVT",
+    "name": "Royce Small-Cap Trust, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RVTY",
+    "name": "Revvity, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RWAY",
+    "name": "Runway Growth Finance Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "RWT",
+    "name": "Redwood Trust, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RXO",
+    "name": "RXO, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RXRX",
+    "name": "Recursion Pharmaceuticals, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RXST",
+    "name": "RxSight, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "RXT",
+    "name": "Rackspace Technology, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "RY",
+    "name": "Royal Bank Of Canada Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RYAM",
+    "name": "Rayonier Advanced Materials Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RYAN",
+    "name": "Ryan Specialty Holdings, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RYDE",
+    "name": "Ryde Group Ltd. Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "RYET",
+    "name": "Ruanyun Edai Technology Inc. - Ordinary shares",
+    "sector": null
+  },
+  {
+    "symbol": "RYM",
+    "name": "RYTHM, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "RYN",
+    "name": "Rayonier Inc. REIT Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RYOJ",
+    "name": "rYojbaba Co., Ltd. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "RYTM",
+    "name": "Rhythm Pharmaceuticals, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "RYZ",
+    "name": "Ryerson Holding Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "RZLT",
+    "name": "Rezolute, Inc. - Common Stock (NV)",
+    "sector": null
+  },
+  {
+    "symbol": "RZLV",
+    "name": "Rezolve AI PLC - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "S",
+    "name": "SentinelOne, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SA",
+    "name": "Seabridge Gold, Inc. Common Shares New",
+    "sector": null
+  },
+  {
+    "symbol": "SAAQ",
+    "name": "Space Asset Acquisition Corp. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SABR",
+    "name": "Sabre Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "SABS",
+    "name": "SAB Biotherapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SAC",
+    "name": "Safeguard Acquisition Corp. Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SACH",
+    "name": "Sachem Capital Corp. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SAFE",
+    "name": "Safehold Inc. New Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SAFT",
+    "name": "Safety Insurance Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SAFX",
+    "name": "XCF Global, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SAGT",
+    "name": "SAGTEC GLOBAL LIMITED - Class A Ordinary shares",
+    "sector": null
+  },
+  {
+    "symbol": "SAGU",
+    "name": "Shreya Acquisition Group Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SAH",
+    "name": "Sonic Automotive, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SAIA",
+    "name": "Saia, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SAIC",
+    "name": "Science Applications International Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "SAIH",
+    "name": "SAIHEAT Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SAIL",
+    "name": "SailPoint, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SAM",
+    "name": "Boston Beer Company, Inc. (The) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SAMG",
+    "name": "Silvercrest Asset Management Group Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SAN",
+    "name": "Banco Santander, S.A. Sponsored ADR (Spain)",
+    "sector": null
+  },
+  {
+    "symbol": "SANA",
+    "name": "Sana Biotechnology, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SANG",
+    "name": "Sangoma Technologies Corporation - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SANM",
+    "name": "Sanmina Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "SAP",
+    "name": "SAP SE ADS",
+    "sector": null
+  },
+  {
+    "symbol": "SAR",
+    "name": "Saratoga Investment Corp New",
+    "sector": null
+  },
+  {
+    "symbol": "SARO",
+    "name": "StandardAero, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SATL",
+    "name": "Satellogic Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SATS",
+    "name": "EchoStar Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "SB",
+    "name": "Safe Bulkers, Inc Common Stock ($0.001 par value)",
+    "sector": null
+  },
+  {
+    "symbol": "SBAC",
+    "name": "SBA Communications Corporation - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SBC",
+    "name": "SBC Medical Group Holdings Incorporated",
+    "sector": null
+  },
+  {
+    "symbol": "SBCF",
+    "name": "Seacoast Banking Corporation of Florida",
+    "sector": null
+  },
+  {
+    "symbol": "SBET",
+    "name": "Sharplink, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SBEV",
+    "name": "Splash Beverage Group, Inc. (NV) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SBFG",
+    "name": "SB Financial Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SBFM",
+    "name": "Sunshine Biopharma Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SBGI",
+    "name": "Sinclair, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SBH",
+    "name": "Sally Beauty Holdings, Inc. (Name to be changed from Sally Holdings, Inc.) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SBI",
+    "name": "Western Asset Intermediate Muni Fund Inc Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SBLK",
+    "name": "Star Bulk Carriers Corp. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SBMT",
+    "name": "Silver Bow Mining Corp. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SBR",
+    "name": "Sabine Royalty Trust Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SBRA",
+    "name": "Sabra Health Care REIT, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SBSI",
+    "name": "Southside Bancshares, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SBSW",
+    "name": "D/B/A Sibanye-Stillwater Limited ADS",
+    "sector": null
+  },
+  {
+    "symbol": "SBUX",
+    "name": "Starbucks Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "SBXD",
+    "name": "SilverBox Corp IV Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SBXE",
+    "name": "SilverBox Corp V Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SCCO",
+    "name": "Southern Copper Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SCD",
+    "name": "LMP Capital and Income Fund Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SCHL",
+    "name": "Scholastic Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "SCHW",
+    "name": "Charles Schwab Corporation (The) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SCI",
+    "name": "Service Corporation International Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SCII",
+    "name": "SC II Acquisition Corp. - Class A ordinary share",
+    "sector": null
+  },
+  {
+    "symbol": "SCKT",
+    "name": "Socket Mobile, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SCL",
+    "name": "Stepan Company Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SCLX",
+    "name": "Scilex Holding Company",
+    "sector": null
+  },
+  {
+    "symbol": "SCM",
+    "name": "Stellus Capital Investment Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SCNX",
+    "name": "Scienture Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SCOR",
+    "name": "comScore, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SCPQ",
+    "name": "Social Commerce Partners Corporation - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SCSC",
+    "name": "ScanSource, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SCWO",
+    "name": "374Water Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SCYX",
+    "name": "SCYNEXIS, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SCZM",
+    "name": "Santacruz Silver Mining Ltd. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SD",
+    "name": "SandRidge Energy, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SDA",
+    "name": "SunCar Technology Group Inc. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SDEV",
+    "name": "Stablecoin Development Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SDGR",
+    "name": "Schrodinger, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SDHC",
+    "name": "Smith Douglas Homes Corp. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SDHI",
+    "name": "Siddhi Acquisition Corp - Class A Common stock",
+    "sector": null
+  },
+  {
+    "symbol": "SDM",
+    "name": "Smart Digital Group Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SDOT",
+    "name": "Sadot Group Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SDRL",
+    "name": "Seadrill Limited Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SDST",
+    "name": "Stardust Power Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SEAT",
+    "name": "Vivid Seats Inc. - Class A common stock",
+    "sector": null
+  },
+  {
+    "symbol": "SEB",
+    "name": "Seaboard Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SEDG",
+    "name": "SolarEdge Technologies, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SEED",
+    "name": "Origin Agritech Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SEER",
+    "name": "Seer, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SEG",
+    "name": "Seaport Entertainment Group Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SEGG",
+    "name": "Sports Entertainment Gaming Global Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "SEI",
+    "name": "Solaris Energy Infrastructure, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SEIC",
+    "name": "SEI Investments Company",
+    "sector": null
+  },
+  {
+    "symbol": "SELF",
+    "name": "Global Self Storage, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SEM",
+    "name": "Select Medical Holdings Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SENEA",
+    "name": "Seneca Foods Corp. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SENEB",
+    "name": "Seneca Foods Corp. - Class B Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SENS",
+    "name": "Senseonics Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SEPN",
+    "name": "Septerna, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SER",
+    "name": "Serina Therapeutics, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SERA",
+    "name": "Sera Prognostics, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SERV",
+    "name": "Serve Robotics Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SES",
+    "name": "SES AI Corporation Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SEV",
+    "name": "Aptera Motors Corp. - Class B Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SEVN",
+    "name": "Seven Hills Realty Trust",
+    "sector": null
+  },
+  {
+    "symbol": "SEZL",
+    "name": "Sezzle Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SF",
+    "name": "Stifel Financial Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SFBC",
+    "name": "Sound Financial Bancorp, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SFBS",
+    "name": "ServisFirst Bancshares, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SFD",
+    "name": "Smithfield Foods, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SFHG",
+    "name": "Samfine Creation Holdings Group Limited - Class A Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "SFIX",
+    "name": "Stitch Fix, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SFL",
+    "name": "SFL Corporation Ltd",
+    "sector": null
+  },
+  {
+    "symbol": "SFM",
+    "name": "Sprouts Farmers Market, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SFNC",
+    "name": "Simmons First National Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "SFST",
+    "name": "Southern First Bancshares, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SFWL",
+    "name": "Shengfeng Development Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SG",
+    "name": "Sweetgreen, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SGA",
+    "name": "Saga Communications, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SGC",
+    "name": "Superior Group of Companies, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SGHC",
+    "name": "Super Group (SGHC) Limited Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SGHT",
+    "name": "Sight Sciences, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SGI",
+    "name": "Somnigroup International Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SGLY",
+    "name": "Singularity Future Technology Ltd.",
+    "sector": null
+  },
+  {
+    "symbol": "SGML",
+    "name": "Sigma Lithium Corporation - common shares",
+    "sector": null
+  },
+  {
+    "symbol": "SGMT",
+    "name": "Sagimet Biosciences Inc. - Series A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SGP",
+    "name": "SpyGlass Pharma, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SGRP",
+    "name": "SPAR Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SGRY",
+    "name": "Surgery Partners, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SGU",
+    "name": "Star Group L.P. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SHAK",
+    "name": "Shake Shack, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SHAZ",
+    "name": "SharonAI Holdings, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SHBI",
+    "name": "Shore Bancshares, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SHC",
+    "name": "Sotera Health Company",
+    "sector": null
+  },
+  {
+    "symbol": "SHEN",
+    "name": "Shenandoah Telecommunications Co",
+    "sector": null
+  },
+  {
+    "symbol": "SHFS",
+    "name": "SHF Holdings, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SHIM",
+    "name": "Shimmick Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "SHIP",
+    "name": "Seanergy Maritime Holdings Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "SHLS",
+    "name": "Shoals Technologies Group, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SHMD",
+    "name": "SCHMID Group N.V. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SHO",
+    "name": "Sunstone Hotel Investors, Inc. Sunstone Hotel Investors, Inc. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SHOE",
+    "name": "Shoe Station Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SHOO",
+    "name": "Steven Madden, Ltd.",
+    "sector": null
+  },
+  {
+    "symbol": "SHOP",
+    "name": "Shopify Inc. - Class A Subordinate Voting Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SHPH",
+    "name": "Shuttle Pharmaceuticals Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SHW",
+    "name": "Sherwin-Williams Company (The) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SI",
+    "name": "Shoulder Innovations, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SIBN",
+    "name": "SI-BONE, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SID",
+    "name": "Companhia Siderurgica Nacional S.A. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SIDU",
+    "name": "Sidus Space, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SIEB",
+    "name": "Siebert Financial Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "SIF",
+    "name": "SIFCO Industries, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SIFY",
+    "name": "Sify Technologies Limited - American Depository Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SIG",
+    "name": "Signet Jewelers Limited Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SIGA",
+    "name": "SIGA Technologies Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SIGI",
+    "name": "Selective Insurance Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SII",
+    "name": "Sprott Inc. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SILA",
+    "name": "Sila Realty Trust, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SILC",
+    "name": "Silicom Ltd - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SILO",
+    "name": "Silo Pharma, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SIMA",
+    "name": "SIM Acquisition Corp. I - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SINT",
+    "name": "SiNtx Technologies, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SION",
+    "name": "Sionna Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SIRI",
+    "name": "SiriusXM Holdings Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SITC",
+    "name": "SITE Centers Corp. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SITE",
+    "name": "SiteOne Landscape Supply, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SITM",
+    "name": "SiTime Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "SJ",
+    "name": "Scienjoy Holding Corporation - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SJM",
+    "name": "The J.M. Smucker Company Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SJT",
+    "name": "San Juan Basin Royalty Trust Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SKBL",
+    "name": "Skyline Builders Group Holding Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SKE",
+    "name": "Skeena Resources Limited Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SKIL",
+    "name": "Skillsoft Corp. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SKIN",
+    "name": "SkinHealth Systems Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SKK",
+    "name": "SKK Holdings Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SKLZ",
+    "name": "Skillz Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SKM",
+    "name": "SK Telecom Co., Ltd. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SKT",
+    "name": "Tanger Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SKWD",
+    "name": "Skyward Specialty Insurance Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SKY",
+    "name": "Champion Homes, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SKYA",
+    "name": "SkyAI, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SKYE",
+    "name": "Skye Bioscience, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SKYH",
+    "name": "Sky Harbour Group Corporation Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SKYQ",
+    "name": "Sky Quarry Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SKYT",
+    "name": "SkyWater Technology, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SKYW",
+    "name": "SkyWest, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SKYX",
+    "name": "SKYX Platforms Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "SLAB",
+    "name": "Silicon Laboratories, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SLB",
+    "name": "SLB Limited Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SLDB",
+    "name": "Solid Biosciences Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SLDE",
+    "name": "Slide Insurance Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SLDP",
+    "name": "Solid Power, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SLE",
+    "name": "Super League Enterprise, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SLF",
+    "name": "Sun Life Financial Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SLG",
+    "name": "SL Green Realty Corp Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SLGB",
+    "name": "Smart Logistics Global Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SLGL",
+    "name": "Sol-Gel Technologies Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SLGN",
+    "name": "Silgan Holdings Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SLI",
+    "name": "Standard Lithium Ltd. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SLM",
+    "name": "SLM Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "SLMT",
+    "name": "Brera Holdings PLC - Class B Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SLN",
+    "name": "Silence Therapeutics Plc - American Depository Share",
+    "sector": null
+  },
+  {
+    "symbol": "SLND",
+    "name": "Southland Holdings, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SLNG",
+    "name": "Stabilis Solutions, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SLNH",
+    "name": "Soluna Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SLP",
+    "name": "Simulations Plus, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SLQT",
+    "name": "SelectQuote, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SLRC",
+    "name": "SLR Investment Corp. - Closed End Fund",
+    "sector": null
+  },
+  {
+    "symbol": "SLS",
+    "name": "SELLAS Life Sciences Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SLSN",
+    "name": "Solesence, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SLSR",
+    "name": "Solaris Resources Inc. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SLVM",
+    "name": "Sylvamo Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SLXN",
+    "name": "Silexion Therapeutics Corp - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SM",
+    "name": "SM Energy Company Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SMA",
+    "name": "SmartStop Self Storage REIT, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SMBC",
+    "name": "Southern Missouri Bancorp, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SMBK",
+    "name": "SmartFinancial, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SMC",
+    "name": "Summit Midstream Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SMCI",
+    "name": "Super Micro Computer, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SMG",
+    "name": "Scotts Miracle-Gro Company (The) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SMHB",
+    "name": "ETRACS Monthly Pay 2x Leveraged Small Cap High Dividend ETN Series B",
+    "sector": null
+  },
+  {
+    "symbol": "SMHI",
+    "name": "SEACOR Marine Holdings Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SMID",
+    "name": "Smith-Midland Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "SMJF",
+    "name": "SMJ International Holdings Inc. Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SMMT",
+    "name": "Summit Therapeutics Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SMP",
+    "name": "Standard Motor Products, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SMPL",
+    "name": "The Simply Good Foods Company",
+    "sector": null
+  },
+  {
+    "symbol": "SMR",
+    "name": "NuScale Power Corporation Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SMRT",
+    "name": "SmartRent, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SMSI",
+    "name": "Smith Micro Software, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SMTC",
+    "name": "Semtech Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "SMTI",
+    "name": "Sanara MedTech Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SMTK",
+    "name": "SmartKem, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SMWB",
+    "name": "Similarweb Ltd. Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SMX",
+    "name": "SMX (Security Matters) Public Limited Company - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SMXT",
+    "name": "Solarmax Technology Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SN",
+    "name": "SharkNinja, Inc. Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SNA",
+    "name": "Snap-On Incorporated Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SNAL",
+    "name": "Snail, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SNAP",
+    "name": "Snap Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SNBR",
+    "name": "Sleep Number Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "SND",
+    "name": "Smart Sand, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SNDA",
+    "name": "Sonida Senior Living, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SNDK",
+    "name": "Sandisk Corporation - Common Stock When-Issued",
+    "sector": null
+  },
+  {
+    "symbol": "SNDL",
+    "name": "SNDL Inc. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SNDR",
+    "name": "Schneider National, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SNDX",
+    "name": "Syndax Pharmaceuticals, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SNES",
+    "name": "SenesTech, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SNEX",
+    "name": "StoneX Group Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SNFCA",
+    "name": "Security National Financial Corporation - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SNGX",
+    "name": "Soligenix, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SNN",
+    "name": "Smith & Nephew SNATS, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SNOA",
+    "name": "Sonoma Pharmaceuticals, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SNOW",
+    "name": "Snowflake Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SNPS",
+    "name": "Synopsys, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SNSE",
+    "name": "Sensei Biotherapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SNT",
+    "name": "Senstar Technologies Corporation - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SNTG",
+    "name": "Sentage Holdings Inc. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SNTI",
+    "name": "Senti Biosciences Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SNWV",
+    "name": "SANUWAVE Health, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SNX",
+    "name": "TD SYNNEX Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SNYR",
+    "name": "Synergy CHC Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "SO",
+    "name": "Southern Company (The) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SOAR",
+    "name": "Volato Group, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SOBO",
+    "name": "South Bow Corporation Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SOBR",
+    "name": "SOBR Safe, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SOC",
+    "name": "Sable Offshore Corp. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SOCA",
+    "name": "Solarius Capital Acquisition Corp. - Class A Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "SOFI",
+    "name": "SoFi Technologies, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SOLS",
+    "name": "Solstice Advanced Materials Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SOLV",
+    "name": "Solventum Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SON",
+    "name": "Sonoco Products Company Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SONM",
+    "name": "DNA X, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SONO",
+    "name": "Sonos, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SOPH",
+    "name": "SOPHiA GENETICS SA - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SOR",
+    "name": "Source Capital, Inc. Cmn Shs of BI",
+    "sector": null
+  },
+  {
+    "symbol": "SORA",
+    "name": "AsiaStrategy - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SORN",
+    "name": "Soren Acquisition Corp. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SOS",
+    "name": "SOS Limited Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SOTK",
+    "name": "Sono-Tek Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "SOUL",
+    "name": "Soulpower Acquisition Corporation Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SOUN",
+    "name": "SoundHound AI, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SOWG",
+    "name": "Sow Good Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SPAI",
+    "name": "Safe Pro Group Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SPB",
+    "name": "Spectrum Brands Holdings, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SPCB",
+    "name": "SuperCom, Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SPCE",
+    "name": "Virgin Galactic Holdings, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SPCX",
+    "name": "Space Exploration Technologies Corp. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SPEG",
+    "name": "Silver Pegasus Acquisition Corp - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SPFI",
+    "name": "South Plains Financial, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SPG",
+    "name": "Simon Property Group, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SPGI",
+    "name": "S&P Global Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SPH",
+    "name": "Suburban Propane Partners, L.P. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SPHL",
+    "name": "Springview Holdings Ltd - Ordinary shares",
+    "sector": null
+  },
+  {
+    "symbol": "SPHR",
+    "name": "Sphere Entertainment Co. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SPIR",
+    "name": "Spire Global, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SPKL",
+    "name": "Spark I Acquisition Corp. - Class A Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "SPMC",
+    "name": "Sound Point Meridian Capital, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SPNT",
+    "name": "SiriusPoint Ltd. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SPOK",
+    "name": "Spok Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SPOT",
+    "name": "Spotify Technology S.A. Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SPPL",
+    "name": "SIMPPLE LTD. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SPRB",
+    "name": "Spruce Biosciences, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SPRC",
+    "name": "SciSparc Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SPRO",
+    "name": "Spero Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SPRU",
+    "name": "Spruce Power Holding Corporation Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SPRY",
+    "name": "ARS Pharmaceuticals, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SPSC",
+    "name": "SPS Commerce, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SPT",
+    "name": "Sprout Social, Inc - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SPTX",
+    "name": "Seaport Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SPWH",
+    "name": "Sportsman's Warehouse Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SPWR",
+    "name": "SunPower Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SPXC",
+    "name": "SPX Technologies, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SPXX",
+    "name": "Nuveen S&P 500 Dynamic Overwrite Fund",
+    "sector": null
+  },
+  {
+    "symbol": "SQFT",
+    "name": "Presidio Property Trust, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SQM",
+    "name": "Sociedad Quimica y Minera S.A. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SR",
+    "name": "Spire Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SRAD",
+    "name": "Sportradar Group AG - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SRBK",
+    "name": "SR Bancorp, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SRCE",
+    "name": "1st Source Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "SRE",
+    "name": "DBA Sempra Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SRFM",
+    "name": "Surf Air Mobility Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SRG",
+    "name": "Seritage Growth Properties Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SRI",
+    "name": "Stoneridge, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SRL",
+    "name": "Scully Royalty Ltd.",
+    "sector": null
+  },
+  {
+    "symbol": "SRPT",
+    "name": "Sarepta Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SRRK",
+    "name": "Scholar Rock Holding Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "SRTA",
+    "name": "Strata Critical Medical, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SRTS",
+    "name": "Sensus Healthcare, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SRV",
+    "name": "NXG Cushing Midstream Energy Fund Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "SRXH",
+    "name": "SRX Health Solutions, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SRZN",
+    "name": "Surrozen, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SSAC",
+    "name": "SPACSphere Acquisition Corp. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SSB",
+    "name": "SouthState Bank Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SSBI",
+    "name": "Summit State Bank",
+    "sector": null
+  },
+  {
+    "symbol": "SSD",
+    "name": "Simpson Manufacturing Company, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SSEA",
+    "name": "Starry Sea Acquisition Corp - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SSII",
+    "name": "SS Innovations International Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SSM",
+    "name": "Sono Group N.V. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SSMR",
+    "name": "Sunshine Silver Mining & Refining Company Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SSNC",
+    "name": "SS&C Technologies Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SSP",
+    "name": "E.W. Scripps Company (The) - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SSRM",
+    "name": "SSR Mining Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SSSS",
+    "name": "SuRo Capital Corp. - Closed End Fund",
+    "sector": null
+  },
+  {
+    "symbol": "SST",
+    "name": "System1, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SSTI",
+    "name": "SoundThinking, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SSTK",
+    "name": "Shutterstock, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SSYS",
+    "name": "Stratasys, Ltd.",
+    "sector": null
+  },
+  {
+    "symbol": "ST",
+    "name": "Sensata Technologies Holding plc Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "STAA",
+    "name": "STAAR Surgical Company",
+    "sector": null
+  },
+  {
+    "symbol": "STAG",
+    "name": "Stag Industrial, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "STAK",
+    "name": "STAK Inc. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "STBA",
+    "name": "S&T Bancorp, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "STC",
+    "name": "Stewart Information Services Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "STE",
+    "name": "STERIS plc (Ireland) Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "STEL",
+    "name": "Stellar Bancorp, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "STEM",
+    "name": "Stem, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "STEP",
+    "name": "StepStone Group Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "STEW",
+    "name": "SRH Total Return Fund, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "STEX",
+    "name": "Streamex Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "STFS",
+    "name": "Star Fashion Culture Holdings Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "STGW",
+    "name": "Stagwell Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "STHO",
+    "name": "Star Holdings - Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "STI",
+    "name": "Solidion Technology, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "STIM",
+    "name": "Neuronetics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "STK",
+    "name": "Columbia Seligman Premium Technology Growth Fund Inc",
+    "sector": null
+  },
+  {
+    "symbol": "STKE",
+    "name": "Sol Strategies Inc. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "STKS",
+    "name": "The ONE Group Hospitality, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "STLA",
+    "name": "Stellantis N.V. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "STLD",
+    "name": "Steel Dynamics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "STM",
+    "name": "STMicroelectronics N.V. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "STN",
+    "name": "Stantec Inc Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "STNE",
+    "name": "StoneCo Ltd. - Class A Common Share",
+    "sector": null
+  },
+  {
+    "symbol": "STNG",
+    "name": "Scorpio Tankers Inc. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "STOK",
+    "name": "Stoke Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "STRA",
+    "name": "Strategic Education, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "STRL",
+    "name": "Sterling Infrastructure, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "STRO",
+    "name": "Sutro Biopharma, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "STRR",
+    "name": "Star Equity Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "STRS",
+    "name": "Stratus Properties Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "STRT",
+    "name": "STRATTEC SECURITY CORPORATION",
+    "sector": null
+  },
+  {
+    "symbol": "STRW",
+    "name": "Strawberry Fields REIT, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "STRZ",
+    "name": "Starz Entertainment Corp. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "STT",
+    "name": "State Street Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "STTK",
+    "name": "Shattuck Labs, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "STUB",
+    "name": "StubHub Holdings, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "STVN",
+    "name": "Stevanato Group S.p.A. Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "STWD",
+    "name": "STARWOOD PROPERTY TRUST, INC. Starwood Property Trust Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "STX",
+    "name": "Seagate Technology Holdings PLC - Ordinary Shares (Ireland)",
+    "sector": null
+  },
+  {
+    "symbol": "STXS",
+    "name": "Stereotaxis, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "STZ",
+    "name": "Constellation Brands, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SU",
+    "name": "Suncor Energy Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SUGP",
+    "name": "SU Group Holdings Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SUIG",
+    "name": "Sui Group Holdings Limited",
+    "sector": null
+  },
+  {
+    "symbol": "SUJA",
+    "name": "Suja Life, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SUMA",
+    "name": "SUMA Acquisition Corporation - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SUNB",
+    "name": "Sunbelt Rentals Holdings, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SUNE",
+    "name": "SUNation Energy, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SUNS",
+    "name": "Sunrise Realty Trust, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SUPN",
+    "name": "Supernus Pharmaceuticals, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SUPX",
+    "name": "SuperX AI Technology Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SURG",
+    "name": "SurgePays, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SVA",
+    "name": "Sinovac Biotech, Ltd. - Ordinary Shares (Antigua/Barbudo)",
+    "sector": null
+  },
+  {
+    "symbol": "SVAC",
+    "name": "Spring Valley Acquisition Corp. III - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SVAQ",
+    "name": "Silicon Valley Acquisition Corp. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SVC",
+    "name": "Service Properties Trust - Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "SVCC",
+    "name": "Stellar V Capital Corp. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SVCO",
+    "name": "Silvaco Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SVIV",
+    "name": "Spring Valley Acquisition Corp. IV - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SVM",
+    "name": "Silvercorp Metals Inc. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SVRA",
+    "name": "Savara, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SVRN",
+    "name": "OceanPal Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SVV",
+    "name": "Savers Value Village, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SW",
+    "name": "Smurfit WestRock plc Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SWAG",
+    "name": "Stran & Company, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SWBI",
+    "name": "Smith & Wesson Brands, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SWIM",
+    "name": "Latham Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SWK",
+    "name": "Stanley Black & Decker, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SWKS",
+    "name": "Skyworks Solutions, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SWMR",
+    "name": "Swarmer, Inc",
+    "sector": null
+  },
+  {
+    "symbol": "SWVL",
+    "name": "Swvl Holdings Corp - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SWX",
+    "name": "Southwest Gas Holdings, Inc. Common Stock (DE)",
+    "sector": null
+  },
+  {
+    "symbol": "SWZ",
+    "name": "Total Return Securities Fund Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SXC",
+    "name": "SunCoke Energy, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SXI",
+    "name": "Standex International Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SXT",
+    "name": "Sensient Technologies Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SXTC",
+    "name": "China SXT Pharmaceuticals, Inc. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SXTP",
+    "name": "60 Degrees Pharmaceuticals, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SY",
+    "name": "So-Young International Inc. - American Depository Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SYBT",
+    "name": "Stock Yards Bancorp, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SYF",
+    "name": "Synchrony Financial Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SYK",
+    "name": "Stryker Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SYM",
+    "name": "Symbotic Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SYNA",
+    "name": "Synaptics Incorporated",
+    "sector": null
+  },
+  {
+    "symbol": "SYNX",
+    "name": "Silynxcom Ltd. Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "SYPR",
+    "name": "Sypris Solutions, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SYRE",
+    "name": "Spyre Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "SYY",
+    "name": "Sysco Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "SZZL",
+    "name": "Sizzle Acquisition Corp. II - Class A ordinary shares",
+    "sector": null
+  },
+  {
+    "symbol": "T",
+    "name": "AT&T Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TAC",
+    "name": "TransAlta Corporation Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "TACH",
+    "name": "Titan Acquisition Corp. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "TACO",
+    "name": "Berto Acquisition Corp. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "TACT",
+    "name": "TransAct Technologies Incorporated",
+    "sector": null
+  },
+  {
+    "symbol": "TALK",
+    "name": "Talkspace, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TALO",
+    "name": "Talos Energy, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TANH",
+    "name": "Tantech Holdings Ltd. - Class A Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "TAOP",
+    "name": "Taoping Inc. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "TAOX",
+    "name": "Tao Synergies Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TAP",
+    "name": "Molson Coors Beverage Company Class B Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TAP.A",
+    "name": "Molson Coors Beverage Company Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TARA",
+    "name": "Protara Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TARS",
+    "name": "Tarsus Pharmaceuticals, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TASK",
+    "name": "TaskUs, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TATT",
+    "name": "TAT Technologies Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "TAVI",
+    "name": "Tavia Acquisition Corp. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "TAYD",
+    "name": "Taylor Devices, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TBBB",
+    "name": "BBB Foods Inc. Class A Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "TBBK",
+    "name": "The Bancorp, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TBCH",
+    "name": "Turtle Beach Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "TBH",
+    "name": "Brag House Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TBI",
+    "name": "TrueBlue, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TBLA",
+    "name": "Taboola.com Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "TBN",
+    "name": "Tamboran Resources Corporation Common stock",
+    "sector": null
+  },
+  {
+    "symbol": "TBPH",
+    "name": "Theravance Biopharma, Inc. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "TBRG",
+    "name": "TruBridge, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TCBI",
+    "name": "Texas Capital Bancshares, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TCBK",
+    "name": "TriCo Bancshares",
+    "sector": null
+  },
+  {
+    "symbol": "TCBX",
+    "name": "Third Coast Bancshares, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TCGL",
+    "name": "TechCreate Group Ltd. Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "TCI",
+    "name": "Transcontinental Realty Investors, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TCMD",
+    "name": "Tactile Systems Technology, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TCPC",
+    "name": "BlackRock TCP Capital Corp. - Closed End Fund",
+    "sector": null
+  },
+  {
+    "symbol": "TCRT",
+    "name": "Alaunos Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TCRX",
+    "name": "TScan Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TCX",
+    "name": "Tucows Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TD",
+    "name": "Toronto Dominion Bank (The) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TDAC",
+    "name": "Translational Development Acquisition Corp. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "TDAY",
+    "name": "USA TODAY Co., Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TDC",
+    "name": "Teradata Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TDF",
+    "name": "Templeton Dragon Fund, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TDG",
+    "name": "Transdigm Group Incorporated Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TDIC",
+    "name": "Dreamland Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "TDOC",
+    "name": "Teladoc Health, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TDS",
+    "name": "Telephone and Data Systems, Inc. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "TDTH",
+    "name": "Trident Digital Tech Holdings Ltd - American Depository Shares",
+    "sector": null
+  },
+  {
+    "symbol": "TDUP",
+    "name": "ThredUp Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TDW",
+    "name": "Tidewater Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TDWD",
+    "name": "Tailwind 2.0 Acquisition Corp. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "TDY",
+    "name": "Teledyne Technologies Incorporated Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TE",
+    "name": "T1 Energy Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TEAD",
+    "name": "Teads Holding Co.",
+    "sector": null
+  },
+  {
+    "symbol": "TEAM",
+    "name": "Atlassian Corporation - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TECH",
+    "name": "Bio-Techne Corp",
+    "sector": null
+  },
+  {
+    "symbol": "TECK",
+    "name": "Teck Resources Ltd Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "TECX",
+    "name": "Tectonic Therapeutic, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TEI",
+    "name": "Templeton Emerging Markets Income Fund, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TEL",
+    "name": "TE Connectivity plc Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "TELA",
+    "name": "TELA Bio, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TELO",
+    "name": "Telomir Pharmaceuticals, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TEM",
+    "name": "Tempus AI, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TEN",
+    "name": "Tsakos Energy Navigation Ltd Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "TENB",
+    "name": "Tenable Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TENX",
+    "name": "Tenax Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TEO",
+    "name": "Telecom Argentina SA",
+    "sector": null
+  },
+  {
+    "symbol": "TER",
+    "name": "Teradyne, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TEX",
+    "name": "Terex Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TFC",
+    "name": "Truist Financial Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TFII",
+    "name": "TFI International Inc. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "TFIN",
+    "name": "Triumph Financial, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TFPM",
+    "name": "Triple Flag Precious Metals Corp. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "TFSL",
+    "name": "TFS Financial Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "TFX",
+    "name": "Teleflex Incorporated Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TG",
+    "name": "Tredegar Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TGB",
+    "name": "Taseko Mines, Ltd. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TGE",
+    "name": "The Generation Essentials Group Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "TGEN",
+    "name": "Tecogen Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TGHL",
+    "name": "The GrowHub Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "TGL",
+    "name": "Treasure Global Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TGLS",
+    "name": "Tecnoglass Inc. Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "TGS",
+    "name": "Transportadora de Gas del Sur SA TGS Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TGT",
+    "name": "Target Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TGTX",
+    "name": "TG Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TH",
+    "name": "Target Hospitality Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "THC",
+    "name": "Tenet Healthcare Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "THCH",
+    "name": "TH International Limited - Ordinary shares",
+    "sector": null
+  },
+  {
+    "symbol": "THFF",
+    "name": "First Financial Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "THG",
+    "name": "Hanover Insurance Group Inc",
+    "sector": null
+  },
+  {
+    "symbol": "THH",
+    "name": "TryHard Holdings Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "THM",
+    "name": "International Tower Hill Mines, Ltd. Ordinary Shares (Canada)",
+    "sector": null
+  },
+  {
+    "symbol": "THO",
+    "name": "Thor Industries, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "THRM",
+    "name": "Gentherm Inc",
+    "sector": null
+  },
+  {
+    "symbol": "THRY",
+    "name": "Thryv Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "THW",
+    "name": "abrdn World Healthcare Fund Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "TIC",
+    "name": "TIC Solutions, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TIGO",
+    "name": "Millicom International Cellular S.A.",
+    "sector": null
+  },
+  {
+    "symbol": "TII",
+    "name": "Titan Mining Corporation Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "TIL",
+    "name": "Instil Bio, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TILE",
+    "name": "Interface, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TIPT",
+    "name": "Tiptree Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TISI",
+    "name": "Team, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TITN",
+    "name": "Titan Machinery Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TJGC",
+    "name": "TJGC Group Limited - ordinary shares",
+    "sector": null
+  },
+  {
+    "symbol": "TJX",
+    "name": "TJX Companies, Inc. (The) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TK",
+    "name": "Teekay Corporation Ltd. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TKC",
+    "name": "Turkcell Iletisim Hizmetleri AS Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TKNO",
+    "name": "Alpha Teknova, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TKO",
+    "name": "TKO Group Holdings, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TKR",
+    "name": "Timken Company (The) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TLF",
+    "name": "Tandy Leather Factory, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TLIH",
+    "name": "Ten-League International Holdings Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "TLK",
+    "name": "PT Telekomunikasi Indonesia, Tbk",
+    "sector": null
+  },
+  {
+    "symbol": "TLN",
+    "name": "Talen Energy Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "TLNC",
+    "name": "Talon Capital Corp. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "TLPH",
+    "name": "Talphera, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TLRY",
+    "name": "Tilray Brands, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TLS",
+    "name": "Telos Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "TLSA",
+    "name": "Tiziana Life Sciences Ltd - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "TLSI",
+    "name": "TriSalus Life Sciences, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TLYS",
+    "name": "Tilly's, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TM",
+    "name": "Toyota Motor Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TMC",
+    "name": "TMC the metals company Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TMCI",
+    "name": "Treace Medical Concepts, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TMCR",
+    "name": "The Metals Royalty Company Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TMDE",
+    "name": "TMD Energy Limited Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "TMDX",
+    "name": "TransMedics Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TMHC",
+    "name": "Taylor Morrison Home Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TMO",
+    "name": "Thermo Fisher Scientific Inc Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TMP",
+    "name": "Tompkins Financial Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TMQ",
+    "name": "Trilogy Metals Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TMTS",
+    "name": "Spartacus Acquisition Corp. II - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "TMUS",
+    "name": "T-Mobile US, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TNC",
+    "name": "Tennant Company Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TNDM",
+    "name": "Tandem Diabetes Care, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TNET",
+    "name": "TriNet Group, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TNGX",
+    "name": "Tango Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TNK",
+    "name": "Teekay Tankers Ltd.",
+    "sector": null
+  },
+  {
+    "symbol": "TNL",
+    "name": "Travel Leisure Co. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TNMG",
+    "name": "TNL Mediagene - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "TNON",
+    "name": "Tenon Medical, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TNXP",
+    "name": "Tonix Pharmaceuticals Holding Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "TNYA",
+    "name": "Tenaya Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TOI",
+    "name": "The Oncology Institute, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TOL",
+    "name": "Toll Brothers, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TOMZ",
+    "name": "TOMI Environmental Solutions, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TONX",
+    "name": "TON Strategy Company",
+    "sector": null
+  },
+  {
+    "symbol": "TOON",
+    "name": "Kartoon Studios, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TOP",
+    "name": "TOP Financial Group Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "TOPP",
+    "name": "Toppoint Holdings Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TOPS",
+    "name": "TOP Ships, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TORO",
+    "name": "Toro Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "TOST",
+    "name": "Toast, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TOVX",
+    "name": "Theriva Biologics, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TOWN",
+    "name": "Towne Bank",
+    "sector": null
+  },
+  {
+    "symbol": "TOYO",
+    "name": "TOYO Co., Ltd - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "TPB",
+    "name": "Turning Point Brands, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TPC",
+    "name": "Tutor Perini Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TPCS",
+    "name": "TechPrecision Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "TPET",
+    "name": "Trio Petroleum Corp. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TPG",
+    "name": "TPG Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TPL",
+    "name": "Texas Pacific Land Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TPR",
+    "name": "Tapestry, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TPST",
+    "name": "Tempest Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TPVG",
+    "name": "TriplePoint Venture Growth BDC Corp. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TR",
+    "name": "Tootsie Roll Industries, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TRAD",
+    "name": "APEX Tech Acquisition Inc. Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "TRAK",
+    "name": "ReposiTrak, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TRAW",
+    "name": "Traws Pharma, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TRAX",
+    "name": "First Tracks Biotherapeutics, Inc. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "TRC",
+    "name": "Tejon Ranch Co Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TRDA",
+    "name": "Entrada Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TREE",
+    "name": "LendingTree, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TREX",
+    "name": "Trex Company, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TRGP",
+    "name": "Targa Resources, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TRGS",
+    "name": "TRG Latin America Acquisitions Corp. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "TRI",
+    "name": "Thomson Reuters Corp - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "TRIN",
+    "name": "Trinity Capital Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TRIP",
+    "name": "TripAdvisor, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TRLV",
+    "name": "Trulieve Cannabis Corp. Subordinate Voting Shares",
+    "sector": null
+  },
+  {
+    "symbol": "TRMB",
+    "name": "Trimble Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TRMD",
+    "name": "TORM plc - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TRMK",
+    "name": "Trustmark Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "TRN",
+    "name": "Trinity Industries, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TRNO",
+    "name": "Terreno Realty Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TRNR",
+    "name": "Interactive Strength Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TRNS",
+    "name": "Transcat, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TRON",
+    "name": "Tron Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TROO",
+    "name": "TROOPS, Inc. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "TROW",
+    "name": "T. Rowe Price Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TROX",
+    "name": "Tronox Holdings plc Ordinary Shares (UK)",
+    "sector": null
+  },
+  {
+    "symbol": "TRP",
+    "name": "TC Energy Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TRS",
+    "name": "TriMas Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "TRSG",
+    "name": "Tungray Technologies Inc - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "TRST",
+    "name": "TrustCo Bank Corp NY",
+    "sector": null
+  },
+  {
+    "symbol": "TRT",
+    "name": "Trio-Tech International Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TRTX",
+    "name": "TPG RE Finance Trust, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TRU",
+    "name": "TransUnion Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TRUG",
+    "name": "TruGolf Holdings, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TRUP",
+    "name": "Trupanion, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TRV",
+    "name": "The Travelers Companies, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TRVI",
+    "name": "Trevi Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TRX",
+    "name": "TRX Gold Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TSAT",
+    "name": "Telesat Corporation - Class A Common Shares and Class B Variable Voting Shares",
+    "sector": null
+  },
+  {
+    "symbol": "TSBK",
+    "name": "Timberland Bancorp, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TSCO",
+    "name": "Tractor Supply Company",
+    "sector": null
+  },
+  {
+    "symbol": "TSEM",
+    "name": "Tower Semiconductor Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "TSHA",
+    "name": "Taysha Gene Therapies, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TSI",
+    "name": "TCW Strategic Income Fund, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TSLA",
+    "name": "Tesla, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TSLX",
+    "name": "Sixth Street Specialty Lending, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TSM",
+    "name": "Taiwan Semiconductor Manufacturing Company Ltd.",
+    "sector": null
+  },
+  {
+    "symbol": "TSN",
+    "name": "Tyson Foods, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TSQ",
+    "name": "Townsquare Media, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TSSI",
+    "name": "TSS, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TT",
+    "name": "Trane Technologies plc",
+    "sector": null
+  },
+  {
+    "symbol": "TTAM",
+    "name": "Titan America SA Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "TTAN",
+    "name": "ServiceTitan, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TTC",
+    "name": "Toro Company (The) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TTD",
+    "name": "The Trade Desk, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TTE",
+    "name": "TotalEnergies SE Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "TTEC",
+    "name": "TTEC Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TTEK",
+    "name": "Tetra Tech, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TTGT",
+    "name": "TechTarget, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TTI",
+    "name": "Tetra Technologies, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TTMI",
+    "name": "TTM Technologies, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TTRX",
+    "name": "Turn Therapeutics Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TTWO",
+    "name": "Take-Two Interactive Software, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TU",
+    "name": "Telus Corporation Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "TULP",
+    "name": "Bloomia Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TUSK",
+    "name": "Mammoth Energy Services, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TV",
+    "name": "Grupo Televisa S.A.B. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TVA",
+    "name": "Texas Ventures Acquisition III Corp - Class A Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "TVAI",
+    "name": "Thayer Ventures Acquisition Corporation II - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "TVC",
+    "name": "Tennessee Valley Authority Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TVE",
+    "name": "Tennessee Valley Authority",
+    "sector": null
+  },
+  {
+    "symbol": "TVGN",
+    "name": "Tevogen Bio Holdings Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TVRD",
+    "name": "Tvardi Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TVTX",
+    "name": "Travere Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TW",
+    "name": "Tradeweb Markets Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TWAV",
+    "name": "TaoWeave, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TWFG",
+    "name": "TWFG, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TWG",
+    "name": "Top Wealth Group Holding Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "TWI",
+    "name": "Titan International, Inc. (DE) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TWIN",
+    "name": "Twin Disc, Incorporated",
+    "sector": null
+  },
+  {
+    "symbol": "TWLO",
+    "name": "Twilio Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TWLV",
+    "name": "Twelve Seas Investment Company III - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "TWN",
+    "name": "Taiwan Fund, Inc. (The) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TWO",
+    "name": "Two Harbors Investment Corp",
+    "sector": null
+  },
+  {
+    "symbol": "TWST",
+    "name": "Twist Bioscience Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "TXG",
+    "name": "10x Genomics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TXMD",
+    "name": "TherapeuticsMD, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TXN",
+    "name": "Texas Instruments Incorporated",
+    "sector": null
+  },
+  {
+    "symbol": "TXNM",
+    "name": "TXNM Energy, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TXRH",
+    "name": "Texas Roadhouse, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TXT",
+    "name": "Textron Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TY",
+    "name": "Tri Continental Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TYG",
+    "name": "Tortoise Energy Infrastructure Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TYGO",
+    "name": "Tigo Energy, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TYL",
+    "name": "Tyler Technologies, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "TYRA",
+    "name": "Tyra Biosciences, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TZOO",
+    "name": "Travelzoo",
+    "sector": null
+  },
+  {
+    "symbol": "UA",
+    "name": "Under Armour, Inc. Class C Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "UAA",
+    "name": "Under Armour, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "UAVS",
+    "name": "AgEagle Aerial Systems, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "UBER",
+    "name": "Uber Technologies, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "UBS",
+    "name": "UBS Group AG Registered Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "UBXG",
+    "name": "U-BX Technology Ltd. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "UCAR",
+    "name": "U Power Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "UCFI",
+    "name": "CN Healthy Food Tech Group Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "UCIB",
+    "name": "ETRACS UBS Bloomberg Constant Maturity Commodity Index (CMCI) Total Return ETN Series B due April 5, 2038",
+    "sector": null
+  },
+  {
+    "symbol": "UCTT",
+    "name": "Ultra Clean Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "UDR",
+    "name": "UDR, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "UE",
+    "name": "Urban Edge Properties Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "UEC",
+    "name": "Uranium Energy Corp. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "UEIC",
+    "name": "Universal Electronics Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "UFG",
+    "name": "Uni-Fuels Holdings Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "UFI",
+    "name": "Unifi, Inc. New Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "UFPI",
+    "name": "UFP Industries, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "UFPT",
+    "name": "UFP Technologies, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "UGI",
+    "name": "UGI Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "UGRO",
+    "name": "urban-gro, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "UHAL",
+    "name": "U-Haul Holding Company Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "UHAL.B",
+    "name": "U-Haul Holding Company Series N Non-Voting Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "UHS",
+    "name": "Universal Health Services, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "UHT",
+    "name": "Universal Health Realty Income Trust Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "UI",
+    "name": "Ubiquiti Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "UIS",
+    "name": "Unisys Corporation New Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "UK",
+    "name": "Ucommune International Ltd - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ULBI",
+    "name": "Ultralife Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "ULCC",
+    "name": "Frontier Group Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ULH",
+    "name": "Universal Logistics Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ULS",
+    "name": "UL Solutions Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ULTA",
+    "name": "Ulta Beauty, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "UMAC",
+    "name": "Unusual Machines, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "UMBF",
+    "name": "UMB Financial Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "UMH",
+    "name": "UMH Properties, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "UNB",
+    "name": "Union Bankshares, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "UNCY",
+    "name": "Unicycive Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "UNF",
+    "name": "Unifirst Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "UNM",
+    "name": "Unum Group Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "UNP",
+    "name": "Union Pacific Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "UONE",
+    "name": "Urban One, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "UONEK",
+    "name": "Urban One, Inc. - Class D Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "UP",
+    "name": "Wheels Up Experience Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "UPB",
+    "name": "Upstream Bio, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "UPBD",
+    "name": "Upbound Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "UPC",
+    "name": "Universe Pharmaceuticals Inc - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "UPLD",
+    "name": "Upland Software, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "UPST",
+    "name": "Upstart Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "UPWK",
+    "name": "Upwork Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "UPXI",
+    "name": "Upexi, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "URBN",
+    "name": "Urban Outfitters, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "URG",
+    "name": "Ur Energy Inc Common Shares (Canada)",
+    "sector": null
+  },
+  {
+    "symbol": "URGN",
+    "name": "UroGen Pharma Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "UROY",
+    "name": "Uranium Royalty Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "USA",
+    "name": "Liberty All-Star Equity Fund Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "USAR",
+    "name": "USA Rare Earth, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "USAS",
+    "name": "Americas Gold and Silver Corporation Common Shares, no par value",
+    "sector": null
+  },
+  {
+    "symbol": "USAU",
+    "name": "U.S. Gold Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "USB",
+    "name": "U.S. Bancorp Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "USBC",
+    "name": "USBC, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "USCB",
+    "name": "USCB Financial Holdings, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "USFD",
+    "name": "US Foods Holding Corp. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "USGO",
+    "name": "U.S. GoldMining Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "USIO",
+    "name": "Usio, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "USNA",
+    "name": "USANA Health Sciences, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "USPH",
+    "name": "U.S. Physical Therapy, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "UTF",
+    "name": "Cohen & Steers Infrastructure Fund, Inc Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "UTG",
+    "name": "Reaves Utility Income Fund Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "UTI",
+    "name": "Universal Technical Institute Inc Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "UTMD",
+    "name": "Utah Medical Products, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "UTSI",
+    "name": "UTStarcom Holdings Corp - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "UTZ",
+    "name": "Utz Brands Inc Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "UUU",
+    "name": "Universal Safety Products, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "UUUU",
+    "name": "Energy Fuels Inc Ordinary Shares (Canada)",
+    "sector": null
+  },
+  {
+    "symbol": "UVE",
+    "name": "UNIVERSAL INSURANCE HOLDINGS INC Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "UVSP",
+    "name": "Univest Financial Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "UVV",
+    "name": "Universal Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "UWMC",
+    "name": "UWM Holdings Corporation Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "UYSC",
+    "name": "UY Scuti Acquisition Corp. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "UZX",
+    "name": "Linkage Global Inc - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "V",
+    "name": "Visa Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "VABK",
+    "name": "Virginia National Bankshares Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "VAC",
+    "name": "Marriott Vacations Worldwide Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "VACI",
+    "name": "Viking Acquisition Corp. I Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "VAL",
+    "name": "Valaris Limited Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "VALU",
+    "name": "Value Line, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "VANI",
+    "name": "Vivani Medical, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "VATE",
+    "name": "INNOVATE Corp. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "VBIO",
+    "name": "Valion Bio, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "VBNK",
+    "name": "VersaBank - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "VC",
+    "name": "Visteon Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "VCEL",
+    "name": "Vericel Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "VCIG",
+    "name": "VCI Global Limited - Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "VCTR",
+    "name": "Victory Capital Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "VCV",
+    "name": "Invesco California Value Municipal Income Trust Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "VCX",
+    "name": "Fundrise Innovation Fund, LLC Common Shares of Limited Liability Company Interests",
+    "sector": null
+  },
+  {
+    "symbol": "VCYT",
+    "name": "Veracyte, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "VECA",
+    "name": "Vernal Capital Acquisition Corp. Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "VECO",
+    "name": "Veeco Instruments Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "VEEA",
+    "name": "Veea Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "VEEE",
+    "name": "Twin Vee PowerCats Co.",
+    "sector": null
+  },
+  {
+    "symbol": "VEEV",
+    "name": "Veeva Systems Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "VEL",
+    "name": "Velocity Financial, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "VELO",
+    "name": "Velo3D, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "VENU",
+    "name": "Venu Holding Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "VERA",
+    "name": "Vera Therapeutics, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "VERI",
+    "name": "Veritone, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "VERU",
+    "name": "Veru Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "VERX",
+    "name": "Vertex, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "VET",
+    "name": "Vermilion Energy Inc. Common (Canada)",
+    "sector": null
+  },
+  {
+    "symbol": "VFC",
+    "name": "V.F. Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "VFF",
+    "name": "Village Farms International, Inc. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "VFL",
+    "name": "abrdn National Municipal Income Fund Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "VFS",
+    "name": "VinFast Auto Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "VG",
+    "name": "Venture Global, Inc. Class A common stock",
+    "sector": null
+  },
+  {
+    "symbol": "VGAS",
+    "name": "Verde Clean Fuels, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "VGI",
+    "name": "Virtus Global Multi-Sector Income Fund Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "VGM",
+    "name": "Invesco Trust for Investment Grade Municipals Common Stock (DE)",
+    "sector": null
+  },
+  {
+    "symbol": "VGNT",
+    "name": "Versigent PLC Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "VGZ",
+    "name": "Vista Gold Corp Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "VHC",
+    "name": "VirnetX Holding Corp",
+    "sector": null
+  },
+  {
+    "symbol": "VHCP",
+    "name": "Vine Hill Capital Investment Corp. II - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "VHI",
+    "name": "Valhi, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "VHUB",
+    "name": "VenHub Global, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "VIA",
+    "name": "Via Transportation, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "VIAV",
+    "name": "Viavi Solutions Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "VICI",
+    "name": "VICI Properties Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "VICR",
+    "name": "Vicor Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "VIDA",
+    "name": "VIDA Global Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "VIK",
+    "name": "Viking Holdings Ltd Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "VINP",
+    "name": "Vinci Compass Investments Ltd. - Class A Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "VIR",
+    "name": "Vir Biotechnology, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "VIRC",
+    "name": "Virco Manufacturing Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "VIRT",
+    "name": "Virtu Financial, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "VISN",
+    "name": "Vistance Networks, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "VITL",
+    "name": "Vital Farms, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "VIVK",
+    "name": "Vivakor, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "VIVO",
+    "name": "VivoPower PLC - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "VIVS",
+    "name": "VivoSim Labs, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "VKI",
+    "name": "Invesco Advantage Municipal Income Trust II Common Shares of Beneficial Interest (DE)",
+    "sector": null
+  },
+  {
+    "symbol": "VKQ",
+    "name": "Invesco Municipal Trust Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "VKTX",
+    "name": "Viking Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "VLGEA",
+    "name": "Village Super Market, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "VLN",
+    "name": "Valens Semiconductor Ltd. Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "VLO",
+    "name": "Valero Energy Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "VLT",
+    "name": "Invesco High Income Trust II",
+    "sector": null
+  },
+  {
+    "symbol": "VLTO",
+    "name": "Veralto Corp Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "VLY",
+    "name": "Valley National Bancorp",
+    "sector": null
+  },
+  {
+    "symbol": "VMAR",
+    "name": "Vision Marine Technologies Inc. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "VMC",
+    "name": "Vulcan Materials Company (Holding Company) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "VMD",
+    "name": "Viemed Healthcare, Inc. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "VMET",
+    "name": "Versamet Royalties Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "VMI",
+    "name": "Valmont Industries, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "VNCE",
+    "name": "Vince Holding Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "VNDA",
+    "name": "Vanda Pharmaceuticals Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "VNME",
+    "name": "Vendome Acquisition Corporation I - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "VNO",
+    "name": "Vornado Realty Trust Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "VNOM",
+    "name": "Viper Energy, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "VNRX",
+    "name": "VolitionRX Limited Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "VNT",
+    "name": "Vontier Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "VNTG",
+    "name": "Vantage Corp Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "VOR",
+    "name": "Vor Biopharma Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "VOXR",
+    "name": "Vox Royalty Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "VOYA",
+    "name": "Voya Financial, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "VOYG",
+    "name": "Voyager Technologies, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "VPG",
+    "name": "Vishay Precision Group, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "VPV",
+    "name": "Invesco Pennsylvania Value Municipal Income Trust Common Stock (DE)",
+    "sector": null
+  },
+  {
+    "symbol": "VRA",
+    "name": "Vera Bradley, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "VRAX",
+    "name": "Virax Biolabs Group Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "VRCA",
+    "name": "Verrica Pharmaceuticals Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "VRDN",
+    "name": "Viridian Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "VREX",
+    "name": "Varex Imaging Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "VRM",
+    "name": "Vroom, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "VRME",
+    "name": "VerifyMe, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "VRNS",
+    "name": "Varonis Systems, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "VRRM",
+    "name": "Verra Mobility Corporation - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "VRSK",
+    "name": "Verisk Analytics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "VRSN",
+    "name": "VeriSign, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "VRT",
+    "name": "Vertiv Holdings, LLC Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "VRTS",
+    "name": "Virtus Investment Partners, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "VRTX",
+    "name": "Vertex Pharmaceuticals Incorporated",
+    "sector": null
+  },
+  {
+    "symbol": "VRXA",
+    "name": "Veraxa Biotech AG - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "VS",
+    "name": "Versus Systems Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "VSAT",
+    "name": "ViaSat, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "VSEC",
+    "name": "VSE Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "VSEE",
+    "name": "VSee Health, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "VSH",
+    "name": "Vishay Intertechnology, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "VSME",
+    "name": "VS Media Holdings Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "VSNT",
+    "name": "Versant Media Group, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "VST",
+    "name": "Vistra Corp. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "VSTD",
+    "name": "Vestand Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "VSTM",
+    "name": "Verastem, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "VSTS",
+    "name": "Vestis Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "VSXY",
+    "name": "Victorias Secret & Co. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "VTAK",
+    "name": "Catheter Precision, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "VTEX",
+    "name": "VTEX Class A Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "VTGN",
+    "name": "Vistagen Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "VTIX",
+    "name": "Virtuix Holdings Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "VTN",
+    "name": "Invesco Trust for Investment Grade New York Municipals Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "VTOL",
+    "name": "Bristow Group, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "VTR",
+    "name": "Ventas, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "VTRS",
+    "name": "Viatris Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "VTS",
+    "name": "Vitesse Energy, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "VTSI",
+    "name": "VirTra, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "VTVT",
+    "name": "vTv Therapeutics Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "VUZI",
+    "name": "Vuzix Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "VVOS",
+    "name": "Vivos Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "VVR",
+    "name": "Invesco Senior Income Trust Common Stock (DE)",
+    "sector": null
+  },
+  {
+    "symbol": "VVV",
+    "name": "Valvoline Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "VVX",
+    "name": "V2X, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "VWAV",
+    "name": "VisionWave Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "VXX",
+    "name": "iPath Series B S&P 500 VIX Short-Term Futures ETN",
+    "sector": null
+  },
+  {
+    "symbol": "VXZ",
+    "name": "iPath Series B S&P 500 VIX Mid-Term Futures ETN",
+    "sector": null
+  },
+  {
+    "symbol": "VYGR",
+    "name": "Voyager Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "VYNE",
+    "name": "VYNE Therapeutics Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "VYX",
+    "name": "NCR Voyix Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "VZ",
+    "name": "Verizon Communications Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "VZLA",
+    "name": "Vizsla Silver Corp. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "W",
+    "name": "Wayfair Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "WAB",
+    "name": "Westinghouse Air Brake Technologies Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "WABC",
+    "name": "Westamerica Bancorporation",
+    "sector": null
+  },
+  {
+    "symbol": "WAFD",
+    "name": "WaFd, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "WAFU",
+    "name": "Wah Fu Education Group Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "WAI",
+    "name": "Top KingWin Ltd - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "WAL",
+    "name": "Western Alliance Bancorporation Common Stock (DE)",
+    "sector": null
+  },
+  {
+    "symbol": "WALD",
+    "name": "Waldencast plc - Class A Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "WASH",
+    "name": "Washington Trust Bancorp, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "WAT",
+    "name": "Waters Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "WATT",
+    "name": "Energous Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "WAY",
+    "name": "Waystar Holding Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "WBD",
+    "name": "Warner Bros. Discovery, Inc. - Series A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "WBI",
+    "name": "WaterBridge Infrastructure LLC Class A Shares Representing Limited Liability Company Interests",
+    "sector": null
+  },
+  {
+    "symbol": "WBS",
+    "name": "Webster Financial Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "WBTN",
+    "name": "WEBTOON Entertainment Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "WBUY",
+    "name": "WEBUY GLOBAL LTD. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "WBX",
+    "name": "Wallbox N.V. Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "WCC",
+    "name": "WESCO International, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "WCN",
+    "name": "Waste Connections, Inc. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "WCT",
+    "name": "Wellchange Holdings Company Limited - Class A Ordinary shares",
+    "sector": null
+  },
+  {
+    "symbol": "WD",
+    "name": "Walker & Dunlop, Inc Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "WDAY",
+    "name": "Workday, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "WDC",
+    "name": "Western Digital Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "WDFC",
+    "name": "WD-40 Company",
+    "sector": null
+  },
+  {
+    "symbol": "WDI",
+    "name": "Western Asset Diversified Income Fund Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "WEAV",
+    "name": "Weave Communications, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "WEC",
+    "name": "WEC Energy Group, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "WELL",
+    "name": "Welltower Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "WEN",
+    "name": "Wendy's Company (The)",
+    "sector": null
+  },
+  {
+    "symbol": "WENC",
+    "name": "West Enclave Merger Corp. Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "WENN",
+    "name": "Wen Acquisition Corp - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "WERN",
+    "name": "Werner Enterprises, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "WEST",
+    "name": "Westrock Coffee Company",
+    "sector": null
+  },
+  {
+    "symbol": "WETH",
+    "name": "Wetouch Technology Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "WETO",
+    "name": "Wetour Robotics Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "WEX",
+    "name": "WEX Inc. common stock",
+    "sector": null
+  },
+  {
+    "symbol": "WEYS",
+    "name": "Weyco Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "WFC",
+    "name": "Wells Fargo & Company Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "WFCF",
+    "name": "Where Food Comes From, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "WFF",
+    "name": "WF Holding Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "WFG",
+    "name": "West Fraser Timber Co. Ltd Common stock",
+    "sector": null
+  },
+  {
+    "symbol": "WFRD",
+    "name": "Weatherford International plc - Ordinary shares",
+    "sector": null
+  },
+  {
+    "symbol": "WGO",
+    "name": "Winnebago Industries, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "WGRX",
+    "name": "Wellgistics Health, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "WGS",
+    "name": "GeneDx Holdings Corp. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "WH",
+    "name": "Wyndham Hotels & Resorts, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "WHD",
+    "name": "Cactus, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "WHF",
+    "name": "WhiteHorse Finance, Inc. - Closed End Fund",
+    "sector": null
+  },
+  {
+    "symbol": "WHG",
+    "name": "Westwood Holdings Group Inc Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "WHK",
+    "name": "WhiteHawk Minerals Corp Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "WHLR",
+    "name": "Wheeler Real Estate Investment Trust, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "WHR",
+    "name": "Whirlpool Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "WHWK",
+    "name": "Whitehawk Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "WIA",
+    "name": "Western Asset Inflation-Linked Income Fund",
+    "sector": null
+  },
+  {
+    "symbol": "WILC",
+    "name": "G. Willi-Food International, Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "WIMI",
+    "name": "WiMi Hologram Cloud Inc. - Class B Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "WINA",
+    "name": "Winmark Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "WING",
+    "name": "Wingstop Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "WIT",
+    "name": "Wipro Limited Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "WIX",
+    "name": "Wix.com Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "WK",
+    "name": "Workiva Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "WKC",
+    "name": "World Kinect Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "WKHS",
+    "name": "Workhorse Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "WKSP",
+    "name": "Worksport, Ltd.",
+    "sector": null
+  },
+  {
+    "symbol": "WLDN",
+    "name": "Willdan Group, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "WLDS",
+    "name": "Wearable Devices Ltd. - Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "WLFC",
+    "name": "Willis Lease Finance Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "WLII",
+    "name": "Willow Lane Acquisition Corp. II - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "WLK",
+    "name": "Westlake Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "WLTH",
+    "name": "Wealthfront Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "WLY",
+    "name": "John Wiley & Sons, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "WLYB",
+    "name": "John Wiley & Sons, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "WM",
+    "name": "Waste Management, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "WMB",
+    "name": "Williams Companies, Inc. (The) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "WMG",
+    "name": "Warner Music Group Corp. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "WMK",
+    "name": "Weis Markets, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "WMS",
+    "name": "Advanced Drainage Systems, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "WMT",
+    "name": "Walmart Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "WNC",
+    "name": "Wabash National Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "WNEB",
+    "name": "Western New England Bancorp, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "WNW",
+    "name": "Meiwu Technology Company Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "WOK",
+    "name": "WORK Medical Technology Group LTD - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "WOLF",
+    "name": "Wolfspeed, Inc. Common Stock New",
+    "sector": null
+  },
+  {
+    "symbol": "WOOF",
+    "name": "Petco Health and Wellness Company, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "WOR",
+    "name": "Worthington Enterprises, Inc. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "WPAC",
+    "name": "White Pearl Acquisition Corp. Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "WPC",
+    "name": "W. P. Carey Inc. REIT",
+    "sector": null
+  },
+  {
+    "symbol": "WPM",
+    "name": "Wheaton Precious Metals Corp Common Shares (Canada)",
+    "sector": null
+  },
+  {
+    "symbol": "WPRT",
+    "name": "Westport Fuel Systems Inc - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "WRAP",
+    "name": "Wrap Technologies, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "WRB",
+    "name": "W.R. Berkley Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "WRBY",
+    "name": "Warby Parker Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "WRLD",
+    "name": "World Acceptance Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "WRN",
+    "name": "Western Copper and Gold Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "WS",
+    "name": "Worthington Steel, Inc. Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "WSBC",
+    "name": "WesBanco, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "WSBF",
+    "name": "Waterstone Financial, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "WSBK",
+    "name": "Winchester Bancorp, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "WSC",
+    "name": "WillScot Holdings Corporation - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "WSE",
+    "name": "Wise Group plc - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "WSFS",
+    "name": "WSFS Financial Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "WSHP",
+    "name": "WeShop Holdings Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "WSM",
+    "name": "Williams-Sonoma, Inc. Common Stock (DE)",
+    "sector": null
+  },
+  {
+    "symbol": "WSO",
+    "name": "Watsco, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "WSO.B",
+    "name": "Watsco, Inc. Class B Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "WSR",
+    "name": "Whitestone REIT Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "WST",
+    "name": "West Pharmaceutical Services, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "WSTN",
+    "name": "Westin Acquisition Corp - Class A Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "WT",
+    "name": "WisdomTree, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "WTBA",
+    "name": "West Bancorporation",
+    "sector": null
+  },
+  {
+    "symbol": "WTF",
+    "name": "Waton Financial Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "WTFC",
+    "name": "Wintrust Financial Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "WTG",
+    "name": "Wintergreen Acquisition Corp. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "WTI",
+    "name": "W&T Offshore, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "WTM",
+    "name": "White Mountains Insurance Group, Ltd. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "WTO",
+    "name": "UTime Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "WTRG",
+    "name": "Essential Utilities, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "WTS",
+    "name": "Watts Water Technologies, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "WTTR",
+    "name": "Select Water Solutions, Inc. Class A common stock",
+    "sector": null
+  },
+  {
+    "symbol": "WTW",
+    "name": "Willis Towers Watson Public Limited Company - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "WU",
+    "name": "Western Union Company (The) Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "WULF",
+    "name": "TeraWulf Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "WVE",
+    "name": "Wave Life Sciences Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "WVVI",
+    "name": "Willamette Valley Vineyards, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "WW",
+    "name": "WW International, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "WWD",
+    "name": "Woodward, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "WWR",
+    "name": "Westwater Resources, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "WWW",
+    "name": "Wolverine World Wide, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "WXM",
+    "name": "WF International Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "WY",
+    "name": "Weyerhaeuser Company Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "WYFI",
+    "name": "WhiteFiber, Inc. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "WYNN",
+    "name": "Wynn Resorts, Limited",
+    "sector": null
+  },
+  {
+    "symbol": "WYY",
+    "name": "WidePoint Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "XAIR",
+    "name": "Beyond Air, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "XBIO",
+    "name": "Xenetic Biosciences, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "XBIT",
+    "name": "XBiotech Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "XBP",
+    "name": "XBP Global Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "XCBE",
+    "name": "X3 Acquisition Corp. Ltd. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "XCH",
+    "name": "XCHG Limited - ADS",
+    "sector": null
+  },
+  {
+    "symbol": "XCUR",
+    "name": "Exicure, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "XE",
+    "name": "X-Energy, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "XEL",
+    "name": "Xcel Energy Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "XELB",
+    "name": "Xcel Brands, Inc",
+    "sector": null
+  },
+  {
+    "symbol": "XENE",
+    "name": "Xenon Pharmaceuticals Inc. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "XERS",
+    "name": "Xeris Biopharma Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "XFLH",
+    "name": "XFLH Capital Corporation Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "XFLT",
+    "name": "XAI Floating Rate & Alternative Income Trust Common Shares of Beneficial Interest",
+    "sector": null
+  },
+  {
+    "symbol": "XFOR",
+    "name": "X4 Pharmaceuticals, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "XGN",
+    "name": "Exagen Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "XHLD",
+    "name": "TEN Holdings, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "XHR",
+    "name": "Xenia Hotels & Resorts, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "XLO",
+    "name": "Xilio Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "XMAX",
+    "name": "XMAX, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "XMTR",
+    "name": "Xometry, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "XNCR",
+    "name": "Xencor, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "XNDU",
+    "name": "Xanadu Quantum Technologies Limited - Class B Subordinate Voting Shares",
+    "sector": null
+  },
+  {
+    "symbol": "XOM",
+    "name": "Exxon Mobil Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "XOMA",
+    "name": "XOMA Royalty Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "XOS",
+    "name": "Xos, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "XP",
+    "name": "XP Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "XPEL",
+    "name": "XPEL, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "XPER",
+    "name": "Xperi Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "XPL",
+    "name": "Solitario Resources Corp. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "XPO",
+    "name": "XPO, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "XPOF",
+    "name": "Xponential Fitness, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "XPON",
+    "name": "Expion360 Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "XPRO",
+    "name": "Expro Group Holdings N.V. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "XRAY",
+    "name": "DENTSPLY SIRONA Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "XRN",
+    "name": "Chiron Real Estate Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "XRPN",
+    "name": "Armada Acquisition Corp. II - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "XRTX",
+    "name": "XORTX Therapeutics Inc. - Common Shares",
+    "sector": null
+  },
+  {
+    "symbol": "XRX",
+    "name": "Xerox Holdings Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "XSLL",
+    "name": "Xsolla SPAC 1 - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "XTIA",
+    "name": "XTI Aerospace, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "XTNT",
+    "name": "Xtant Medical Holdings, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "XWEL",
+    "name": "XWELL, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "XXI",
+    "name": "Twenty One Capital, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "XXII",
+    "name": "22nd Century Group, Inc",
+    "sector": null
+  },
+  {
+    "symbol": "XYL",
+    "name": "Xylem Inc. Common Stock New",
+    "sector": null
+  },
+  {
+    "symbol": "XYZ",
+    "name": "Block, Inc. Class A Common Stock,",
+    "sector": null
+  },
+  {
+    "symbol": "XZO",
+    "name": "Exzeo Group, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "YAAS",
+    "name": "Youxin Technology Ltd - Class A Ordinary shares",
+    "sector": null
+  },
+  {
+    "symbol": "YCBD",
+    "name": "cbdMD, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "YCY",
+    "name": "AA Mission Acquisition Corp. II Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "YDDL",
+    "name": "One and One Green Technologies. INC - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "YDES",
+    "name": "YD Bio Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "YDKG",
+    "name": "Yueda Digital Holding - Class A Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "YELP",
+    "name": "Yelp Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "YETI",
+    "name": "YETI Holdings, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "YEXT",
+    "name": "Yext, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "YHC",
+    "name": "LQR House Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "YHGJ",
+    "name": "Yunhong Green CTI Ltd.",
+    "sector": null
+  },
+  {
+    "symbol": "YHNA",
+    "name": "YHN Acquisition I Limited - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "YIBO",
+    "name": "Planet Image International Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "YJ",
+    "name": "Yunji Inc. - American Depository Shares",
+    "sector": null
+  },
+  {
+    "symbol": "YMAT",
+    "name": "J-Star Holding Co., Ltd. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "YOOV",
+    "name": "Concorde International Group Ltd - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "YORW",
+    "name": "The York Water Company",
+    "sector": null
+  },
+  {
+    "symbol": "YOU",
+    "name": "Clear Secure, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "YPF",
+    "name": "YPF Sociedad Anonima Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "YSS",
+    "name": "York Space Systems Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "YSWY",
+    "name": "Yesway, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "YSXT",
+    "name": "YSX Tech. Co., Ltd - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "YTRA",
+    "name": "Yatra Online, Inc. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "YUM",
+    "name": "Yum! Brands, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "YUMC",
+    "name": "Yum China Holdings, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "YXT",
+    "name": "YXT.COM GROUP HOLDING LIMITED - American Depository Shares",
+    "sector": null
+  },
+  {
+    "symbol": "YYAI",
+    "name": "AiRWA Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "YYGH",
+    "name": "YY Group Holding Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "Z",
+    "name": "Zillow Group, Inc. - Class C Capital Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ZBAO",
+    "name": "Zhibao Technology Inc. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ZBH",
+    "name": "Zimmer Biomet Holdings, Inc. Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ZBIO",
+    "name": "Zenas BioPharma, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ZBRA",
+    "name": "Zebra Technologies Corporation - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ZCMD",
+    "name": "Zhongchao Inc. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ZD",
+    "name": "Ziff Davis, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ZDAI",
+    "name": "DirectBooking Technology Co., Ltd. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ZDGE",
+    "name": "Zedge, Inc. Class B Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ZENA",
+    "name": "ZenaTech, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ZEO",
+    "name": "Zeo Energy Corporation - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ZETA",
+    "name": "Zeta Global Holdings Corp. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ZG",
+    "name": "Zillow Group, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ZGN",
+    "name": "Ermenegildo Zegna N.V. Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ZIM",
+    "name": "ZIM Integrated Shipping Services Ltd. Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ZION",
+    "name": "Zions Bancorporation N.A.",
+    "sector": null
+  },
+  {
+    "symbol": "ZIP",
+    "name": "ZipRecruiter, Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ZJK",
+    "name": "ZJK Industrial Co., Ltd. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ZJYL",
+    "name": "JIN MEDICAL INTERNATIONAL LTD. - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ZKIN",
+    "name": "ZK International Group Co., Ltd - Ordinary Share",
+    "sector": null
+  },
+  {
+    "symbol": "ZKP",
+    "name": "Lafayette Digital Acquisition Corp. I - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ZM",
+    "name": "Zoom Communications, Inc. - Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ZNB",
+    "name": "Zeta Network Group - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ZNTL",
+    "name": "Zentalis Pharmaceuticals, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ZONE",
+    "name": "CleanCore Solutions Inc. Class B Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ZOOZ",
+    "name": "ZOOZ Strategy Ltd. - Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ZS",
+    "name": "Zscaler, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ZSQR",
+    "name": "Z Squared Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ZSTK",
+    "name": "ZeroStack Corp.",
+    "sector": null
+  },
+  {
+    "symbol": "ZTEK",
+    "name": "Zentek Ltd.",
+    "sector": null
+  },
+  {
+    "symbol": "ZTG",
+    "name": "Zenta Group Company Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ZTR",
+    "name": "Virtus Total Return Fund Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ZTS",
+    "name": "Zoetis Inc. Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ZUMZ",
+    "name": "Zumiez Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ZURA",
+    "name": "Zura Bio Limited - Class A Ordinary shares",
+    "sector": null
+  },
+  {
+    "symbol": "ZVIA",
+    "name": "Zevia PBC Class A Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ZVRA",
+    "name": "Zevra Therapeutics, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ZWS",
+    "name": "Zurn Elkay Water Solutions Corporation Common Stock",
+    "sector": null
+  },
+  {
+    "symbol": "ZYBT",
+    "name": "Zhengye Biotechnology Holding Limited - Class A Ordinary Shares",
+    "sector": null
+  },
+  {
+    "symbol": "ZYME",
+    "name": "Zymeworks Inc.",
+    "sector": null
+  }
+]

--- a/data/indexes/nasdaq100.json
+++ b/data/indexes/nasdaq100.json
@@ -1,1 +1,507 @@
-[]
+[
+  {
+    "symbol": "AAPL",
+    "name": "Apple Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ABNB",
+    "name": "Airbnb",
+    "sector": null
+  },
+  {
+    "symbol": "ADBE",
+    "name": "Adobe Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "ADI",
+    "name": "Analog Devices",
+    "sector": null
+  },
+  {
+    "symbol": "ADP",
+    "name": "Automatic Data Processing",
+    "sector": null
+  },
+  {
+    "symbol": "ADSK",
+    "name": "Autodesk",
+    "sector": null
+  },
+  {
+    "symbol": "AEP",
+    "name": "American Electric Power",
+    "sector": null
+  },
+  {
+    "symbol": "ALNY",
+    "name": "Alnylam Pharmaceuticals",
+    "sector": null
+  },
+  {
+    "symbol": "AMAT",
+    "name": "Applied Materials",
+    "sector": null
+  },
+  {
+    "symbol": "AMD",
+    "name": "Advanced Micro Devices",
+    "sector": null
+  },
+  {
+    "symbol": "AMGN",
+    "name": "Amgen",
+    "sector": null
+  },
+  {
+    "symbol": "AMZN",
+    "name": "Amazon",
+    "sector": null
+  },
+  {
+    "symbol": "APP",
+    "name": "AppLovin",
+    "sector": null
+  },
+  {
+    "symbol": "ARM",
+    "name": "Arm Holdings",
+    "sector": null
+  },
+  {
+    "symbol": "ASML",
+    "name": "ASML Holding",
+    "sector": null
+  },
+  {
+    "symbol": "AVGO",
+    "name": "Broadcom",
+    "sector": null
+  },
+  {
+    "symbol": "AXON",
+    "name": "Axon Enterprise",
+    "sector": null
+  },
+  {
+    "symbol": "BKNG",
+    "name": "Booking Holdings",
+    "sector": null
+  },
+  {
+    "symbol": "BKR",
+    "name": "Baker Hughes",
+    "sector": null
+  },
+  {
+    "symbol": "CCEP",
+    "name": "Coca-Cola Europacific Partners",
+    "sector": null
+  },
+  {
+    "symbol": "CDNS",
+    "name": "Cadence Design Systems",
+    "sector": null
+  },
+  {
+    "symbol": "CEG",
+    "name": "Constellation Energy",
+    "sector": null
+  },
+  {
+    "symbol": "CHTR",
+    "name": "Charter Communications",
+    "sector": null
+  },
+  {
+    "symbol": "CMCSA",
+    "name": "Comcast",
+    "sector": null
+  },
+  {
+    "symbol": "COST",
+    "name": "Costco",
+    "sector": null
+  },
+  {
+    "symbol": "CPRT",
+    "name": "Copart",
+    "sector": null
+  },
+  {
+    "symbol": "CRWD",
+    "name": "CrowdStrike",
+    "sector": null
+  },
+  {
+    "symbol": "CSCO",
+    "name": "Cisco",
+    "sector": null
+  },
+  {
+    "symbol": "CSX",
+    "name": "CSX Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "CTAS",
+    "name": "Cintas",
+    "sector": null
+  },
+  {
+    "symbol": "CTSH",
+    "name": "Cognizant",
+    "sector": null
+  },
+  {
+    "symbol": "DASH",
+    "name": "DoorDash",
+    "sector": null
+  },
+  {
+    "symbol": "DDOG",
+    "name": "Datadog",
+    "sector": null
+  },
+  {
+    "symbol": "DXCM",
+    "name": "DexCom",
+    "sector": null
+  },
+  {
+    "symbol": "EA",
+    "name": "Electronic Arts",
+    "sector": null
+  },
+  {
+    "symbol": "EXC",
+    "name": "Exelon",
+    "sector": null
+  },
+  {
+    "symbol": "FANG",
+    "name": "Diamondback Energy",
+    "sector": null
+  },
+  {
+    "symbol": "FAST",
+    "name": "Fastenal",
+    "sector": null
+  },
+  {
+    "symbol": "FER",
+    "name": "Ferrovial",
+    "sector": null
+  },
+  {
+    "symbol": "FTNT",
+    "name": "Fortinet",
+    "sector": null
+  },
+  {
+    "symbol": "GEHC",
+    "name": "GE HealthCare",
+    "sector": null
+  },
+  {
+    "symbol": "GILD",
+    "name": "Gilead Sciences",
+    "sector": null
+  },
+  {
+    "symbol": "GOOG",
+    "name": "Alphabet Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "GOOGL",
+    "name": "Alphabet Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "HON",
+    "name": "Honeywell",
+    "sector": null
+  },
+  {
+    "symbol": "IDXX",
+    "name": "Idexx Laboratories",
+    "sector": null
+  },
+  {
+    "symbol": "INSM",
+    "name": "Insmed Incorporated",
+    "sector": null
+  },
+  {
+    "symbol": "INTC",
+    "name": "Intel",
+    "sector": null
+  },
+  {
+    "symbol": "INTU",
+    "name": "Intuit",
+    "sector": null
+  },
+  {
+    "symbol": "ISRG",
+    "name": "Intuitive Surgical",
+    "sector": null
+  },
+  {
+    "symbol": "KDP",
+    "name": "Keurig Dr Pepper",
+    "sector": null
+  },
+  {
+    "symbol": "KHC",
+    "name": "Kraft Heinz",
+    "sector": null
+  },
+  {
+    "symbol": "KLAC",
+    "name": "KLA Corporation",
+    "sector": null
+  },
+  {
+    "symbol": "LIN",
+    "name": "Linde plc",
+    "sector": null
+  },
+  {
+    "symbol": "LITE",
+    "name": "Lumentum",
+    "sector": null
+  },
+  {
+    "symbol": "LRCX",
+    "name": "Lam Research",
+    "sector": null
+  },
+  {
+    "symbol": "MAR",
+    "name": "Marriott International",
+    "sector": null
+  },
+  {
+    "symbol": "MCHP",
+    "name": "Microchip Technology",
+    "sector": null
+  },
+  {
+    "symbol": "MDLZ",
+    "name": "Mondelez International",
+    "sector": null
+  },
+  {
+    "symbol": "MELI",
+    "name": "Mercado Libre",
+    "sector": null
+  },
+  {
+    "symbol": "META",
+    "name": "Meta Platforms",
+    "sector": null
+  },
+  {
+    "symbol": "MNST",
+    "name": "Monster Beverage",
+    "sector": null
+  },
+  {
+    "symbol": "MPWR",
+    "name": "Monolithic Power Systems",
+    "sector": null
+  },
+  {
+    "symbol": "MRVL",
+    "name": "Marvell Technology",
+    "sector": null
+  },
+  {
+    "symbol": "MSFT",
+    "name": "Microsoft",
+    "sector": null
+  },
+  {
+    "symbol": "MSTR",
+    "name": "MicroStrategy",
+    "sector": null
+  },
+  {
+    "symbol": "MU",
+    "name": "Micron Technology",
+    "sector": null
+  },
+  {
+    "symbol": "NFLX",
+    "name": "Netflix, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "NVDA",
+    "name": "Nvidia",
+    "sector": null
+  },
+  {
+    "symbol": "NXPI",
+    "name": "NXP Semiconductors",
+    "sector": null
+  },
+  {
+    "symbol": "ODFL",
+    "name": "Old Dominion Freight Line",
+    "sector": null
+  },
+  {
+    "symbol": "ORLY",
+    "name": "O'Reilly Automotive",
+    "sector": null
+  },
+  {
+    "symbol": "PANW",
+    "name": "Palo Alto Networks",
+    "sector": null
+  },
+  {
+    "symbol": "PAYX",
+    "name": "Paychex",
+    "sector": null
+  },
+  {
+    "symbol": "PCAR",
+    "name": "Paccar",
+    "sector": null
+  },
+  {
+    "symbol": "PDD",
+    "name": "PDD Holdings",
+    "sector": null
+  },
+  {
+    "symbol": "PEP",
+    "name": "PepsiCo",
+    "sector": null
+  },
+  {
+    "symbol": "PLTR",
+    "name": "Palantir Technologies",
+    "sector": null
+  },
+  {
+    "symbol": "PYPL",
+    "name": "PayPal",
+    "sector": null
+  },
+  {
+    "symbol": "QCOM",
+    "name": "Qualcomm",
+    "sector": null
+  },
+  {
+    "symbol": "REGN",
+    "name": "Regeneron Pharmaceuticals",
+    "sector": null
+  },
+  {
+    "symbol": "ROP",
+    "name": "Roper Technologies",
+    "sector": null
+  },
+  {
+    "symbol": "ROST",
+    "name": "Ross Stores",
+    "sector": null
+  },
+  {
+    "symbol": "SBUX",
+    "name": "Starbucks",
+    "sector": null
+  },
+  {
+    "symbol": "SHOP",
+    "name": "Shopify",
+    "sector": null
+  },
+  {
+    "symbol": "SNDK",
+    "name": "Sandisk",
+    "sector": null
+  },
+  {
+    "symbol": "SNPS",
+    "name": "Synopsys",
+    "sector": null
+  },
+  {
+    "symbol": "STX",
+    "name": "Seagate Technology",
+    "sector": null
+  },
+  {
+    "symbol": "TMUS",
+    "name": "T-Mobile US",
+    "sector": null
+  },
+  {
+    "symbol": "TRI",
+    "name": "Thomson Reuters",
+    "sector": null
+  },
+  {
+    "symbol": "TSLA",
+    "name": "Tesla, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "TTWO",
+    "name": "Take-Two Interactive",
+    "sector": null
+  },
+  {
+    "symbol": "TXN",
+    "name": "Texas Instruments",
+    "sector": null
+  },
+  {
+    "symbol": "VRSK",
+    "name": "Verisk Analytics",
+    "sector": null
+  },
+  {
+    "symbol": "VRTX",
+    "name": "Vertex Pharmaceuticals",
+    "sector": null
+  },
+  {
+    "symbol": "WBD",
+    "name": "Warner Bros. Discovery",
+    "sector": null
+  },
+  {
+    "symbol": "WDAY",
+    "name": "Workday, Inc.",
+    "sector": null
+  },
+  {
+    "symbol": "WDC",
+    "name": "Western Digital",
+    "sector": null
+  },
+  {
+    "symbol": "WMT",
+    "name": "Walmart",
+    "sector": null
+  },
+  {
+    "symbol": "XEL",
+    "name": "Xcel Energy",
+    "sector": null
+  },
+  {
+    "symbol": "ZS",
+    "name": "Zscaler",
+    "sector": null
+  }
+]

--- a/data/indexes/sp500.json
+++ b/data/indexes/sp500.json
@@ -1,1 +1,2517 @@
-[]
+[
+  {
+    "symbol": "A",
+    "name": "Agilent Technologies",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "AAPL",
+    "name": "Apple Inc.",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "ABBV",
+    "name": "AbbVie",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "ABNB",
+    "name": "Airbnb",
+    "sector": "Consumer Discretionary"
+  },
+  {
+    "symbol": "ABT",
+    "name": "Abbott Laboratories",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "ACGL",
+    "name": "Arch Capital Group",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "ACN",
+    "name": "Accenture",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "ADBE",
+    "name": "Adobe Inc.",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "ADI",
+    "name": "Analog Devices",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "ADM",
+    "name": "Archer Daniels Midland",
+    "sector": "Consumer Staples"
+  },
+  {
+    "symbol": "ADP",
+    "name": "Automatic Data Processing",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "ADSK",
+    "name": "Autodesk",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "AEE",
+    "name": "Ameren",
+    "sector": "Utilities"
+  },
+  {
+    "symbol": "AEP",
+    "name": "American Electric Power",
+    "sector": "Utilities"
+  },
+  {
+    "symbol": "AES",
+    "name": "AES Corporation",
+    "sector": "Utilities"
+  },
+  {
+    "symbol": "AFL",
+    "name": "Aflac",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "AIG",
+    "name": "American International Group",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "AIZ",
+    "name": "Assurant",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "AJG",
+    "name": "Arthur J. Gallagher & Co.",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "AKAM",
+    "name": "Akamai Technologies",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "ALB",
+    "name": "Albemarle Corporation",
+    "sector": "Materials"
+  },
+  {
+    "symbol": "ALGN",
+    "name": "Align Technology",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "ALL",
+    "name": "Allstate",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "ALLE",
+    "name": "Allegion",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "AMAT",
+    "name": "Applied Materials",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "AMCR",
+    "name": "Amcor",
+    "sector": "Materials"
+  },
+  {
+    "symbol": "AMD",
+    "name": "Advanced Micro Devices",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "AME",
+    "name": "Ametek",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "AMGN",
+    "name": "Amgen",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "AMP",
+    "name": "Ameriprise Financial",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "AMT",
+    "name": "American Tower",
+    "sector": "Real Estate"
+  },
+  {
+    "symbol": "AMZN",
+    "name": "Amazon",
+    "sector": "Consumer Discretionary"
+  },
+  {
+    "symbol": "ANET",
+    "name": "Arista Networks",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "AON",
+    "name": "Aon plc",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "AOS",
+    "name": "A. O. Smith",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "APA",
+    "name": "APA Corporation",
+    "sector": "Energy"
+  },
+  {
+    "symbol": "APD",
+    "name": "Air Products",
+    "sector": "Materials"
+  },
+  {
+    "symbol": "APH",
+    "name": "Amphenol",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "APO",
+    "name": "Apollo Global Management",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "APP",
+    "name": "AppLovin",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "APTV",
+    "name": "Aptiv",
+    "sector": "Consumer Discretionary"
+  },
+  {
+    "symbol": "ARE",
+    "name": "Alexandria Real Estate Equities",
+    "sector": "Real Estate"
+  },
+  {
+    "symbol": "ARES",
+    "name": "Ares Management",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "ATO",
+    "name": "Atmos Energy",
+    "sector": "Utilities"
+  },
+  {
+    "symbol": "AVB",
+    "name": "AvalonBay Communities",
+    "sector": "Real Estate"
+  },
+  {
+    "symbol": "AVGO",
+    "name": "Broadcom",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "AVY",
+    "name": "Avery Dennison",
+    "sector": "Materials"
+  },
+  {
+    "symbol": "AWK",
+    "name": "American Water Works",
+    "sector": "Utilities"
+  },
+  {
+    "symbol": "AXON",
+    "name": "Axon Enterprise",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "AXP",
+    "name": "American Express",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "AZO",
+    "name": "AutoZone",
+    "sector": "Consumer Discretionary"
+  },
+  {
+    "symbol": "BA",
+    "name": "Boeing",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "BAC",
+    "name": "Bank of America",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "BALL",
+    "name": "Ball Corporation",
+    "sector": "Materials"
+  },
+  {
+    "symbol": "BAX",
+    "name": "Baxter International",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "BBY",
+    "name": "Best Buy",
+    "sector": "Consumer Discretionary"
+  },
+  {
+    "symbol": "BDX",
+    "name": "Becton Dickinson",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "BEN",
+    "name": "Franklin Resources",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "BF.B",
+    "name": "Brown–Forman",
+    "sector": "Consumer Staples"
+  },
+  {
+    "symbol": "BG",
+    "name": "Bunge Global",
+    "sector": "Consumer Staples"
+  },
+  {
+    "symbol": "BIIB",
+    "name": "Biogen",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "BKNG",
+    "name": "Booking Holdings",
+    "sector": "Consumer Discretionary"
+  },
+  {
+    "symbol": "BKR",
+    "name": "Baker Hughes",
+    "sector": "Energy"
+  },
+  {
+    "symbol": "BLDR",
+    "name": "Builders FirstSource",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "BLK",
+    "name": "BlackRock",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "BMY",
+    "name": "Bristol Myers Squibb",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "BNY",
+    "name": "BNY Mellon",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "BR",
+    "name": "Broadridge Financial Solutions",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "BRK.B",
+    "name": "Berkshire Hathaway",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "BRO",
+    "name": "Brown & Brown",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "BSX",
+    "name": "Boston Scientific",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "BX",
+    "name": "Blackstone Inc.",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "BXP",
+    "name": "BXP, Inc.",
+    "sector": "Real Estate"
+  },
+  {
+    "symbol": "C",
+    "name": "Citigroup",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "CAG",
+    "name": "Conagra Brands",
+    "sector": "Consumer Staples"
+  },
+  {
+    "symbol": "CAH",
+    "name": "Cardinal Health",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "CARR",
+    "name": "Carrier Global",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "CASY",
+    "name": "Casey's",
+    "sector": "Consumer Staples"
+  },
+  {
+    "symbol": "CAT",
+    "name": "Caterpillar Inc.",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "CB",
+    "name": "Chubb Limited",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "CBOE",
+    "name": "Cboe Global Markets",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "CBRE",
+    "name": "CBRE Group",
+    "sector": "Real Estate"
+  },
+  {
+    "symbol": "CCI",
+    "name": "Crown Castle",
+    "sector": "Real Estate"
+  },
+  {
+    "symbol": "CCL",
+    "name": "Carnival Corporation",
+    "sector": "Consumer Discretionary"
+  },
+  {
+    "symbol": "CDNS",
+    "name": "Cadence Design Systems",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "CDW",
+    "name": "CDW Corporation",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "CEG",
+    "name": "Constellation Energy",
+    "sector": "Utilities"
+  },
+  {
+    "symbol": "CF",
+    "name": "CF Industries",
+    "sector": "Materials"
+  },
+  {
+    "symbol": "CFG",
+    "name": "Citizens Financial Group",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "CHD",
+    "name": "Church & Dwight",
+    "sector": "Consumer Staples"
+  },
+  {
+    "symbol": "CHRW",
+    "name": "C.H. Robinson",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "CHTR",
+    "name": "Charter Communications",
+    "sector": "Communication Services"
+  },
+  {
+    "symbol": "CI",
+    "name": "Cigna",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "CIEN",
+    "name": "Ciena",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "CINF",
+    "name": "Cincinnati Financial",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "CL",
+    "name": "Colgate-Palmolive",
+    "sector": "Consumer Staples"
+  },
+  {
+    "symbol": "CLX",
+    "name": "Clorox",
+    "sector": "Consumer Staples"
+  },
+  {
+    "symbol": "CMCSA",
+    "name": "Comcast",
+    "sector": "Communication Services"
+  },
+  {
+    "symbol": "CME",
+    "name": "CME Group",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "CMG",
+    "name": "Chipotle Mexican Grill",
+    "sector": "Consumer Discretionary"
+  },
+  {
+    "symbol": "CMI",
+    "name": "Cummins",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "CMS",
+    "name": "CMS Energy",
+    "sector": "Utilities"
+  },
+  {
+    "symbol": "CNC",
+    "name": "Centene Corporation",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "CNP",
+    "name": "CenterPoint Energy",
+    "sector": "Utilities"
+  },
+  {
+    "symbol": "COF",
+    "name": "Capital One",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "COHR",
+    "name": "Coherent Corp.",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "COIN",
+    "name": "Coinbase",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "COO",
+    "name": "Cooper Companies (The)",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "COP",
+    "name": "ConocoPhillips",
+    "sector": "Energy"
+  },
+  {
+    "symbol": "COR",
+    "name": "Cencora",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "COST",
+    "name": "Costco",
+    "sector": "Consumer Staples"
+  },
+  {
+    "symbol": "CPAY",
+    "name": "Corpay",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "CPB",
+    "name": "Campbell's Company (The)",
+    "sector": "Consumer Staples"
+  },
+  {
+    "symbol": "CPRT",
+    "name": "Copart",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "CPT",
+    "name": "Camden Property Trust",
+    "sector": "Real Estate"
+  },
+  {
+    "symbol": "CRH",
+    "name": "CRH plc",
+    "sector": "Materials"
+  },
+  {
+    "symbol": "CRL",
+    "name": "Charles River Laboratories",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "CRM",
+    "name": "Salesforce",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "CRWD",
+    "name": "CrowdStrike",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "CSCO",
+    "name": "Cisco",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "CSGP",
+    "name": "CoStar Group",
+    "sector": "Real Estate"
+  },
+  {
+    "symbol": "CSX",
+    "name": "CSX Corporation",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "CTAS",
+    "name": "Cintas",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "CTSH",
+    "name": "Cognizant",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "CTVA",
+    "name": "Corteva",
+    "sector": "Materials"
+  },
+  {
+    "symbol": "CVNA",
+    "name": "Carvana",
+    "sector": "Consumer Discretionary"
+  },
+  {
+    "symbol": "CVS",
+    "name": "CVS Health",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "CVX",
+    "name": "Chevron Corporation",
+    "sector": "Energy"
+  },
+  {
+    "symbol": "D",
+    "name": "Dominion Energy",
+    "sector": "Utilities"
+  },
+  {
+    "symbol": "DAL",
+    "name": "Delta Air Lines",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "DASH",
+    "name": "DoorDash",
+    "sector": "Consumer Discretionary"
+  },
+  {
+    "symbol": "DD",
+    "name": "DuPont",
+    "sector": "Materials"
+  },
+  {
+    "symbol": "DDOG",
+    "name": "Datadog",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "DE",
+    "name": "Deere & Company",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "DECK",
+    "name": "Deckers Brands",
+    "sector": "Consumer Discretionary"
+  },
+  {
+    "symbol": "DELL",
+    "name": "Dell Technologies",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "DG",
+    "name": "Dollar General",
+    "sector": "Consumer Staples"
+  },
+  {
+    "symbol": "DGX",
+    "name": "Quest Diagnostics",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "DHI",
+    "name": "D. R. Horton",
+    "sector": "Consumer Discretionary"
+  },
+  {
+    "symbol": "DHR",
+    "name": "Danaher Corporation",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "DIS",
+    "name": "Walt Disney Company (The)",
+    "sector": "Communication Services"
+  },
+  {
+    "symbol": "DLR",
+    "name": "Digital Realty",
+    "sector": "Real Estate"
+  },
+  {
+    "symbol": "DLTR",
+    "name": "Dollar Tree",
+    "sector": "Consumer Staples"
+  },
+  {
+    "symbol": "DOC",
+    "name": "Healthpeak Properties",
+    "sector": "Real Estate"
+  },
+  {
+    "symbol": "DOV",
+    "name": "Dover Corporation",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "DOW",
+    "name": "Dow Inc.",
+    "sector": "Materials"
+  },
+  {
+    "symbol": "DPZ",
+    "name": "Domino's",
+    "sector": "Consumer Discretionary"
+  },
+  {
+    "symbol": "DRI",
+    "name": "Darden Restaurants",
+    "sector": "Consumer Discretionary"
+  },
+  {
+    "symbol": "DTE",
+    "name": "DTE Energy",
+    "sector": "Utilities"
+  },
+  {
+    "symbol": "DUK",
+    "name": "Duke Energy",
+    "sector": "Utilities"
+  },
+  {
+    "symbol": "DVA",
+    "name": "DaVita",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "DVN",
+    "name": "Devon Energy",
+    "sector": "Energy"
+  },
+  {
+    "symbol": "DXCM",
+    "name": "Dexcom",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "EA",
+    "name": "Electronic Arts",
+    "sector": "Communication Services"
+  },
+  {
+    "symbol": "EBAY",
+    "name": "eBay Inc.",
+    "sector": "Consumer Discretionary"
+  },
+  {
+    "symbol": "ECL",
+    "name": "Ecolab",
+    "sector": "Materials"
+  },
+  {
+    "symbol": "ED",
+    "name": "Consolidated Edison",
+    "sector": "Utilities"
+  },
+  {
+    "symbol": "EFX",
+    "name": "Equifax",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "EG",
+    "name": "Everest Group",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "EIX",
+    "name": "Edison International",
+    "sector": "Utilities"
+  },
+  {
+    "symbol": "EL",
+    "name": "Estée Lauder Companies (The)",
+    "sector": "Consumer Staples"
+  },
+  {
+    "symbol": "ELV",
+    "name": "Elevance Health",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "EME",
+    "name": "Emcor",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "EMR",
+    "name": "Emerson Electric",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "EOG",
+    "name": "EOG Resources",
+    "sector": "Energy"
+  },
+  {
+    "symbol": "EQIX",
+    "name": "Equinix",
+    "sector": "Real Estate"
+  },
+  {
+    "symbol": "EQR",
+    "name": "Equity Residential",
+    "sector": "Real Estate"
+  },
+  {
+    "symbol": "EQT",
+    "name": "EQT Corporation",
+    "sector": "Energy"
+  },
+  {
+    "symbol": "ERIE",
+    "name": "Erie Indemnity",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "ES",
+    "name": "Eversource Energy",
+    "sector": "Utilities"
+  },
+  {
+    "symbol": "ESS",
+    "name": "Essex Property Trust",
+    "sector": "Real Estate"
+  },
+  {
+    "symbol": "ETN",
+    "name": "Eaton Corporation",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "ETR",
+    "name": "Entergy",
+    "sector": "Utilities"
+  },
+  {
+    "symbol": "EVRG",
+    "name": "Evergy",
+    "sector": "Utilities"
+  },
+  {
+    "symbol": "EW",
+    "name": "Edwards Lifesciences",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "EXC",
+    "name": "Exelon",
+    "sector": "Utilities"
+  },
+  {
+    "symbol": "EXE",
+    "name": "Expand Energy",
+    "sector": "Energy"
+  },
+  {
+    "symbol": "EXPD",
+    "name": "Expeditors International",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "EXPE",
+    "name": "Expedia Group",
+    "sector": "Consumer Discretionary"
+  },
+  {
+    "symbol": "EXR",
+    "name": "Extra Space Storage",
+    "sector": "Real Estate"
+  },
+  {
+    "symbol": "F",
+    "name": "Ford Motor Company",
+    "sector": "Consumer Discretionary"
+  },
+  {
+    "symbol": "FANG",
+    "name": "Diamondback Energy",
+    "sector": "Energy"
+  },
+  {
+    "symbol": "FAST",
+    "name": "Fastenal",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "FCX",
+    "name": "Freeport-McMoRan",
+    "sector": "Materials"
+  },
+  {
+    "symbol": "FDS",
+    "name": "FactSet",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "FDX",
+    "name": "FedEx",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "FDXF",
+    "name": "FedEx Freight",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "FE",
+    "name": "FirstEnergy",
+    "sector": "Utilities"
+  },
+  {
+    "symbol": "FFIV",
+    "name": "F5, Inc.",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "FICO",
+    "name": "Fair Isaac",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "FIS",
+    "name": "Fidelity National Information Services",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "FISV",
+    "name": "Fiserv",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "FITB",
+    "name": "Fifth Third Bancorp",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "FIX",
+    "name": "Comfort Systems USA",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "FOX",
+    "name": "Fox Corporation",
+    "sector": "Communication Services"
+  },
+  {
+    "symbol": "FOXA",
+    "name": "Fox Corporation",
+    "sector": "Communication Services"
+  },
+  {
+    "symbol": "FRT",
+    "name": "Federal Realty Investment Trust",
+    "sector": "Real Estate"
+  },
+  {
+    "symbol": "FSLR",
+    "name": "First Solar",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "FTNT",
+    "name": "Fortinet",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "FTV",
+    "name": "Fortive",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "GD",
+    "name": "General Dynamics",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "GDDY",
+    "name": "GoDaddy",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "GE",
+    "name": "GE Aerospace",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "GEHC",
+    "name": "GE HealthCare",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "GEN",
+    "name": "Gen Digital",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "GEV",
+    "name": "GE Vernova",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "GILD",
+    "name": "Gilead Sciences",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "GIS",
+    "name": "General Mills",
+    "sector": "Consumer Staples"
+  },
+  {
+    "symbol": "GL",
+    "name": "Globe Life",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "GLW",
+    "name": "Corning Inc.",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "GM",
+    "name": "General Motors",
+    "sector": "Consumer Discretionary"
+  },
+  {
+    "symbol": "GNRC",
+    "name": "Generac",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "GOOG",
+    "name": "Alphabet Inc.",
+    "sector": "Communication Services"
+  },
+  {
+    "symbol": "GOOGL",
+    "name": "Alphabet Inc.",
+    "sector": "Communication Services"
+  },
+  {
+    "symbol": "GPC",
+    "name": "Genuine Parts Company",
+    "sector": "Consumer Discretionary"
+  },
+  {
+    "symbol": "GPN",
+    "name": "Global Payments",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "GRMN",
+    "name": "Garmin",
+    "sector": "Consumer Discretionary"
+  },
+  {
+    "symbol": "GS",
+    "name": "Goldman Sachs",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "GWW",
+    "name": "W. W. Grainger",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "HAL",
+    "name": "Halliburton",
+    "sector": "Energy"
+  },
+  {
+    "symbol": "HAS",
+    "name": "Hasbro",
+    "sector": "Consumer Discretionary"
+  },
+  {
+    "symbol": "HBAN",
+    "name": "Huntington Bancshares",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "HCA",
+    "name": "HCA Healthcare",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "HD",
+    "name": "Home Depot (The)",
+    "sector": "Consumer Discretionary"
+  },
+  {
+    "symbol": "HIG",
+    "name": "Hartford (The)",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "HII",
+    "name": "Huntington Ingalls Industries",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "HLT",
+    "name": "Hilton Worldwide",
+    "sector": "Consumer Discretionary"
+  },
+  {
+    "symbol": "HON",
+    "name": "Honeywell",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "HOOD",
+    "name": "Robinhood Markets",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "HPE",
+    "name": "Hewlett Packard Enterprise",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "HPQ",
+    "name": "HP Inc.",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "HRL",
+    "name": "Hormel Foods",
+    "sector": "Consumer Staples"
+  },
+  {
+    "symbol": "HSIC",
+    "name": "Henry Schein",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "HST",
+    "name": "Host Hotels & Resorts",
+    "sector": "Real Estate"
+  },
+  {
+    "symbol": "HSY",
+    "name": "Hershey Company (The)",
+    "sector": "Consumer Staples"
+  },
+  {
+    "symbol": "HUBB",
+    "name": "Hubbell Incorporated",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "HUM",
+    "name": "Humana",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "HWM",
+    "name": "Howmet Aerospace",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "IBKR",
+    "name": "Interactive Brokers",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "IBM",
+    "name": "IBM",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "ICE",
+    "name": "Intercontinental Exchange",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "IDXX",
+    "name": "Idexx Laboratories",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "IEX",
+    "name": "IDEX Corporation",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "IFF",
+    "name": "International Flavors & Fragrances",
+    "sector": "Materials"
+  },
+  {
+    "symbol": "INCY",
+    "name": "Incyte",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "INTC",
+    "name": "Intel",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "INTU",
+    "name": "Intuit",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "INVH",
+    "name": "Invitation Homes",
+    "sector": "Real Estate"
+  },
+  {
+    "symbol": "IP",
+    "name": "International Paper",
+    "sector": "Materials"
+  },
+  {
+    "symbol": "IQV",
+    "name": "IQVIA",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "IR",
+    "name": "Ingersoll Rand",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "IRM",
+    "name": "Iron Mountain",
+    "sector": "Real Estate"
+  },
+  {
+    "symbol": "ISRG",
+    "name": "Intuitive Surgical",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "IT",
+    "name": "Gartner",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "ITW",
+    "name": "Illinois Tool Works",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "IVZ",
+    "name": "Invesco",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "J",
+    "name": "Jacobs Solutions",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "JBHT",
+    "name": "J.B. Hunt",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "JBL",
+    "name": "Jabil",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "JCI",
+    "name": "Johnson Controls",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "JKHY",
+    "name": "Jack Henry & Associates",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "JNJ",
+    "name": "Johnson & Johnson",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "JPM",
+    "name": "JPMorgan Chase",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "KDP",
+    "name": "Keurig Dr Pepper",
+    "sector": "Consumer Staples"
+  },
+  {
+    "symbol": "KEY",
+    "name": "KeyCorp",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "KEYS",
+    "name": "Keysight Technologies",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "KHC",
+    "name": "Kraft Heinz",
+    "sector": "Consumer Staples"
+  },
+  {
+    "symbol": "KIM",
+    "name": "Kimco Realty",
+    "sector": "Real Estate"
+  },
+  {
+    "symbol": "KKR",
+    "name": "KKR & Co.",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "KLAC",
+    "name": "KLA Corporation",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "KMB",
+    "name": "Kimberly-Clark",
+    "sector": "Consumer Staples"
+  },
+  {
+    "symbol": "KMI",
+    "name": "Kinder Morgan",
+    "sector": "Energy"
+  },
+  {
+    "symbol": "KO",
+    "name": "Coca-Cola Company (The)",
+    "sector": "Consumer Staples"
+  },
+  {
+    "symbol": "KR",
+    "name": "Kroger",
+    "sector": "Consumer Staples"
+  },
+  {
+    "symbol": "KVUE",
+    "name": "Kenvue",
+    "sector": "Consumer Staples"
+  },
+  {
+    "symbol": "L",
+    "name": "Loews Corporation",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "LDOS",
+    "name": "Leidos",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "LEN",
+    "name": "Lennar",
+    "sector": "Consumer Discretionary"
+  },
+  {
+    "symbol": "LH",
+    "name": "Labcorp",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "LHX",
+    "name": "L3Harris",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "LII",
+    "name": "Lennox International",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "LIN",
+    "name": "Linde plc",
+    "sector": "Materials"
+  },
+  {
+    "symbol": "LITE",
+    "name": "Lumentum",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "LLY",
+    "name": "Lilly (Eli)",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "LMT",
+    "name": "Lockheed Martin",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "LNT",
+    "name": "Alliant Energy",
+    "sector": "Utilities"
+  },
+  {
+    "symbol": "LOW",
+    "name": "Lowe's",
+    "sector": "Consumer Discretionary"
+  },
+  {
+    "symbol": "LRCX",
+    "name": "Lam Research",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "LULU",
+    "name": "Lululemon Athletica",
+    "sector": "Consumer Discretionary"
+  },
+  {
+    "symbol": "LUV",
+    "name": "Southwest Airlines",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "LVS",
+    "name": "Las Vegas Sands",
+    "sector": "Consumer Discretionary"
+  },
+  {
+    "symbol": "LYB",
+    "name": "LyondellBasell",
+    "sector": "Materials"
+  },
+  {
+    "symbol": "LYV",
+    "name": "Live Nation Entertainment",
+    "sector": "Communication Services"
+  },
+  {
+    "symbol": "MA",
+    "name": "Mastercard",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "MAA",
+    "name": "Mid-America Apartment Communities",
+    "sector": "Real Estate"
+  },
+  {
+    "symbol": "MAR",
+    "name": "Marriott International",
+    "sector": "Consumer Discretionary"
+  },
+  {
+    "symbol": "MAS",
+    "name": "Masco",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "MCD",
+    "name": "McDonald's",
+    "sector": "Consumer Discretionary"
+  },
+  {
+    "symbol": "MCHP",
+    "name": "Microchip Technology",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "MCK",
+    "name": "McKesson Corporation",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "MCO",
+    "name": "Moody's Corporation",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "MDLZ",
+    "name": "Mondelez International",
+    "sector": "Consumer Staples"
+  },
+  {
+    "symbol": "MDT",
+    "name": "Medtronic",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "MET",
+    "name": "MetLife",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "META",
+    "name": "Meta Platforms",
+    "sector": "Communication Services"
+  },
+  {
+    "symbol": "MGM",
+    "name": "MGM Resorts",
+    "sector": "Consumer Discretionary"
+  },
+  {
+    "symbol": "MKC",
+    "name": "McCormick & Company",
+    "sector": "Consumer Staples"
+  },
+  {
+    "symbol": "MLM",
+    "name": "Martin Marietta Materials",
+    "sector": "Materials"
+  },
+  {
+    "symbol": "MMM",
+    "name": "3M",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "MNST",
+    "name": "Monster Beverage",
+    "sector": "Consumer Staples"
+  },
+  {
+    "symbol": "MO",
+    "name": "Altria",
+    "sector": "Consumer Staples"
+  },
+  {
+    "symbol": "MOS",
+    "name": "Mosaic Company (The)",
+    "sector": "Materials"
+  },
+  {
+    "symbol": "MPC",
+    "name": "Marathon Petroleum",
+    "sector": "Energy"
+  },
+  {
+    "symbol": "MPWR",
+    "name": "Monolithic Power Systems",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "MRK",
+    "name": "Merck & Co.",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "MRNA",
+    "name": "Moderna",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "MRSH",
+    "name": "Marsh McLennan",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "MS",
+    "name": "Morgan Stanley",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "MSCI",
+    "name": "MSCI Inc.",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "MSFT",
+    "name": "Microsoft",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "MSI",
+    "name": "Motorola Solutions",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "MTB",
+    "name": "M&T Bank",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "MTD",
+    "name": "Mettler Toledo",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "MU",
+    "name": "Micron Technology",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "NCLH",
+    "name": "Norwegian Cruise Line Holdings",
+    "sector": "Consumer Discretionary"
+  },
+  {
+    "symbol": "NDAQ",
+    "name": "Nasdaq, Inc.",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "NDSN",
+    "name": "Nordson Corporation",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "NEE",
+    "name": "NextEra Energy",
+    "sector": "Utilities"
+  },
+  {
+    "symbol": "NEM",
+    "name": "Newmont",
+    "sector": "Materials"
+  },
+  {
+    "symbol": "NFLX",
+    "name": "Netflix",
+    "sector": "Communication Services"
+  },
+  {
+    "symbol": "NI",
+    "name": "NiSource",
+    "sector": "Utilities"
+  },
+  {
+    "symbol": "NKE",
+    "name": "Nike, Inc.",
+    "sector": "Consumer Discretionary"
+  },
+  {
+    "symbol": "NOC",
+    "name": "Northrop Grumman",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "NOW",
+    "name": "ServiceNow",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "NRG",
+    "name": "NRG Energy",
+    "sector": "Utilities"
+  },
+  {
+    "symbol": "NSC",
+    "name": "Norfolk Southern",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "NTAP",
+    "name": "NetApp",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "NTRS",
+    "name": "Northern Trust",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "NUE",
+    "name": "Nucor",
+    "sector": "Materials"
+  },
+  {
+    "symbol": "NVDA",
+    "name": "Nvidia",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "NVR",
+    "name": "NVR, Inc.",
+    "sector": "Consumer Discretionary"
+  },
+  {
+    "symbol": "NWS",
+    "name": "News Corp",
+    "sector": "Communication Services"
+  },
+  {
+    "symbol": "NWSA",
+    "name": "News Corp",
+    "sector": "Communication Services"
+  },
+  {
+    "symbol": "NXPI",
+    "name": "NXP Semiconductors",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "O",
+    "name": "Realty Income",
+    "sector": "Real Estate"
+  },
+  {
+    "symbol": "ODFL",
+    "name": "Old Dominion",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "OKE",
+    "name": "Oneok",
+    "sector": "Energy"
+  },
+  {
+    "symbol": "OMC",
+    "name": "Omnicom Group",
+    "sector": "Communication Services"
+  },
+  {
+    "symbol": "ON",
+    "name": "ON Semiconductor",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "ORCL",
+    "name": "Oracle Corporation",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "ORLY",
+    "name": "O’Reilly Automotive",
+    "sector": "Consumer Discretionary"
+  },
+  {
+    "symbol": "OTIS",
+    "name": "Otis Worldwide",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "OXY",
+    "name": "Occidental Petroleum",
+    "sector": "Energy"
+  },
+  {
+    "symbol": "PANW",
+    "name": "Palo Alto Networks",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "PAYX",
+    "name": "Paychex",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "PCAR",
+    "name": "Paccar",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "PCG",
+    "name": "PG&E Corporation",
+    "sector": "Utilities"
+  },
+  {
+    "symbol": "PEG",
+    "name": "Public Service Enterprise Group",
+    "sector": "Utilities"
+  },
+  {
+    "symbol": "PEP",
+    "name": "PepsiCo",
+    "sector": "Consumer Staples"
+  },
+  {
+    "symbol": "PFE",
+    "name": "Pfizer",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "PFG",
+    "name": "Principal Financial Group",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "PG",
+    "name": "Procter & Gamble",
+    "sector": "Consumer Staples"
+  },
+  {
+    "symbol": "PGR",
+    "name": "Progressive Corporation",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "PH",
+    "name": "Parker Hannifin",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "PHM",
+    "name": "PulteGroup",
+    "sector": "Consumer Discretionary"
+  },
+  {
+    "symbol": "PKG",
+    "name": "Packaging Corporation of America",
+    "sector": "Materials"
+  },
+  {
+    "symbol": "PLD",
+    "name": "Prologis",
+    "sector": "Real Estate"
+  },
+  {
+    "symbol": "PLTR",
+    "name": "Palantir Technologies",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "PM",
+    "name": "Philip Morris International",
+    "sector": "Consumer Staples"
+  },
+  {
+    "symbol": "PNC",
+    "name": "PNC Financial Services",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "PNR",
+    "name": "Pentair",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "PNW",
+    "name": "Pinnacle West Capital",
+    "sector": "Utilities"
+  },
+  {
+    "symbol": "PODD",
+    "name": "Insulet Corporation",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "POOL",
+    "name": "Pool Corporation",
+    "sector": "Consumer Discretionary"
+  },
+  {
+    "symbol": "PPG",
+    "name": "PPG Industries",
+    "sector": "Materials"
+  },
+  {
+    "symbol": "PPL",
+    "name": "PPL Corporation",
+    "sector": "Utilities"
+  },
+  {
+    "symbol": "PRU",
+    "name": "Prudential Financial",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "PSA",
+    "name": "Public Storage",
+    "sector": "Real Estate"
+  },
+  {
+    "symbol": "PSKY",
+    "name": "Paramount Skydance Corporation",
+    "sector": "Communication Services"
+  },
+  {
+    "symbol": "PSX",
+    "name": "Phillips 66",
+    "sector": "Energy"
+  },
+  {
+    "symbol": "PTC",
+    "name": "PTC Inc.",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "PWR",
+    "name": "Quanta Services",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "PYPL",
+    "name": "PayPal",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "Q",
+    "name": "Qnity Electronics",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "QCOM",
+    "name": "Qualcomm",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "RCL",
+    "name": "Royal Caribbean Group",
+    "sector": "Consumer Discretionary"
+  },
+  {
+    "symbol": "REG",
+    "name": "Regency Centers",
+    "sector": "Real Estate"
+  },
+  {
+    "symbol": "REGN",
+    "name": "Regeneron Pharmaceuticals",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "RF",
+    "name": "Regions Financial Corporation",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "RJF",
+    "name": "Raymond James Financial",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "RL",
+    "name": "Ralph Lauren Corporation",
+    "sector": "Consumer Discretionary"
+  },
+  {
+    "symbol": "RMD",
+    "name": "ResMed",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "ROK",
+    "name": "Rockwell Automation",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "ROL",
+    "name": "Rollins, Inc.",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "ROP",
+    "name": "Roper Technologies",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "ROST",
+    "name": "Ross Stores",
+    "sector": "Consumer Discretionary"
+  },
+  {
+    "symbol": "RSG",
+    "name": "Republic Services",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "RTX",
+    "name": "RTX Corporation",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "RVTY",
+    "name": "Revvity",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "SATS",
+    "name": "EchoStar",
+    "sector": "Communication Services"
+  },
+  {
+    "symbol": "SBAC",
+    "name": "SBA Communications",
+    "sector": "Real Estate"
+  },
+  {
+    "symbol": "SBUX",
+    "name": "Starbucks",
+    "sector": "Consumer Discretionary"
+  },
+  {
+    "symbol": "SCHW",
+    "name": "Charles Schwab Corporation",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "SHW",
+    "name": "Sherwin-Williams",
+    "sector": "Materials"
+  },
+  {
+    "symbol": "SJM",
+    "name": "J.M. Smucker Company (The)",
+    "sector": "Consumer Staples"
+  },
+  {
+    "symbol": "SLB",
+    "name": "Schlumberger",
+    "sector": "Energy"
+  },
+  {
+    "symbol": "SMCI",
+    "name": "Supermicro",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "SNA",
+    "name": "Snap-on",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "SNDK",
+    "name": "Sandisk",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "SNPS",
+    "name": "Synopsys",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "SO",
+    "name": "Southern Company",
+    "sector": "Utilities"
+  },
+  {
+    "symbol": "SOLV",
+    "name": "Solventum",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "SPG",
+    "name": "Simon Property Group",
+    "sector": "Real Estate"
+  },
+  {
+    "symbol": "SPGI",
+    "name": "S&P Global",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "SRE",
+    "name": "Sempra",
+    "sector": "Utilities"
+  },
+  {
+    "symbol": "STE",
+    "name": "Steris",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "STLD",
+    "name": "Steel Dynamics",
+    "sector": "Materials"
+  },
+  {
+    "symbol": "STT",
+    "name": "State Street Corporation",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "STX",
+    "name": "Seagate Technology",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "STZ",
+    "name": "Constellation Brands",
+    "sector": "Consumer Staples"
+  },
+  {
+    "symbol": "SW",
+    "name": "Smurfit Westrock",
+    "sector": "Materials"
+  },
+  {
+    "symbol": "SWK",
+    "name": "Stanley Black & Decker",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "SWKS",
+    "name": "Skyworks Solutions",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "SYF",
+    "name": "Synchrony Financial",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "SYK",
+    "name": "Stryker Corporation",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "SYY",
+    "name": "Sysco",
+    "sector": "Consumer Staples"
+  },
+  {
+    "symbol": "T",
+    "name": "AT&T",
+    "sector": "Communication Services"
+  },
+  {
+    "symbol": "TAP",
+    "name": "Molson Coors Beverage Company",
+    "sector": "Consumer Staples"
+  },
+  {
+    "symbol": "TDG",
+    "name": "TransDigm Group",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "TDY",
+    "name": "Teledyne Technologies",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "TECH",
+    "name": "Bio-Techne",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "TEL",
+    "name": "TE Connectivity",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "TER",
+    "name": "Teradyne",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "TFC",
+    "name": "Truist Financial",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "TGT",
+    "name": "Target Corporation",
+    "sector": "Consumer Staples"
+  },
+  {
+    "symbol": "TJX",
+    "name": "TJX Companies",
+    "sector": "Consumer Discretionary"
+  },
+  {
+    "symbol": "TKO",
+    "name": "TKO Group Holdings",
+    "sector": "Communication Services"
+  },
+  {
+    "symbol": "TMO",
+    "name": "Thermo Fisher Scientific",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "TMUS",
+    "name": "T-Mobile US",
+    "sector": "Communication Services"
+  },
+  {
+    "symbol": "TPL",
+    "name": "Texas Pacific Land Corporation",
+    "sector": "Energy"
+  },
+  {
+    "symbol": "TPR",
+    "name": "Tapestry, Inc.",
+    "sector": "Consumer Discretionary"
+  },
+  {
+    "symbol": "TRGP",
+    "name": "Targa Resources",
+    "sector": "Energy"
+  },
+  {
+    "symbol": "TRMB",
+    "name": "Trimble Inc.",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "TROW",
+    "name": "T. Rowe Price",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "TRV",
+    "name": "Travelers Companies (The)",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "TSCO",
+    "name": "Tractor Supply",
+    "sector": "Consumer Discretionary"
+  },
+  {
+    "symbol": "TSLA",
+    "name": "Tesla, Inc.",
+    "sector": "Consumer Discretionary"
+  },
+  {
+    "symbol": "TSN",
+    "name": "Tyson Foods",
+    "sector": "Consumer Staples"
+  },
+  {
+    "symbol": "TT",
+    "name": "Trane Technologies",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "TTD",
+    "name": "Trade Desk (The)",
+    "sector": "Communication Services"
+  },
+  {
+    "symbol": "TTWO",
+    "name": "Take-Two Interactive",
+    "sector": "Communication Services"
+  },
+  {
+    "symbol": "TXN",
+    "name": "Texas Instruments",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "TXT",
+    "name": "Textron",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "TYL",
+    "name": "Tyler Technologies",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "UAL",
+    "name": "United Airlines Holdings",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "UBER",
+    "name": "Uber",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "UDR",
+    "name": "UDR, Inc.",
+    "sector": "Real Estate"
+  },
+  {
+    "symbol": "UHS",
+    "name": "Universal Health Services",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "ULTA",
+    "name": "Ulta Beauty",
+    "sector": "Consumer Discretionary"
+  },
+  {
+    "symbol": "UNH",
+    "name": "UnitedHealth Group",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "UNP",
+    "name": "Union Pacific Corporation",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "UPS",
+    "name": "United Parcel Service",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "URI",
+    "name": "United Rentals",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "USB",
+    "name": "U.S. Bancorp",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "V",
+    "name": "Visa Inc.",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "VEEV",
+    "name": "Veeva Systems",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "VICI",
+    "name": "Vici Properties",
+    "sector": "Real Estate"
+  },
+  {
+    "symbol": "VLO",
+    "name": "Valero Energy",
+    "sector": "Energy"
+  },
+  {
+    "symbol": "VLTO",
+    "name": "Veralto",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "VMC",
+    "name": "Vulcan Materials Company",
+    "sector": "Materials"
+  },
+  {
+    "symbol": "VRSK",
+    "name": "Verisk Analytics",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "VRSN",
+    "name": "Verisign",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "VRT",
+    "name": "Vertiv",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "VRTX",
+    "name": "Vertex Pharmaceuticals",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "VST",
+    "name": "Vistra Corp",
+    "sector": "Utilities"
+  },
+  {
+    "symbol": "VTR",
+    "name": "Ventas",
+    "sector": "Real Estate"
+  },
+  {
+    "symbol": "VTRS",
+    "name": "Viatris",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "VZ",
+    "name": "Verizon",
+    "sector": "Communication Services"
+  },
+  {
+    "symbol": "WAB",
+    "name": "Wabtec",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "WAT",
+    "name": "Waters Corporation",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "WBD",
+    "name": "Warner Bros. Discovery",
+    "sector": "Communication Services"
+  },
+  {
+    "symbol": "WDAY",
+    "name": "Workday, Inc.",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "WDC",
+    "name": "Western Digital",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "WEC",
+    "name": "WEC Energy Group",
+    "sector": "Utilities"
+  },
+  {
+    "symbol": "WELL",
+    "name": "Welltower",
+    "sector": "Real Estate"
+  },
+  {
+    "symbol": "WFC",
+    "name": "Wells Fargo",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "WM",
+    "name": "Waste Management",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "WMB",
+    "name": "Williams Companies",
+    "sector": "Energy"
+  },
+  {
+    "symbol": "WMT",
+    "name": "Walmart",
+    "sector": "Consumer Staples"
+  },
+  {
+    "symbol": "WRB",
+    "name": "W. R. Berkley Corporation",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "WSM",
+    "name": "Williams-Sonoma, Inc.",
+    "sector": "Consumer Discretionary"
+  },
+  {
+    "symbol": "WST",
+    "name": "West Pharmaceutical Services",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "WTW",
+    "name": "Willis Towers Watson",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "WY",
+    "name": "Weyerhaeuser",
+    "sector": "Real Estate"
+  },
+  {
+    "symbol": "WYNN",
+    "name": "Wynn Resorts",
+    "sector": "Consumer Discretionary"
+  },
+  {
+    "symbol": "XEL",
+    "name": "Xcel Energy",
+    "sector": "Utilities"
+  },
+  {
+    "symbol": "XOM",
+    "name": "ExxonMobil",
+    "sector": "Energy"
+  },
+  {
+    "symbol": "XYL",
+    "name": "Xylem Inc.",
+    "sector": "Industrials"
+  },
+  {
+    "symbol": "XYZ",
+    "name": "Block, Inc.",
+    "sector": "Financials"
+  },
+  {
+    "symbol": "YUM",
+    "name": "Yum! Brands",
+    "sector": "Consumer Discretionary"
+  },
+  {
+    "symbol": "ZBH",
+    "name": "Zimmer Biomet",
+    "sector": "Health Care"
+  },
+  {
+    "symbol": "ZBRA",
+    "name": "Zebra Technologies",
+    "sector": "Information Technology"
+  },
+  {
+    "symbol": "ZTS",
+    "name": "Zoetis",
+    "sector": "Health Care"
+  }
+]

--- a/src/maps.indexes.json
+++ b/src/maps.indexes.json
@@ -1732,8 +1732,8 @@
       "symbol": "LULU",
       "name": "Lululemon Athletica",
       "sector": "Consumer Discretionary",
-      "nameShort": "Lululemon",
-      "marketCap": null
+      "marketCap": null,
+      "nameShort": "Lululemon"
     },
     {
       "symbol": "LUV",
@@ -2075,8 +2075,8 @@
       "symbol": "ODFL",
       "name": "Old Dominion",
       "sector": "Industrials",
-      "nameShort": "Old Dominion Freight Line",
-      "marketCap": null
+      "marketCap": null,
+      "nameShort": "Old Dominion Freight Line"
     },
     {
       "symbol": "OKE",
@@ -2094,8 +2094,8 @@
       "symbol": "ON",
       "name": "ON Semiconductor",
       "sector": "Information Technology",
-      "nameShort": "Onsemi",
-      "marketCap": null
+      "marketCap": null,
+      "nameShort": "Onsemi"
     },
     {
       "symbol": "ORCL",
@@ -2107,8 +2107,8 @@
       "symbol": "ORLY",
       "name": "O’Reilly Automotive",
       "sector": "Consumer Discretionary",
-      "nameShort": "O'Reilly Automotive",
-      "marketCap": null
+      "marketCap": null,
+      "nameShort": "O'Reilly Automotive"
     },
     {
       "symbol": "OTIS",
@@ -3448,15 +3448,15 @@
       "symbol": "ODFL",
       "name": "Old Dominion Freight Line",
       "sector": null,
-      "nameShort": "Old Dominion Freight Line",
-      "marketCap": null
+      "marketCap": null,
+      "nameShort": "Old Dominion Freight Line"
     },
     {
       "symbol": "ORLY",
       "name": "O'Reilly Automotive",
       "sector": null,
-      "nameShort": "O'Reilly Automotive",
-      "marketCap": null
+      "marketCap": null,
+      "nameShort": "O'Reilly Automotive"
     },
     {
       "symbol": "PANW",
@@ -5710,7 +5710,7 @@
     },
     {
       "symbol": "ACHV",
-      "name": "Achieve Life Sciences, Inc.  - Common Shares",
+      "name": "Achieve Life Sciences, Inc. - Common Shares",
       "sector": null,
       "marketCap": null
     },
@@ -5992,7 +5992,7 @@
     },
     {
       "symbol": "ADV",
-      "name": "Advantage Solutions Inc.  - Class A Common Stock",
+      "name": "Advantage Solutions Inc. - Class A Common Stock",
       "sector": null,
       "marketCap": null
     },
@@ -7522,7 +7522,7 @@
     },
     {
       "symbol": "APWC",
-      "name": "Asia Pacific Wire & Cable Corporation Limited  - Common shares, Par value .01 per share",
+      "name": "Asia Pacific Wire & Cable Corporation Limited - Common shares, Par value .01 per share",
       "sector": null,
       "marketCap": null
     },
@@ -7834,7 +7834,7 @@
     },
     {
       "symbol": "ASA",
-      "name": "ASA  Gold and Precious Metals Limited",
+      "name": "ASA Gold and Precious Metals Limited",
       "sector": null,
       "marketCap": null
     },
@@ -8266,7 +8266,7 @@
     },
     {
       "symbol": "AUR",
-      "name": "Aurora Innovation, Inc.  - Class A Common Stock",
+      "name": "Aurora Innovation, Inc. - Class A Common Stock",
       "sector": null,
       "marketCap": null
     },
@@ -8278,7 +8278,7 @@
     },
     {
       "symbol": "AURE",
-      "name": "Aurelion Inc.  - Class A Ordinary Shares",
+      "name": "Aurelion Inc. - Class A Ordinary Shares",
       "sector": null,
       "marketCap": null
     },
@@ -9442,7 +9442,7 @@
     },
     {
       "symbol": "BIO.B",
-      "name": "Bio-Rad Laboratories, Inc. Class B  Common Stock",
+      "name": "Bio-Rad Laboratories, Inc. Class B Common Stock",
       "sector": null,
       "marketCap": null
     },
@@ -9496,7 +9496,7 @@
     },
     {
       "symbol": "BIYA",
-      "name": "Baiya International Group Inc.  - Ordinary Shares",
+      "name": "Baiya International Group Inc. - Ordinary Shares",
       "sector": null,
       "marketCap": null
     },
@@ -9724,7 +9724,7 @@
     },
     {
       "symbol": "BMA",
-      "name": "Banco Macro S.A.  ADR (representing Ten Class B Common Shares)",
+      "name": "Banco Macro S.A. ADR (representing Ten Class B Common Shares)",
       "sector": null,
       "marketCap": null
     },
@@ -10348,7 +10348,7 @@
     },
     {
       "symbol": "BTI",
-      "name": "British American Tobacco  Industries, p.l.c. Common Stock ADR",
+      "name": "British American Tobacco Industries, p.l.c. Common Stock ADR",
       "sector": null,
       "marketCap": null
     },
@@ -10912,7 +10912,7 @@
     },
     {
       "symbol": "CB",
-      "name": "Chubb Limited  Common Stock",
+      "name": "Chubb Limited Common Stock",
       "sector": null,
       "marketCap": null
     },
@@ -11662,7 +11662,7 @@
     },
     {
       "symbol": "CHR",
-      "name": "Cheer Holding, Inc.  - Class A Ordinary Share",
+      "name": "Cheer Holding, Inc. - Class A Ordinary Share",
       "sector": null,
       "marketCap": null
     },
@@ -11764,7 +11764,7 @@
     },
     {
       "symbol": "CIGI",
-      "name": "Colliers International Group Inc.  - Subordinate Voting Shares",
+      "name": "Colliers International Group Inc. - Subordinate Voting Shares",
       "sector": null,
       "marketCap": null
     },
@@ -11980,7 +11980,7 @@
     },
     {
       "symbol": "CLOV",
-      "name": "Clover Health Investments, Corp.  - Class A Common stock",
+      "name": "Clover Health Investments, Corp. - Class A Common stock",
       "sector": null,
       "marketCap": null
     },
@@ -13276,7 +13276,7 @@
     },
     {
       "symbol": "CURI",
-      "name": "CuriosityStream Inc.  - Class A Common Stock",
+      "name": "CuriosityStream Inc. - Class A Common Stock",
       "sector": null,
       "marketCap": null
     },
@@ -13636,7 +13636,7 @@
     },
     {
       "symbol": "DAVE",
-      "name": "Dave Inc.  - Class A Common Stock",
+      "name": "Dave Inc. - Class A Common Stock",
       "sector": null,
       "marketCap": null
     },
@@ -13894,7 +13894,7 @@
     },
     {
       "symbol": "DFTX",
-      "name": "Definium Therapeutics, Inc.  - Common Shares",
+      "name": "Definium Therapeutics, Inc. - Common Shares",
       "sector": null,
       "marketCap": null
     },
@@ -13960,7 +13960,7 @@
     },
     {
       "symbol": "DHC",
-      "name": "Diversified Healthcare Trust  - Common Shares of Beneficial Interest",
+      "name": "Diversified Healthcare Trust - Common Shares of Beneficial Interest",
       "sector": null,
       "marketCap": null
     },
@@ -14980,7 +14980,7 @@
     },
     {
       "symbol": "EGY",
-      "name": "VAALCO Energy, Inc.  Common Stock",
+      "name": "VAALCO Energy, Inc. Common Stock",
       "sector": null,
       "marketCap": null
     },
@@ -15862,7 +15862,7 @@
     },
     {
       "symbol": "EVI",
-      "name": "EVI Industries, Inc.  Common Stock",
+      "name": "EVI Industries, Inc. Common Stock",
       "sector": null,
       "marketCap": null
     },
@@ -16420,7 +16420,7 @@
     },
     {
       "symbol": "FF",
-      "name": "FutureFuel Corp.  Common shares",
+      "name": "FutureFuel Corp. Common shares",
       "sector": null,
       "marketCap": null
     },
@@ -16858,13 +16858,13 @@
     },
     {
       "symbol": "FNGD",
-      "name": "MicroSectors FANG  Index -3X Inverse Leveraged ETNs due January 8, 2038",
+      "name": "MicroSectors FANG Index -3X Inverse Leveraged ETNs due January 8, 2038",
       "sector": null,
       "marketCap": null
     },
     {
       "symbol": "FNGO",
-      "name": "MicroSectors FANG  Index 2X Leveraged ETNs due January 8, 2038",
+      "name": "MicroSectors FANG Index 2X Leveraged ETNs due January 8, 2038",
       "sector": null,
       "marketCap": null
     },
@@ -17002,7 +17002,7 @@
     },
     {
       "symbol": "FRA",
-      "name": "Blackrock Floating Rate Income Strategies Fund Inc  Common Stock",
+      "name": "Blackrock Floating Rate Income Strategies Fund Inc Common Stock",
       "sector": null,
       "marketCap": null
     },
@@ -17638,7 +17638,7 @@
     },
     {
       "symbol": "GDHG",
-      "name": "Golden Heaven Group Holdings Ltd.  - Class A Ordinary Shares",
+      "name": "Golden Heaven Group Holdings Ltd. - Class A Ordinary Shares",
       "sector": null,
       "marketCap": null
     },
@@ -18202,7 +18202,7 @@
     },
     {
       "symbol": "GMM",
-      "name": "Global Mofy AI Limited  - Class A Ordinary Shares",
+      "name": "Global Mofy AI Limited - Class A Ordinary Shares",
       "sector": null,
       "marketCap": null
     },
@@ -19138,7 +19138,7 @@
     },
     {
       "symbol": "HERZ",
-      "name": "Herzfeld Credit Income Fund, Inc.  - Closed End Fund",
+      "name": "Herzfeld Credit Income Fund, Inc. - Closed End Fund",
       "sector": null,
       "marketCap": null
     },
@@ -19288,7 +19288,7 @@
     },
     {
       "symbol": "HKPD",
-      "name": "Cellyan Biotechnology Co., Ltd  - Class A Ordinary Shares",
+      "name": "Cellyan Biotechnology Co., Ltd - Class A Ordinary Shares",
       "sector": null,
       "marketCap": null
     },
@@ -19942,7 +19942,7 @@
     },
     {
       "symbol": "HYPR",
-      "name": "Hyperfine, Inc.  - Class A Common Stock",
+      "name": "Hyperfine, Inc. - Class A Common Stock",
       "sector": null,
       "marketCap": null
     },
@@ -19954,7 +19954,7 @@
     },
     {
       "symbol": "HZO",
-      "name": "MarineMax, Inc.  (FL) Common Stock",
+      "name": "MarineMax, Inc. (FL) Common Stock",
       "sector": null,
       "marketCap": null
     },
@@ -20626,7 +20626,7 @@
     },
     {
       "symbol": "INMD",
-      "name": "InMode Ltd.  - Ordinary Shares",
+      "name": "InMode Ltd. - Ordinary Shares",
       "sector": null,
       "marketCap": null
     },
@@ -25241,7 +25241,7 @@
     },
     {
       "symbol": "MUC",
-      "name": "Blackrock MuniHoldings California Quality Fund, Inc.  Common Stock",
+      "name": "Blackrock MuniHoldings California Quality Fund, Inc. Common Stock",
       "sector": null,
       "marketCap": null
     },
@@ -25397,7 +25397,7 @@
     },
     {
       "symbol": "MYPS",
-      "name": "PLAYSTUDIOS, Inc.  - Class A Common Stock",
+      "name": "PLAYSTUDIOS, Inc. - Class A Common Stock",
       "sector": null,
       "marketCap": null
     },
@@ -27655,7 +27655,7 @@
     },
     {
       "symbol": "ORGO",
-      "name": "Organogenesis Holdings Inc.  - Class A",
+      "name": "Organogenesis Holdings Inc. - Class A",
       "sector": null,
       "marketCap": null
     },
@@ -28082,7 +28082,7 @@
     },
     {
       "symbol": "PARR",
-      "name": "Par Pacific Holdings, Inc.  Common Stock",
+      "name": "Par Pacific Holdings, Inc. Common Stock",
       "sector": null,
       "marketCap": null
     },
@@ -29030,7 +29030,7 @@
     },
     {
       "symbol": "PMCB",
-      "name": "PharmaCyte  Biotech, Inc.",
+      "name": "PharmaCyte Biotech, Inc.",
       "sector": null,
       "marketCap": null
     },
@@ -31562,7 +31562,7 @@
     },
     {
       "symbol": "SAP",
-      "name": "SAP  SE ADS",
+      "name": "SAP SE ADS",
       "sector": null,
       "marketCap": null
     },
@@ -33716,7 +33716,7 @@
     },
     {
       "symbol": "SU",
-      "name": "Suncor Energy  Inc. Common Stock",
+      "name": "Suncor Energy Inc. Common Stock",
       "sector": null,
       "marketCap": null
     },
@@ -34322,7 +34322,7 @@
     },
     {
       "symbol": "TEAM",
-      "name": "Atlassian Corporation  - Class A Common Stock",
+      "name": "Atlassian Corporation - Class A Common Stock",
       "sector": null,
       "marketCap": null
     },
@@ -34832,7 +34832,7 @@
     },
     {
       "symbol": "TNL",
-      "name": "Travel   Leisure Co. Common  Stock",
+      "name": "Travel Leisure Co. Common Stock",
       "sector": null,
       "marketCap": null
     },
@@ -35132,7 +35132,7 @@
     },
     {
       "symbol": "TROO",
-      "name": "TROOPS, Inc.  - Ordinary Shares",
+      "name": "TROOPS, Inc. - Ordinary Shares",
       "sector": null,
       "marketCap": null
     },
@@ -35732,7 +35732,7 @@
     },
     {
       "symbol": "UK",
-      "name": "Ucommune International Ltd  - Class A Ordinary Shares",
+      "name": "Ucommune International Ltd - Class A Ordinary Shares",
       "sector": null,
       "marketCap": null
     },
@@ -35816,13 +35816,13 @@
     },
     {
       "symbol": "UONE",
-      "name": "Urban One, Inc.  - Class A Common Stock",
+      "name": "Urban One, Inc. - Class A Common Stock",
       "sector": null,
       "marketCap": null
     },
     {
       "symbol": "UONEK",
-      "name": "Urban One, Inc.  - Class D Common Stock",
+      "name": "Urban One, Inc. - Class D Common Stock",
       "sector": null,
       "marketCap": null
     },
@@ -35936,7 +35936,7 @@
     },
     {
       "symbol": "USCB",
-      "name": "USCB Financial Holdings, Inc.  - Class A Common Stock",
+      "name": "USCB Financial Holdings, Inc. - Class A Common Stock",
       "sector": null,
       "marketCap": null
     },
@@ -36518,7 +36518,7 @@
     },
     {
       "symbol": "VNOM",
-      "name": "Viper Energy, Inc.  - Class A Common Stock",
+      "name": "Viper Energy, Inc. - Class A Common Stock",
       "sector": null,
       "marketCap": null
     },
@@ -36716,7 +36716,7 @@
     },
     {
       "symbol": "VSTD",
-      "name": "Vestand Inc.  - Class A Common Stock",
+      "name": "Vestand Inc. - Class A Common Stock",
       "sector": null,
       "marketCap": null
     },
@@ -37214,7 +37214,7 @@
     },
     {
       "symbol": "WILC",
-      "name": "G. Willi-Food International,  Ltd. - Ordinary Shares",
+      "name": "G. Willi-Food International, Ltd. - Ordinary Shares",
       "sector": null,
       "marketCap": null
     },
@@ -38102,7 +38102,7 @@
     },
     {
       "symbol": "YSXT",
-      "name": "YSX Tech. Co., Ltd  - Class A Ordinary Shares",
+      "name": "YSX Tech. Co., Ltd - Class A Ordinary Shares",
       "sector": null,
       "marketCap": null
     },
@@ -38383,5 +38383,5 @@
       "marketCap": null
     }
   ],
-  "generatedAt": "2026-06-14T03:47:54.164Z"
+  "generatedAt": "2026-06-14T06:31:33.857Z"
 }

--- a/src/news/fetchByTicker.js
+++ b/src/news/fetchByTicker.js
@@ -276,16 +276,43 @@ function loadIndexSymbols(...relPaths) {
   return out;
 }
 
-const SP500_MEMBERS = loadIndexSymbols(
-  'data/indexes/sp500.json',
-  'data/indexes/sp500.offline.json',
-  'data/index-constituents/sp500.json'
+function loadIndexMapMembers(...keys) {
+  const out = new Set();
+  try {
+    const idx = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'src/maps.indexes.json'), 'utf8'));
+    for (const key of keys) {
+      const rows = Array.isArray(idx?.[key]) ? idx[key] : [];
+      for (const item of rows) {
+        const symbol = typeof item === 'string' ? item : item?.symbol;
+        if (symbol) out.add(String(symbol).trim().toUpperCase());
+      }
+    }
+  } catch {}
+  return out;
+}
+
+function unionSets(...sets) {
+  const out = new Set();
+  for (const set of sets) for (const item of set) out.add(item);
+  return out;
+}
+
+const SP500_MEMBERS = unionSets(
+  loadIndexMapMembers('sp500'),
+  loadIndexSymbols(
+    'data/indexes/sp500.json',
+    'data/indexes/sp500.offline.json',
+    'data/index-constituents/sp500.json'
+  )
 );
 
-const NASDAQ100_MEMBERS = loadIndexSymbols(
-  'data/indexes/nasdaq100.json',
-  'data/indexes/nasdaq100.offline.json',
-  'data/index-constituents/nasdaq100.json'
+const NASDAQ100_MEMBERS = unionSets(
+  loadIndexMapMembers('nasdaq100'),
+  loadIndexSymbols(
+    'data/indexes/nasdaq100.json',
+    'data/indexes/nasdaq100.offline.json',
+    'data/index-constituents/nasdaq100.json'
+  )
 );
 
 function isUSIndexHeavyweight(sym) {

--- a/tools/updateDataIndexes.mjs
+++ b/tools/updateDataIndexes.mjs
@@ -1,0 +1,155 @@
+// tools/updateDataIndexes.mjs
+// Refresh lightweight index constituent JSON files under data/indexes from public sources.
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { execFile } from 'node:child_process';
+
+const OFFLINE = process.env.OFFLINE === '1' || process.env.NO_NET === '1';
+const OUT_DIR = 'data/indexes';
+const UA = 'Mozilla/5.0 (compatible; stock-recs/1.0; +https://singaseongj.github.io)';
+const SOURCES = {
+  sp500: ['https://en.wikipedia.org/wiki/List_of_S%26P_500_companies'],
+  nasdaq100: ['https://en.wikipedia.org/wiki/Nasdaq-100'],
+  nasdaqTrader: [
+    'https://www.nasdaqtrader.com/dynamic/SymDir/nasdaqlisted.txt',
+    'https://www.nasdaqtrader.com/dynamic/SymDir/otherlisted.txt',
+  ],
+  kospi200: [
+    'https://ko.wikipedia.org/wiki/KOSPI_200',
+    'https://finance.naver.com/sise/entryJongmok.naver?page=1',
+    'https://finance.naver.com/sise/entryJongmok.naver?page=2',
+    'https://finance.naver.com/sise/entryJongmok.naver?page=3',
+    'https://finance.naver.com/sise/entryJongmok.naver?page=4',
+  ],
+  kosdaq100: [
+    'https://ko.wikipedia.org/wiki/KOSDAQ_100',
+    'https://finance.naver.com/sise/entryJongmok.naver?type=KQ&page=1',
+    'https://finance.naver.com/sise/entryJongmok.naver?type=KQ&page=2',
+  ],
+};
+
+const US_SYMBOL_PATTERN = /^[A-Z]{1,5}(\.[A-Z]{1,2})?$/;
+const canonUS = s => String(s || '').toUpperCase().replace('/', '.').replace('-', '.').trim();
+const six = s => String(s || '').replace(/\D/g, '').padStart(6, '0');
+const decode = s => String(s || '')
+  .replace(/&amp;/g, '&')
+  .replace(/&nbsp;/g, ' ')
+  .replace(/&#(\d+);/g, (_, n) => String.fromCharCode(+n))
+  .replace(/&#x([0-9a-f]+);/gi, (_, h) => String.fromCharCode(parseInt(h, 16)));
+const clean = s => decode(s).replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim();
+
+function execFileText(cmd, args) {
+  return new Promise(resolve => {
+    execFile(cmd, args, { encoding: 'utf8', maxBuffer: 16 * 1024 * 1024 }, (err, stdout) => resolve(err ? null : stdout));
+  });
+}
+
+async function fetchText(url) {
+  if (OFFLINE) return null;
+  try {
+    const res = await fetch(url, { headers: { 'user-agent': UA } });
+    if (res.ok) return await res.text();
+    console.warn(`[data-indexes] ${url} returned HTTP ${res.status}`);
+  } catch (err) {
+    console.warn(`[data-indexes] ${url} fetch failed: ${err.message}`);
+  }
+  const curled = await execFileText('curl', ['-L', '-s', '-f', '-A', UA, url]);
+  if (curled) return curled;
+  console.warn(`[data-indexes] ${url} curl fallback failed`);
+  return null;
+}
+
+function uniqBySymbol(rows) {
+  const seen = new Set();
+  const out = [];
+  for (const row of rows) {
+    const symbol = canonUS(row?.symbol || row?.ticker || row);
+    if (!symbol || seen.has(symbol)) continue;
+    seen.add(symbol);
+    out.push({ symbol, name: clean(row?.name || symbol), sector: row?.sector ? clean(row.sector) : null });
+  }
+  return out.sort((a, b) => a.symbol.localeCompare(b.symbol));
+}
+
+function parseSp500(html) {
+  if (!html) return [];
+  const rows = [...html.matchAll(/<tr>\s*<td[^>]*>\s*(?:<a[^>]*>)?([A-Z.\-]+)<\/(?:a|td)>[\s\S]*?<td[^>]*>\s*(?:<a[^>]*>)?([^<]+)<\/(?:a|td)>[\s\S]*?<td[^>]*>\s*(?:<a[^>]*>)?([^<]+)<\/(?:a|td)>/gi)];
+  return rows.map(m => ({ symbol: canonUS(m[1]), name: clean(m[2]), sector: clean(m[3]) }));
+}
+
+function parseNasdaq100(html) {
+  if (!html) return [];
+  const part = html.split(/id="constituents"/i)[1] || html;
+  const linked = [...part.matchAll(/<tr>\s*<td><a [^>]*>([^<]+)<\/a>[\s\S]*?<td>([A-Z.\-]+)<\/td>/gi)];
+  if (linked.length) return linked.map(m => ({ symbol: canonUS(m[2]), name: clean(m[1]), sector: null }));
+  const rows = [...part.matchAll(/<tr>\s*<td>([A-Z.\-]+)<\/td>\s*<td[^>]*>\s*(?:<a [^>]*>)?([^<]+)<\/(?:a|td)>/gi)];
+  return rows.map(m => ({ symbol: canonUS(m[1]), name: clean(m[2]), sector: null }));
+}
+
+function parseNasdaqTrader(txt) {
+  if (!txt) return [];
+  const [headerLine, ...lines] = txt.split(/\r?\n/).filter(Boolean);
+  if (!headerLine?.includes('|')) return [];
+  const headers = headerLine.split('|').map(h => h.trim().toLowerCase());
+  const col = (...names) => names.map(n => headers.indexOf(n.toLowerCase())).find(i => i >= 0) ?? -1;
+  const symbolIdx = col('Symbol', 'ACT Symbol');
+  const nameIdx = col('Security Name');
+  const testIdx = col('Test Issue');
+  const etfIdx = col('ETF');
+  if (symbolIdx < 0 || nameIdx < 0) return [];
+  return lines
+    .filter(line => !/^File Creation Time:/i.test(line))
+    .map(line => line.split('|'))
+    .filter(cols => cols.length >= headers.length)
+    .filter(cols => testIdx < 0 || cols[testIdx] === 'N')
+    .filter(cols => etfIdx < 0 || cols[etfIdx] !== 'Y')
+    .map(cols => ({ symbol: canonUS(clean(cols[symbolIdx])), name: clean(cols[nameIdx]).replace(/\s+-\s+Common Stock$/i, ''), sector: null }))
+    .filter(row => US_SYMBOL_PATTERN.test(row.symbol))
+    .filter(row => !/(warrants?|units?|rights?|preferred|depositary|notes?|bonds?|debentures?)/i.test(row.name));
+}
+
+function parseKoreanWiki(html, suffix) {
+  if (!html) return [];
+  const rows = [...html.matchAll(/<tr>[\s\S]*?<td[^>]*>\s*(?:<a [^>]*>)?([^<\n]+)<\/(?:a|td)>[\s\S]*?<td[^>]*>\s*(\d{6})\s*<\/td>/gi)];
+  return rows.map(m => ({ symbol: `${six(m[2])}${suffix}`, name: clean(m[1]), sector: null }));
+}
+
+function parseNaver(html, suffix) {
+  if (!html) return [];
+  const rows = [...html.matchAll(/href="\/item\/main\.naver\?code=(\d{6})"[^>]*>([^<]+)<\/a>/gi)];
+  return rows.map(m => ({ symbol: `${six(m[1])}${suffix}`, name: clean(m[2]), sector: null }));
+}
+
+async function readExisting(file, mapKey) {
+  try {
+    const raw = JSON.parse(await fs.readFile(file, 'utf8'));
+    if (Array.isArray(raw) && raw.length) return raw;
+  } catch {}
+  try {
+    const map = JSON.parse(await fs.readFile('src/maps.indexes.json', 'utf8'));
+    const rows = Array.isArray(map?.[mapKey]) ? map[mapKey] : [];
+    if (rows.length) return rows;
+  } catch {}
+  return [];
+}
+
+async function writeIndex(name, rows, minCount, mapKey = name) {
+  const file = path.join(OUT_DIR, `${name}.json`);
+  const next = uniqBySymbol(rows);
+  const finalRows = next.length >= minCount ? next : await readExisting(file, mapKey);
+  if (next.length < minCount) console.warn(`[data-indexes] keeping existing ${file}; parsed ${next.length}, expected at least ${minCount}`);
+  await fs.writeFile(file, JSON.stringify(finalRows, null, 2));
+  console.log(`[data-indexes] wrote ${file} (${finalRows.length})`);
+}
+
+async function main() {
+  await fs.mkdir(OUT_DIR, { recursive: true });
+  const texts = Object.fromEntries(await Promise.all(Object.entries(SOURCES).map(async ([key, urls]) => [key, await Promise.all(urls.map(fetchText))])));
+  await writeIndex('sp500', parseSp500(texts.sp500[0]), 350);
+  await writeIndex('nasdaq100', parseNasdaq100(texts.nasdaq100[0]), 70);
+  await writeIndex('nasdaq-trader', texts.nasdaqTrader.flatMap(parseNasdaqTrader), 1000, 'nasdaqTrader');
+  await writeIndex('kospi200', [...parseKoreanWiki(texts.kospi200[0], '.KS'), ...texts.kospi200.slice(1).flatMap(t => parseNaver(t, '.KS'))], 150);
+  await writeIndex('kosdaq100', [...parseKoreanWiki(texts.kosdaq100[0], '.KQ'), ...texts.kosdaq100.slice(1).flatMap(t => parseNaver(t, '.KQ'))], 80);
+}
+
+main().catch(err => { console.error('[data-indexes] failed:', err); process.exit(1); });

--- a/tools/updateIndexMaps.mjs
+++ b/tools/updateIndexMaps.mjs
@@ -4,6 +4,7 @@ import { execFile } from 'node:child_process';
 
 const OFFLINE = process.env.OFFLINE === '1' || process.env.NO_NET === '1';
 const INDEX_PATH = 'src/maps.indexes.json';
+const DATA_INDEX_DIR = 'data/indexes';
 const UA = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123 Safari/537.36';
 
 function execFileText(cmd, args) {
@@ -60,6 +61,30 @@ function uniqBySymbol(arr){
     out.push(r);
   }
   return out.sort((a,b)=>a.symbol.localeCompare(b.symbol));
+}
+
+
+async function readDataIndex(name) {
+  const candidates = [
+    `${DATA_INDEX_DIR}/${name}.json`,
+    `${DATA_INDEX_DIR}/${name}.offline.json`,
+  ];
+  for (const file of candidates) {
+    try {
+      const raw = JSON.parse(await fs.readFile(file, 'utf8'));
+      if (!Array.isArray(raw)) continue;
+      return raw.map(item => {
+        if (typeof item === 'string') return { symbol: canonUS(item), name: canonUS(item), sector: null };
+        return {
+          symbol: canonUS(item.symbol || item.ticker || ''),
+          name: clean(item.name || item.symbol || item.ticker || ''),
+          sector: item.sector ? clean(item.sector) : null,
+          marketCap: typeof item.marketCap === 'number' ? item.marketCap : null,
+        };
+      }).filter(row => row.symbol);
+    } catch {}
+  }
+  return [];
 }
 
 function parseCap(str){
@@ -211,6 +236,14 @@ async function main() {
   let current = { sp500: [], nasdaq100: [], kospi200: [], kosdaq100: [], nasdaqTrader: [], generatedAt: null };
   try { current = JSON.parse(await fs.readFile(INDEX_PATH, 'utf8')); } catch {}
 
+  const dataIndexes = {
+    sp500: await readDataIndex('sp500'),
+    nasdaq100: await readDataIndex('nasdaq100'),
+    kospi200: await readDataIndex('kospi200'),
+    kosdaq100: await readDataIndex('kosdaq100'),
+    nasdaqTrader: await readDataIndex('nasdaq-trader'),
+  };
+
   const [
     spTxt, nqTxt, k200Txt, kq100Txt,
     nasdaqListedTxt, otherListedTxt,
@@ -250,8 +283,11 @@ async function main() {
   ]);
 
   // Sanity thresholds; fallback to current if parse looks wrong/too small
+  if (sp500.length < 350 && dataIndexes.sp500.length >= 350) { console.log('[indexes] use data/indexes S&P500 (parsed=', dataIndexes.sp500.length, ')'); sp500 = dataIndexes.sp500; }
   if (sp500.length < 350) { console.log('[indexes] keep current S&P500 (parsed=', sp500.length, ')'); sp500 = current.sp500; }
+  if (nasdaq100.length < 70 && dataIndexes.nasdaq100.length >= 70) { console.log('[indexes] use data/indexes Nasdaq100 (parsed=', dataIndexes.nasdaq100.length, ')'); nasdaq100 = dataIndexes.nasdaq100; }
   if (nasdaq100.length < 70) { console.log('[indexes] keep current Nasdaq100 (parsed=', nasdaq100.length, ')'); nasdaq100 = current.nasdaq100; }
+  if (nasdaqTrader.length < 1000 && dataIndexes.nasdaqTrader.length >= 1000) { console.log('[indexes] use data/indexes NasdaqTrader (parsed=', dataIndexes.nasdaqTrader.length, ')'); nasdaqTrader = dataIndexes.nasdaqTrader; }
   if (nasdaqTrader.length < 1000) { console.log('[indexes] keep current NasdaqTrader (parsed=', nasdaqTrader.length, ')'); nasdaqTrader = current.nasdaqTrader || []; }
   if (kospi200.length < 150 && kospi200FromNaver.length >= 150) {
     console.log('[indexes] use Naver KOSPI200 (parsed=', kospi200FromNaver.length, ')');
@@ -261,7 +297,9 @@ async function main() {
     console.log('[indexes] use Naver KOSDAQ100 (parsed=', kosdaq100FromNaver.length, ')');
     kosdaq100 = kosdaq100FromNaver;
   }
+  if (kospi200.length < 150 && dataIndexes.kospi200.length >= 150) { console.log('[indexes] use data/indexes KOSPI200 (parsed=', dataIndexes.kospi200.length, ')'); kospi200 = dataIndexes.kospi200; }
   if (kospi200.length < 150) { console.log('[indexes] keep current KOSPI200 (parsed=', kospi200.length, ')'); kospi200 = current.kospi200; }
+  if (kosdaq100.length < 80 && dataIndexes.kosdaq100.length >= 80) { console.log('[indexes] use data/indexes KOSDAQ100 (parsed=', dataIndexes.kosdaq100.length, ')'); kosdaq100 = dataIndexes.kosdaq100; }
   if (kosdaq100.length < 80) { console.log('[indexes] keep current KOSDAQ100 (parsed=', kosdaq100.length, ')'); kosdaq100 = current.kosdaq100; }
 
   const NAME_OVERRIDES = {


### PR DESCRIPTION
### Motivation
- Keep index constituent sources up-to-date and allow the workflow to include new tickers (e.g. `SPCX`) by refreshing lightweight JSON snapshots under `data/indexes` from public sources (Wikipedia, Nasdaq Trader, finance.naver.com). 
- Make `tools/updateIndexMaps.mjs` and news collection code use those refreshed JSON files and `src/maps.indexes.json` as authoritative local maps to stabilize CI/offline runs. 
- Ensure the stock-recs workflow updates `data/indexes` before regenerating `src/maps.indexes.json` so downstream steps see newly added tickers. 

### Description
- Added `tools/updateDataIndexes.mjs`, a Node ESM script that fetches index constituents (S&P500, Nasdaq-100, Nasdaq Trader, KOSPI200, KOSDAQ100), uses a `curl` fallback, parses HTML/flat files, applies sanity thresholds, and writes snapshots under `data/indexes/*.json`. 
- Modified `tools/updateIndexMaps.mjs` to consult `data/indexes` via a new `readDataIndex()` helper and prefer those data-index snapshots when live parsing is missing or under sanity thresholds, and to fall back to existing maps when needed. 
- Updated `src/news/fetchByTicker.js` to combine members loaded from `data/indexes/*` and `src/maps.indexes.json` (via `loadIndexMapMembers` + `loadIndexSymbols`) so index-heavyweight detection recognizes symbols present in `src/maps.indexes.json`. 
- Updated the GitHub Actions job `.github/workflows/stock-recs.yml` to run `node tools/updateDataIndexes.mjs` before `node tools/updateIndexMaps.mjs`. 
- Committed refreshed snapshots under `data/indexes` (including `nasdaq-trader.json`, `sp500.json`, `nasdaq100.json`, `kospi200.json`, `kosdaq100.json`) and updated `src/maps.indexes.json` to include the refreshed entries (verified `SPCX` is present). 

### Testing
- Ran `node tools/updateDataIndexes.mjs` locally to build `data/indexes` (succeeded). 
- Ran `OFFLINE=1 node tools/updateIndexMaps.mjs` to rebuild `src/maps.indexes.json` from local snapshots (succeeded). 
- Ran the repository test with `node tests/apple_association.test.js` (printed `All tests passed`). 
- Verified index coverage with `node -e "const m=require('./src/maps.indexes.json'); console.log(m.nasdaqTrader.some(r=>r.symbol==='SPCX'), m.sp500.length, m.nasdaq100.length)"` which returned `true` and updated counts. 
- Ran `git diff --check` and `node --check` on modified scripts (`tools/updateDataIndexes.mjs`, `tools/updateIndexMaps.mjs`, `src/news/fetchByTicker.js`) to verify syntax and no obvious repo errors (all checks passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2e4a0fc6d88331b291e183ba8cdc08)