### PR TITLE
Render AI-selected recommendations (from aiselected.JSON) in stocks.html

### DIFF
--- a/src/template.html
+++ b/src/template.html
@@ -177,6 +177,11 @@
       <ul class="skeleton"><li></li><li></li><li></li></ul>
     </div>
     <div id="recommendations"><p class="error" style="display:none"></p></div>
+    <section id="aiSelectedRecommendations" class="ai-selected" aria-labelledby="aiSelectedTitle">
+      <h2 id="aiSelectedTitle" data-i18n="aiSelectedTitle">AI 선정 트렌드 추천</h2>
+      <div id="aiSelectedList"></div>
+      <p id="aiSelectedError" class="error" role="alert" style="display:none"></p>
+    </section>
     <div id="portfolioUpdated" class="last-updated"></div>
     <noscript>자바스크립트를 활성화하면 추천 종목이 표시됩니다.</noscript>
   </section>
@@ -198,6 +203,8 @@
         keywordError: '키워드를 불러오지 못했습니다.',
         keywordMarkets: '적용 시장',
         portfolioRecs: '포트폴리오 추천',
+        aiSelectedTitle: 'AI 선정 트렌드 추천',
+        aiSelectedError: 'AI 선정 추천을 불러오지 못했습니다.',
         dashboardLink: '👉 주식 시장 요약 대시보드',
         refreshing: '새로고침 중...',
         refreshData: '데이터 새로고침',
@@ -230,6 +237,8 @@
         keywordError: 'Failed to load keywords.',
         keywordMarkets: 'Markets',
         portfolioRecs: 'Portfolio Recommendations',
+        aiSelectedTitle: 'AI Selected Trend Recommendations',
+        aiSelectedError: 'Failed to load AI selected recommendations.',
         dashboardLink: '👉 Stock News Summary Dashboard',
         refreshing: 'Refreshing...',
         refreshData: 'Refresh Data',
@@ -780,6 +789,100 @@
       renderKeywordBox();
     }
 
