### PR TITLE
Localize AI-selected headings and make company names clickable (hide tickers)

### DIFF
--- a/src/template.html
+++ b/src/template.html
@@ -801,6 +801,11 @@
       return `<button type="button" class="ai-reason-toggle" aria-label="Show reason for ${safeTicker}" aria-expanded="false" data-reason="${safeReason}">?</button>`;
     }
 
+    const aiSelectedCategoryLabels = {
+      korean_market: '국내 증시',
+      new_york_market: '미국 증시'
+    };
+
     function renderAiSelected(data) {
       const listEl = document.getElementById('aiSelectedList');
       const errorEl = document.getElementById('aiSelectedError');
@@ -816,20 +821,20 @@
 
       listEl.innerHTML = groups.map(([category, items]) => {
         const rows = items.slice(0, 10).map(item => {
-          const company = String(item?.company_name || item?.ticker || '').trim();
+          const company = String(item?.company_name || '').trim();
           const ticker = String(item?.ticker || '').trim();
           const exchange = String(item?.exchange || '').trim();
           const searchUrl = buildCompanySearchUrl(company);
-          const tickerLabel = escapeHtml(ticker || company);
-          const tickerHtml = searchUrl
-            ? `<a href="${escapeHtml(searchUrl)}" target="_blank" rel="noopener noreferrer">${tickerLabel}</a>`
-            : tickerLabel;
-          const companyHtml = company && company !== ticker ? `<span class="ai-company">${escapeHtml(company)}</span>` : '';
+          const companyLabel = escapeHtml(company || translations[currentLang].noPicks);
+          const companyHtml = searchUrl
+            ? `<a class="ai-company" href="${escapeHtml(searchUrl)}" target="_blank" rel="noopener noreferrer">${companyLabel}</a>`
+            : `<span class="ai-company">${companyLabel}</span>`;
           const exchangeHtml = exchange ? `<span class="sector">${escapeHtml(exchange)}</span>` : '';
           const reasonHtml = buildAiReasonButton(item?.reason_trendy, ticker || company);
-          return `<li>${tickerHtml}${companyHtml}${exchangeHtml}${reasonHtml}</li>`;
+          return `<li>${companyHtml}${exchangeHtml}${reasonHtml}</li>`;
         }).join('') || `<li class="empty">${translations[currentLang].noPicks}</li>`;
-        return `<div class="portfolio-group ai-selected-group"><h3>${escapeHtml(category)}</h3><ul>${rows}</ul></div>`;
+        const categoryLabel = aiSelectedCategoryLabels[category] || category;
+        return `<div class="portfolio-group ai-selected-group"><h3>${escapeHtml(categoryLabel)}</h3><ul>${rows}</ul></div>`;
       }).join('');
       errorEl.style.display = 'none';
       attachAiReasonHandlers();

--- a/stocks.html
+++ b/stocks.html
@@ -801,6 +801,11 @@
       return `<button type="button" class="ai-reason-toggle" aria-label="Show reason for ${safeTicker}" aria-expanded="false" data-reason="${safeReason}">?</button>`;
     }
 
+    const aiSelectedCategoryLabels = {
+      korean_market: '국내 증시',
+      new_york_market: '미국 증시'
+    };
+
     function renderAiSelected(data) {
       const listEl = document.getElementById('aiSelectedList');
       const errorEl = document.getElementById('aiSelectedError');
@@ -816,20 +821,20 @@
 
       listEl.innerHTML = groups.map(([category, items]) => {
         const rows = items.slice(0, 10).map(item => {
-          const company = String(item?.company_name || item?.ticker || '').trim();
+          const company = String(item?.company_name || '').trim();
           const ticker = String(item?.ticker || '').trim();
           const exchange = String(item?.exchange || '').trim();
           const searchUrl = buildCompanySearchUrl(company);
-          const tickerLabel = escapeHtml(ticker || company);
-          const tickerHtml = searchUrl
-            ? `<a href="${escapeHtml(searchUrl)}" target="_blank" rel="noopener noreferrer">${tickerLabel}</a>`
-            : tickerLabel;
-          const companyHtml = company && company !== ticker ? `<span class="ai-company">${escapeHtml(company)}</span>` : '';
+          const companyLabel = escapeHtml(company || translations[currentLang].noPicks);
+          const companyHtml = searchUrl
+            ? `<a class="ai-company" href="${escapeHtml(searchUrl)}" target="_blank" rel="noopener noreferrer">${companyLabel}</a>`
+            : `<span class="ai-company">${companyLabel}</span>`;
           const exchangeHtml = exchange ? `<span class="sector">${escapeHtml(exchange)}</span>` : '';
           const reasonHtml = buildAiReasonButton(item?.reason_trendy, ticker || company);
-          return `<li>${tickerHtml}${companyHtml}${exchangeHtml}${reasonHtml}</li>`;
+          return `<li>${companyHtml}${exchangeHtml}${reasonHtml}</li>`;
         }).join('') || `<li class="empty">${translations[currentLang].noPicks}</li>`;
-        return `<div class="portfolio-group ai-selected-group"><h3>${escapeHtml(category)}</h3><ul>${rows}</ul></div>`;
+        const categoryLabel = aiSelectedCategoryLabels[category] || category;
+        return `<div class="portfolio-group ai-selected-group"><h3>${escapeHtml(categoryLabel)}</h3><ul>${rows}</ul></div>`;
       }).join('');
       errorEl.style.display = 'none';
       attachAiReasonHandlers();


### PR DESCRIPTION
### Motivation
- Improve the AI-selected picks UI by showing human-friendly Korean labels for market groups and making company names the primary clickable element.
- Remove visible ticker symbols from the list to reduce clutter while keeping ticker data available for accessibility/logic (reason button).

### Description
- Added `aiSelectedCategoryLabels` mapping and render the category heading as `국내 증시` for `korean_market` and `미국 증시` for `new_york_market`.
- Reworked `renderAiSelected` to use `company_name` as the clickable Google search link and to stop rendering the ticker text in the visible list.
- Kept `ticker` values available and passed them to `buildAiReasonButton` so the reason popover/button still uses the ticker for ARIA labels.
- Applied the changes to `src/template.html` and the generated `stocks.html` so the site build and served page reflect the updates.

### Testing
- Ran `node src/build.js` to rebuild `stocks.html` and the build completed successfully.
- Ran the repository test `node tests/apple_association.test.js` which printed `All tests passed`.
- Verified `git diff --check` (no whitespace errors) and local smoke verification of the modified `stocks.html` succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a48c66bbd5c8331a6782e8ca6f3fd0f)