### PR TITLE
Show ranked AI stock recommendations (top 10 per market)

### DIFF
--- a/airecommendations.js
+++ b/airecommendations.js
@@ -5,12 +5,12 @@ const API_KEY = process.env.GPT_API;
 const MODEL = process.env.GPT_MODEL || 'gpt-4o-mini';
 const ENDPOINT = process.env.GPT_API_ENDPOINT || 'https://api.openai.com/v1/chat/completions';
 
-const BASE_PROMPT = `Fetch 10 currently trendy publicly traded companies: 5 from the Korean stock market and 5 from the New York stock market. 
+const BASE_PROMPT = `Fetch 20 currently trendy publicly traded companies: 10 from the Korean stock market and 10 from the New York stock market.
 
-Use recent market attention, news momentum, trading interest, sector trend, or investor discussion as the basis for “trendy.”
+Use recent market attention, news momentum, trading interest, sector trend, or investor discussion as the basis for “trendy.” Rank each market from 1 to 10, where 1 is the trendiest company in that market.
 
 
-Put korean market compant names in Korean, and produce "reason trendy" also in Korean.
+Put Korean market company names in Korean, and produce "reason trendy" also in Korean.
 
 Return only valid JSON. Do not include markdown, explanations, or comments.
 
@@ -20,6 +20,7 @@ JSON format:
 {
   "korean_market": [
     {
+      "rank": 1,
       "company_name": "",
       "ticker": "",
       "exchange": "",
@@ -28,6 +29,7 @@ JSON format:
   ],
   "new_york_market": [
     {
+      "rank": 1,
       "company_name": "",
       "ticker": "",
       "exchange": "",
@@ -55,12 +57,21 @@ function stripCodeFence(text) {
     .trim();
 }
 
-function assertMarketItems(items, marketName) {
-  if (!Array.isArray(items) || items.length !== 5) {
-    throw new Error(`${marketName} must contain exactly 5 companies`);
+function assertMarketItems(items, marketName, { allowPartial = false } = {}) {
+  const validLength = allowPartial
+    ? Array.isArray(items) && items.length > 0 && items.length <= 10
+    : Array.isArray(items) && items.length === 10;
+  if (!validLength) {
+    throw new Error(`${marketName} must contain ${allowPartial ? '1 to 10' : 'exactly 10'} companies`);
   }
 
   for (const [index, item] of items.entries()) {
+    if (item?.rank !== undefined) {
+      const rank = Number(item.rank);
+      if (!Number.isInteger(rank) || rank !== index + 1) {
+        throw new Error(`${marketName}[${index}].rank must be ${index + 1}`);
+      }
+    }
     for (const key of ['company_name', 'ticker', 'exchange', 'reason_trendy']) {
       if (typeof item?.[key] !== 'string' || !item[key].trim()) {
         throw new Error(`${marketName}[${index}].${key} must be a non-empty string`);
@@ -69,22 +80,24 @@ function assertMarketItems(items, marketName) {
   }
 }
 
-function validateSelection(selection) {
+function validateSelection(selection, options = {}) {
   if (!selection || typeof selection !== 'object' || Array.isArray(selection)) {
     throw new Error('AI response must be a JSON object');
   }
 
-  assertMarketItems(selection.korean_market, 'korean_market');
-  assertMarketItems(selection.new_york_market, 'new_york_market');
+  assertMarketItems(selection.korean_market, 'korean_market', options);
+  assertMarketItems(selection.new_york_market, 'new_york_market', options);
 
   return {
-    korean_market: selection.korean_market.map(({ company_name, ticker, exchange, reason_trendy }) => ({
+    korean_market: selection.korean_market.map(({ company_name, ticker, exchange, reason_trendy }, index) => ({
+      rank: index + 1,
       company_name: company_name.trim(),
       ticker: ticker.trim(),
       exchange: exchange.trim(),
       reason_trendy: reason_trendy.trim(),
     })),
-    new_york_market: selection.new_york_market.map(({ company_name, ticker, exchange, reason_trendy }) => ({
+    new_york_market: selection.new_york_market.map(({ company_name, ticker, exchange, reason_trendy }, index) => ({
+      rank: index + 1,
       company_name: company_name.trim(),
       ticker: ticker.trim(),
       exchange: exchange.trim(),
@@ -95,7 +108,7 @@ function validateSelection(selection) {
 
 async function readExistingSelection() {
   try {
-    return validateSelection(JSON.parse(await readFile(OUTPUT_FILE, 'utf8')));
+    return validateSelection(JSON.parse(await readFile(OUTPUT_FILE, 'utf8')), { allowPartial: true });
   } catch (error) {
     if (error?.code === 'ENOENT') return null;
     throw new Error(`Could not read existing ${OUTPUT_FILE}: ${error.message || error}`);
@@ -115,10 +128,10 @@ function mergeMarketSelections(freshItems, existingItems) {
     if (seen.has(tickerKey)) continue;
     seen.add(tickerKey);
     merged.push(item);
-    if (merged.length === 5) break;
+    if (merged.length === 10) break;
   }
 
-  return merged;
+  return merged.map((item, index) => ({ ...item, rank: index + 1 }));
 }
 
 function mergeSelections(freshSelection, existingSelection) {

--- a/src/template.html
+++ b/src/template.html
@@ -801,6 +801,22 @@
       return `<button type="button" class="ai-reason-toggle" aria-label="Show reason for ${safeTicker}" aria-expanded="false" data-reason="${safeReason}">?</button>`;
     }
 
+    function buildAiSelectedItem(item, index) {
+      const rankValue = Number(item?.rank);
+      const rank = Number.isInteger(rankValue) && rankValue > 0 ? rankValue : index + 1;
+      const company = String(item?.company_name || '').trim();
+      const ticker = String(item?.ticker || '').trim();
+      const exchange = String(item?.exchange || '').trim();
+      const searchUrl = buildCompanySearchUrl(company);
+      const companyLabel = escapeHtml(company || translations[currentLang].noPicks);
+      const companyHtml = searchUrl
+        ? `<a class="ai-company" href="${escapeHtml(searchUrl)}" target="_blank" rel="noopener noreferrer">${companyLabel}</a>`
+        : `<span class="ai-company">${companyLabel}</span>`;
+      const exchangeHtml = exchange ? `<span class="sector">${escapeHtml(exchange)}</span>` : '';
+      const reasonHtml = buildAiReasonButton(item?.reason_trendy, ticker || company);
+      return `<li><span class="ai-rank">${rank}.</span>${companyHtml}${exchangeHtml}${reasonHtml}</li>`;
+    }
+
     const aiSelectedCategoryLabels = {
       korean_market: '국내 증시',
       new_york_market: '미국 증시'
@@ -820,21 +836,14 @@
       }
 
       listEl.innerHTML = groups.map(([category, items]) => {
-        const rows = items.slice(0, 10).map(item => {
-          const company = String(item?.company_name || '').trim();
-          const ticker = String(item?.ticker || '').trim();
-          const exchange = String(item?.exchange || '').trim();
-          const searchUrl = buildCompanySearchUrl(company);
-          const companyLabel = escapeHtml(company || translations[currentLang].noPicks);
-          const companyHtml = searchUrl
-            ? `<a class="ai-company" href="${escapeHtml(searchUrl)}" target="_blank" rel="noopener noreferrer">${companyLabel}</a>`
-            : `<span class="ai-company">${companyLabel}</span>`;
-          const exchangeHtml = exchange ? `<span class="sector">${escapeHtml(exchange)}</span>` : '';
-          const reasonHtml = buildAiReasonButton(item?.reason_trendy, ticker || company);
-          return `<li>${companyHtml}${exchangeHtml}${reasonHtml}</li>`;
-        }).join('') || `<li class="empty">${translations[currentLang].noPicks}</li>`;
+        const rankedItems = items.slice(0, 10);
+        const leftRows = rankedItems.slice(0, 5).map(buildAiSelectedItem).join('');
+        const rightRows = rankedItems.slice(5, 10).map((item, index) => buildAiSelectedItem(item, index + 5)).join('');
+        const rows = rankedItems.length
+          ? `<div class="ai-selected-columns"><ul>${leftRows}</ul><ul>${rightRows}</ul></div>`
+          : `<ul><li class="empty">${translations[currentLang].noPicks}</li></ul>`;
         const categoryLabel = aiSelectedCategoryLabels[category] || category;
-        return `<div class="portfolio-group ai-selected-group"><h3>${escapeHtml(categoryLabel)}</h3><ul>${rows}</ul></div>`;
+        return `<div class="portfolio-group ai-selected-group"><h3>${escapeHtml(categoryLabel)}</h3>${rows}</div>`;
       }).join('');
       errorEl.style.display = 'none';
       attachAiReasonHandlers();

--- a/stocks.css
+++ b/stocks.css
@@ -194,6 +194,25 @@ tr:hover {
   padding: 0.25rem 0;
 }
 
+.ai-selected-columns {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.5rem 1.5rem;
+}
+
+.ai-selected-columns ul {
+  margin: 0;
+  padding-left: 0;
+  list-style: none;
+}
+
+.ai-rank {
+  flex: 0 0 1.8rem;
+  color: #111827;
+  font-weight: 800;
+  text-align: right;
+}
+
 .ai-selected-group a {
   color: #2563eb;
   font-weight: 700;
@@ -336,5 +355,10 @@ tr:hover {
 
   #marketSnapshot, #portfolioRecommendations, #marketNews {
     padding: 15px;
+  }
+
+  .ai-selected-columns {
+    grid-template-columns: 1fr;
+    gap: 0;
   }
 }

--- a/stocks.html
+++ b/stocks.html
@@ -135,7 +135,7 @@
   <h1 data-i18n="title">데일리 주식 리포트 자동화</h1>
   <p class="dashboard-link"><a href="stocks/rationale.html">매력점수 계산식</a></p>
   <p class="dashboard-link"><a data-i18n="dashboardLink" href="stocks/index.html">👉 Stock News Summary Dashboard</a></p>
-  <p id="currentDate"><span id="datePrefix" data-i18n="today">오늘:</span> 2026년 7월 4일</p>
+  <p id="currentDate"><span id="datePrefix" data-i18n="today">오늘:</span> 2026년 7월 6일</p>
   
   <div id="debugInfo" class="debug" style="display: none;">
     <h4>디버그 정보:</h4>
@@ -801,6 +801,22 @@
       return `<button type="button" class="ai-reason-toggle" aria-label="Show reason for ${safeTicker}" aria-expanded="false" data-reason="${safeReason}">?</button>`;
     }
 
+    function buildAiSelectedItem(item, index) {
+      const rankValue = Number(item?.rank);
+      const rank = Number.isInteger(rankValue) && rankValue > 0 ? rankValue : index + 1;
+      const company = String(item?.company_name || '').trim();
+      const ticker = String(item?.ticker || '').trim();
+      const exchange = String(item?.exchange || '').trim();
+      const searchUrl = buildCompanySearchUrl(company);
+      const companyLabel = escapeHtml(company || translations[currentLang].noPicks);
+      const companyHtml = searchUrl
+        ? `<a class="ai-company" href="${escapeHtml(searchUrl)}" target="_blank" rel="noopener noreferrer">${companyLabel}</a>`
+        : `<span class="ai-company">${companyLabel}</span>`;
+      const exchangeHtml = exchange ? `<span class="sector">${escapeHtml(exchange)}</span>` : '';
+      const reasonHtml = buildAiReasonButton(item?.reason_trendy, ticker || company);
+      return `<li><span class="ai-rank">${rank}.</span>${companyHtml}${exchangeHtml}${reasonHtml}</li>`;
+    }
+
     const aiSelectedCategoryLabels = {
       korean_market: '국내 증시',
       new_york_market: '미국 증시'
@@ -820,21 +836,14 @@
       }
 
       listEl.innerHTML = groups.map(([category, items]) => {
-        const rows = items.slice(0, 10).map(item => {
-          const company = String(item?.company_name || '').trim();
-          const ticker = String(item?.ticker || '').trim();
-          const exchange = String(item?.exchange || '').trim();
-          const searchUrl = buildCompanySearchUrl(company);
-          const companyLabel = escapeHtml(company || translations[currentLang].noPicks);
-          const companyHtml = searchUrl
-            ? `<a class="ai-company" href="${escapeHtml(searchUrl)}" target="_blank" rel="noopener noreferrer">${companyLabel}</a>`
-            : `<span class="ai-company">${companyLabel}</span>`;
-          const exchangeHtml = exchange ? `<span class="sector">${escapeHtml(exchange)}</span>` : '';
-          const reasonHtml = buildAiReasonButton(item?.reason_trendy, ticker || company);
-          return `<li>${companyHtml}${exchangeHtml}${reasonHtml}</li>`;
-        }).join('') || `<li class="empty">${translations[currentLang].noPicks}</li>`;
+        const rankedItems = items.slice(0, 10);
+        const leftRows = rankedItems.slice(0, 5).map(buildAiSelectedItem).join('');
+        const rightRows = rankedItems.slice(5, 10).map((item, index) => buildAiSelectedItem(item, index + 5)).join('');
+        const rows = rankedItems.length
+          ? `<div class="ai-selected-columns"><ul>${leftRows}</ul><ul>${rightRows}</ul></div>`
+          : `<ul><li class="empty">${translations[currentLang].noPicks}</li></ul>`;
         const categoryLabel = aiSelectedCategoryLabels[category] || category;
-        return `<div class="portfolio-group ai-selected-group"><h3>${escapeHtml(categoryLabel)}</h3><ul>${rows}</ul></div>`;
+        return `<div class="portfolio-group ai-selected-group"><h3>${escapeHtml(categoryLabel)}</h3>${rows}</div>`;
       }).join('');
       errorEl.style.display = 'none';
       attachAiReasonHandlers();


### PR DESCRIPTION
### Motivation
- Increase AI-selected coverage from 5 to 10 companies per market and provide an explicit 1–10 ranking so users can see trend priority. 
- Surface the rank in the UI and improve presentation by splitting displayed recommendations into two columns (1–5 left, 6–10 right) for readability.

### Description
- Update AI prompt, parsing and validation in `airecommendations.js` to request 10 items per market, accept/assign `rank` values, and validate/merge up to 10 companies per market while preserving/renumbering ranks. 
- Render ranked items in the client by adding `buildAiSelectedItem` and updating the AI-selected renderer in `src/template.html` and the generated `stocks.html` to show a visible rank (e.g. `1. 삼성전자`) and split ranks `1–5` (left) and `6–10` (right). 
- Add responsive styles in `stocks.css` (`.ai-selected-columns`, `.ai-rank`) to present two columns on wider screens and fall back to a single column on small screens. 
- Minor prompt wording/typo fixes and allowed partial read of existing `aiselected.json` during validation so the tool tolerates 1–10 items when reading previous data.

### Testing
- Ran `node src/build.js` to regenerate `stocks.html` and the build completed successfully. 
- Ran repository test `node tests/apple_association.test.js` and it printed `All tests passed`. 
- Static check `node --check airecommendations.js` succeeded with no syntax errors. 
- Ran repository checks including `git diff --check` and code style checks used in the rollout; they reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4b1a44dcf08331b1e213c236056e62)