+
+    function buildCompanySearchUrl(companyName) {
+      const query = String(companyName || '').trim();
+      return query ? `https://www.google.com/search?q=${encodeURIComponent(query)}` : '';
+    }
+
+    function buildAiReasonButton(reason, ticker) {
+      const safeReason = escapeHtml(reason || '');
+      const safeTicker = escapeHtml(ticker || '');
+      return `<button type="button" class="ai-reason-toggle" aria-label="Show reason for ${safeTicker}" aria-expanded="false" data-reason="${safeReason}">?</button>`;
+    }
+
+    function renderAiSelected(data) {
+      const listEl = document.getElementById('aiSelectedList');
+      const errorEl = document.getElementById('aiSelectedError');
+      if (!listEl || !errorEl) return;
+
+      const groups = Object.entries(data || {}).filter(([, items]) => Array.isArray(items));
+      if (!groups.length) {
+        listEl.innerHTML = '';
+        errorEl.textContent = translations[currentLang].aiSelectedError;
+        errorEl.style.display = 'block';
+        return;
+      }
+
+      listEl.innerHTML = groups.map(([category, items]) => {
+        const rows = items.slice(0, 10).map(item => {
+          const company = String(item?.company_name || item?.ticker || '').trim();
+          const ticker = String(item?.ticker || '').trim();
+          const exchange = String(item?.exchange || '').trim();
+          const searchUrl = buildCompanySearchUrl(company);
+          const tickerLabel = escapeHtml(ticker || company);
+          const tickerHtml = searchUrl
+            ? `<a href="${escapeHtml(searchUrl)}" target="_blank" rel="noopener noreferrer">${tickerLabel}</a>`
+            : tickerLabel;
+          const companyHtml = company && company !== ticker ? `<span class="ai-company">${escapeHtml(company)}</span>` : '';
+          const exchangeHtml = exchange ? `<span class="sector">${escapeHtml(exchange)}</span>` : '';
+          const reasonHtml = buildAiReasonButton(item?.reason_trendy, ticker || company);
+          return `<li>${tickerHtml}${companyHtml}${exchangeHtml}${reasonHtml}</li>`;
+        }).join('') || `<li class="empty">${translations[currentLang].noPicks}</li>`;
+        return `<div class="portfolio-group ai-selected-group"><h3>${escapeHtml(category)}</h3><ul>${rows}</ul></div>`;
+      }).join('');
+      errorEl.style.display = 'none';
+      attachAiReasonHandlers();
+    }
+
+    async function loadAiSelectedRecommendations() {
+      const listEl = document.getElementById('aiSelectedList');
+      const errorEl = document.getElementById('aiSelectedError');
+      if (!listEl || !errorEl) return;
+      try {
+        const res = await fetch('aiselected.JSON?_=' + Date.now(), { cache: 'no-store' });
+        if (!res.ok) throw new Error('HTTP ' + res.status);
+        renderAiSelected(await res.json());
+      } catch (err) {
+        console.error('Failed to load AI selected recommendations:', err);
+        listEl.innerHTML = '';
+        errorEl.textContent = translations[currentLang].aiSelectedError;
+        errorEl.style.display = 'block';
+      }
+    }
+
+    function closeAiReasonPopovers(exceptButton = null) {
+      document.querySelectorAll('.ai-reason-popover').forEach(popover => {
+        if (!exceptButton || popover.dataset.ownerId !== exceptButton.dataset.reasonId) {
+          popover.remove();
+        }
+      });
+      document.querySelectorAll('.ai-reason-toggle[aria-expanded="true"]').forEach(button => {
+        if (button !== exceptButton) button.setAttribute('aria-expanded', 'false');
+      });
+    }
+
+    function attachAiReasonHandlers() {
+      document.querySelectorAll('.ai-reason-toggle').forEach((button, index) => {
+        button.dataset.reasonId = button.dataset.reasonId || `ai-reason-${Date.now()}-${index}`;
+        button.addEventListener('click', event => {
+          event.stopPropagation();
+          const isOpen = button.getAttribute('aria-expanded') === 'true';
+          closeAiReasonPopovers(button);
+          if (isOpen) {
+            button.setAttribute('aria-expanded', 'false');
+            return;
+          }
+          const popover = document.createElement('span');
+          popover.className = 'ai-reason-popover';
+          popover.dataset.ownerId = button.dataset.reasonId;
+          popover.textContent = button.dataset.reason || '';
+          button.insertAdjacentElement('afterend', popover);
+          button.setAttribute('aria-expanded', 'true');
+        });
+      });
+    }
+
     // 추천 종목 로드
     const FULL_NAME_MAP = {
       'AMD': 'Advanced Micro Devices',
@@ -908,7 +1011,7 @@
         button.disabled = true;
         button.textContent = translations[currentLang].refreshing;
       }
