### PR TITLE
Avoid redundant cleaning in index map loader

### DIFF
--- a/tools/updateIndexMaps.mjs
+++ b/tools/updateIndexMaps.mjs
@@ -77,8 +77,8 @@ async function readDataIndex(name) {
         if (typeof item === 'string') return { symbol: canonUS(item), name: canonUS(item), sector: null };
         return {
           symbol: canonUS(item.symbol || item.ticker || ''),
-          name: clean(item.name || item.symbol || item.ticker || ''),
-          sector: item.sector ? clean(item.sector) : null,
+          name: item.name || item.symbol || item.ticker || '',
+          sector: item.sector || null,
           marketCap: typeof item.marketCap === 'number' ? item.marketCap : null,
         };
       }).filter(row => row.symbol);


### PR DESCRIPTION
### Motivation
- `readDataIndex` called `clean(...)` even though `clean` is defined elsewhere and the JSON files in `data/indexes/` are already cleaned, which could cause a `ReferenceError` and is redundant.

### Description
- Stop re-cleaning index entries by using `name: item.name || item.symbol || item.ticker || ''` and `sector: item.sector || null` while keeping `symbol` canonicalization and `marketCap` handling intact in `tools/updateIndexMaps.mjs`.

### Testing
- Ran `node tests/apple_association.test.js` which passed.
- Ran `node --check tools/updateIndexMaps.mjs` which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2e4c728b208331a3e3e91de58a289c)