-      Promise.all([loadMarketData(), fetchRecs(), loadMarketNews(), loadKeywordHighlights()]).finally(() => {
+      Promise.all([loadMarketData(), fetchRecs(), loadMarketNews(), loadKeywordHighlights(), loadAiSelectedRecommendations()]).finally(() => {
         if (button) {
           button.disabled = false;
           button.textContent = translations[currentLang].refreshData;
@@ -932,6 +1035,7 @@
         renderNewsUpdated();
         renderKeywordBox();
         if (lastRecommendations) render(lastRecommendations);
+        loadAiSelectedRecommendations();
         updateVisitCounts();
       });
       document.getElementById('btnEn').addEventListener('click', function() {
@@ -941,6 +1045,7 @@
         renderNewsUpdated();
         renderKeywordBox();
         if (lastRecommendations) render(lastRecommendations);
+        loadAiSelectedRecommendations();
         updateVisitCounts();
       });
 
@@ -957,7 +1062,16 @@
     });
     
     // 키보드 단축키
+    document.addEventListener('click', function(event) {
+      if (!event.target.closest('.ai-reason-toggle') && !event.target.closest('.ai-reason-popover')) {
+        closeAiReasonPopovers();
+      }
+    });
+
     document.addEventListener('keydown', function(e) {
+      if (e.key === 'Escape') {
+        closeAiReasonPopovers();
+      }
       // Ctrl + D: 디버그 모드 토글
       if (e.ctrlKey && e.key === 'd') {
         e.preventDefault();

--- a/stocks.css
+++ b/stocks.css
@@ -176,6 +176,75 @@ tr:hover {
   font-size: 0.85em;
 }
 
+
+.ai-selected {
+  margin-top: 30px;
+}
+
+.ai-selected > h2 {
+  margin-top: 0;
+}
+
+.ai-selected-group li {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+  padding: 0.25rem 0;
+}
+
+.ai-selected-group a {
+  color: #2563eb;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.ai-selected-group a:hover,
+.ai-selected-group a:focus-visible {
+  text-decoration: underline;
+}
+
+.ai-company {
+  color: #374151;
+  font-size: 0.9em;
+}
+
+.ai-reason-toggle {
+  width: 1.35rem;
+  height: 1.35rem;
+  min-width: 1.35rem;
+  padding: 0;
+  margin: 0 0 0 0.15rem;
+  border-radius: 999px;
+  background: #f59e0b;
+  color: #fff;
+  font-size: 0.85rem;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.ai-reason-toggle:hover,
+.ai-reason-toggle:focus-visible {
+  background: #d97706;
+}
+
+.ai-reason-popover {
+  position: absolute;
+  left: 0;
+  top: calc(100% + 0.35rem);
+  z-index: 20;
+  width: min(28rem, calc(100vw - 4rem));
+  padding: 0.75rem 0.85rem;
+  border: 1px solid #f59e0b;
+  border-radius: 8px;
+  background: #fffbeb;
+  color: #78350f;
+  box-shadow: 0 10px 24px rgba(0,0,0,0.15);
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+
 .tooltip {
   display: block;
   color: #6b7280;

--- a/stocks.html
+++ b/stocks.html
@@ -135,7 +135,7 @@
   <h1 data-i18n="title">데일리 주식 리포트 자동화</h1>
   <p class="dashboard-link"><a href="stocks/rationale.html">매력점수 계산식</a></p>
   <p class="dashboard-link"><a data-i18n="dashboardLink" href="stocks/index.html">👉 Stock News Summary Dashboard</a></p>
-  <p id="currentDate"><span id="datePrefix" data-i18n="today">오늘:</span> 2026년 5월 20일</p>
+  <p id="currentDate"><span id="datePrefix" data-i18n="today">오늘:</span> 2026년 7월 4일</p>
   
   <div id="debugInfo" class="debug" style="display: none;">
     <h4>디버그 정보:</h4>
@@ -177,6 +177,11 @@
       <ul class="skeleton"><li></li><li></li><li></li></ul>
     </div>
     <div id="recommendations"><p class="error" style="display:none"></p></div>
+    <section id="aiSelectedRecommendations" class="ai-selected" aria-labelledby="aiSelectedTitle">
+      <h2 id="aiSelectedTitle" data-i18n="aiSelectedTitle">AI 선정 트렌드 추천</h2>
+      <div id="aiSelectedList"></div>
+      <p id="aiSelectedError" class="error" role="alert" style="display:none"></p>
+    </section>
     <div id="portfolioUpdated" class="last-updated"></div>
     <noscript>자바스크립트를 활성화하면 추천 종목이 표시됩니다.</noscript>
   </section>
@@ -198,6 +203,8 @@
         keywordError: '키워드를 불러오지 못했습니다.',
         keywordMarkets: '적용 시장',
         portfolioRecs: '포트폴리오 추천',
+        aiSelectedTitle: 'AI 선정 트렌드 추천',
+        aiSelectedError: 'AI 선정 추천을 불러오지 못했습니다.',
         dashboardLink: '👉 주식 시장 요약 대시보드',
         refreshing: '새로고침 중...',
         refreshData: '데이터 새로고침',
@@ -230,6 +237,8 @@
         keywordError: 'Failed to load keywords.',
         keywordMarkets: 'Markets',
         portfolioRecs: 'Portfolio Recommendations',
+        aiSelectedTitle: 'AI Selected Trend Recommendations',
+        aiSelectedError: 'Failed to load AI selected recommendations.',
         dashboardLink: '👉 Stock News Summary Dashboard',
         refreshing: 'Refreshing...',
         refreshData: 'Refresh Data',
@@ -780,6 +789,100 @@
       renderKeywordBox();
     }
 
+
+    function buildCompanySearchUrl(companyName) {
+      const query = String(companyName || '').trim();
+      return query ? `https://www.google.com/search?q=${encodeURIComponent(query)}` : '';
+    }
+
+    function buildAiReasonButton(reason, ticker) {
+      const safeReason = escapeHtml(reason || '');
+      const safeTicker = escapeHtml(ticker || '');
+      return `<button type="button" class="ai-reason-toggle" aria-label="Show reason for ${safeTicker}" aria-expanded="false" data-reason="${safeReason}">?</button>`;
+    }
+
+    function renderAiSelected(data) {
+      const listEl = document.getElementById('aiSelectedList');
+      const errorEl = document.getElementById('aiSelectedError');
+      if (!listEl || !errorEl) return;
+
+      const groups = Object.entries(data || {}).filter(([, items]) => Array.isArray(items));
+      if (!groups.length) {
+        listEl.innerHTML = '';
+        errorEl.textContent = translations[currentLang].aiSelectedError;
+        errorEl.style.display = 'block';
+        return;
+      }
+
+      listEl.innerHTML = groups.map(([category, items]) => {
+        const rows = items.slice(0, 10).map(item => {
+          const company = String(item?.company_name || item?.ticker || '').trim();
+          const ticker = String(item?.ticker || '').trim();
+          const exchange = String(item?.exchange || '').trim();
+          const searchUrl = buildCompanySearchUrl(company);
+          const tickerLabel = escapeHtml(ticker || company);
+          const tickerHtml = searchUrl
+            ? `<a href="${escapeHtml(searchUrl)}" target="_blank" rel="noopener noreferrer">${tickerLabel}</a>`
+            : tickerLabel;
+          const companyHtml = company && company !== ticker ? `<span class="ai-company">${escapeHtml(company)}</span>` : '';
+          const exchangeHtml = exchange ? `<span class="sector">${escapeHtml(exchange)}</span>` : '';
+          const reasonHtml = buildAiReasonButton(item?.reason_trendy, ticker || company);
+          return `<li>${tickerHtml}${companyHtml}${exchangeHtml}${reasonHtml}</li>`;
+        }).join('') || `<li class="empty">${translations[currentLang].noPicks}</li>`;
+        return `<div class="portfolio-group ai-selected-group"><h3>${escapeHtml(category)}</h3><ul>${rows}</ul></div>`;
+      }).join('');
+      errorEl.style.display = 'none';
+      attachAiReasonHandlers();
+    }
+
+    async function loadAiSelectedRecommendations() {
+      const listEl = document.getElementById('aiSelectedList');
+      const errorEl = document.getElementById('aiSelectedError');
+      if (!listEl || !errorEl) return;
+      try {
+        const res = await fetch('aiselected.JSON?_=' + Date.now(), { cache: 'no-store' });
+        if (!res.ok) throw new Error('HTTP ' + res.status);
+        renderAiSelected(await res.json());
+      } catch (err) {
+        console.error('Failed to load AI selected recommendations:', err);
+        listEl.innerHTML = '';
+        errorEl.textContent = translations[currentLang].aiSelectedError;
+        errorEl.style.display = 'block';
+      }
+    }
+
+    function closeAiReasonPopovers(exceptButton = null) {
+      document.querySelectorAll('.ai-reason-popover').forEach(popover => {
+        if (!exceptButton || popover.dataset.ownerId !== exceptButton.dataset.reasonId) {
+          popover.remove();
+        }
+      });
+      document.querySelectorAll('.ai-reason-toggle[aria-expanded="true"]').forEach(button => {
+        if (button !== exceptButton) button.setAttribute('aria-expanded', 'false');
+      });
+    }
+
+    function attachAiReasonHandlers() {
+      document.querySelectorAll('.ai-reason-toggle').forEach((button, index) => {
+        button.dataset.reasonId = button.dataset.reasonId || `ai-reason-${Date.now()}-${index}`;
+        button.addEventListener('click', event => {
+          event.stopPropagation();
+          const isOpen = button.getAttribute('aria-expanded') === 'true';
+          closeAiReasonPopovers(button);
+          if (isOpen) {
+            button.setAttribute('aria-expanded', 'false');
+            return;
+          }
+          const popover = document.createElement('span');
+          popover.className = 'ai-reason-popover';
+          popover.dataset.ownerId = button.dataset.reasonId;
+          popover.textContent = button.dataset.reason || '';
+          button.insertAdjacentElement('afterend', popover);
+          button.setAttribute('aria-expanded', 'true');
+        });
+      });
+    }
+
     // 추천 종목 로드
     const FULL_NAME_MAP = {
       'AMD': 'Advanced Micro Devices',
@@ -908,7 +1011,7 @@
         button.disabled = true;
         button.textContent = translations[currentLang].refreshing;
       }
-      Promise.all([loadMarketData(), fetchRecs(), loadMarketNews(), loadKeywordHighlights()]).finally(() => {
+      Promise.all([loadMarketData(), fetchRecs(), loadMarketNews(), loadKeywordHighlights(), loadAiSelectedRecommendations()]).finally(() => {
         if (button) {
           button.disabled = false;
           button.textContent = translations[currentLang].refreshData;
@@ -932,6 +1035,7 @@
         renderNewsUpdated();
         renderKeywordBox();
         if (lastRecommendations) render(lastRecommendations);
+        loadAiSelectedRecommendations();
         updateVisitCounts();
       });
       document.getElementById('btnEn').addEventListener('click', function() {
@@ -941,6 +1045,7 @@
         renderNewsUpdated();
         renderKeywordBox();
         if (lastRecommendations) render(lastRecommendations);
+        loadAiSelectedRecommendations();
         updateVisitCounts();
       });
 
@@ -957,7 +1062,16 @@
     });
     
     // 키보드 단축키
+    document.addEventListener('click', function(event) {
+      if (!event.target.closest('.ai-reason-toggle') && !event.target.closest('.ai-reason-popover')) {
+        closeAiReasonPopovers();
+      }
+    });
+
     document.addEventListener('keydown', function(e) {
+      if (e.key === 'Escape') {
+        closeAiReasonPopovers();
+      }
       // Ctrl + D: 디버그 모드 토글
       if (e.ctrlKey && e.key === 'd') {
         e.preventDefault();


### PR DESCRIPTION
### Motivation
- Surface AI-selected trend recommendations from `aiselected.JSON` on the public stock page so users can view the two JSON categories and the top 10 tickers per category inline. 
- Make tickers clickable (linking to a Google search for the company name) and provide a compact way to surface the `reason_trendy` text via a clickable `?` popover.

### Description
- Inserted a new AI section under the existing portfolio recommendations in `src/template.html` and regenerated `stocks.html` to render it below the normal recommendation groups. 
- Added client-side logic (`loadAiSelectedRecommendations`, `renderAiSelected`, `buildCompanySearchUrl`, `buildAiReasonButton`, popover handlers and integration points) to fetch `aiselected.JSON` and render up to 10 tickers per category with company-name Google search links and `?` buttons that show `reason_trendy` popovers. 
- Added localized translation keys for the new section (`aiSelectedTitle`, `aiSelectedError`) and wired the loader to run on refresh and language toggles. 
- Added CSS rules in `stocks.css` to style AI groups, ticker links, `?` buttons and floating popovers.

### Testing
- Ran `node src/build.js` and the build completed successfully. 
- Ran `node --check src/build.js` and the build script syntax checked OK. 
- Ran the repository test `node tests/apple_association.test.js` and it reported `All tests passed`. 
- Attempted a Playwright screenshot to capture the rendered page but Chromium could not start in this environment due to a missing system library (`libatk-1.0.so.0`), so screenshot verification failed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a48c39d41a4833194c5e096144335b0)