### PR TITLE
Fix AI recommendations workflow length check

### DIFF
--- a/.github/workflows/stock-recs.yml
+++ b/.github/workflows/stock-recs.yml
@@ -430,8 +430,8 @@ jobs:
           set -Eeuo pipefail
           node airecommendations.js
           test -s aiselected.json
-          jq -e '.korean_market | length == 5' aiselected.json
-          jq -e '.new_york_market | length == 5' aiselected.json
+          jq -e '.korean_market | length == 10' aiselected.json
+          jq -e '.new_york_market | length == 10' aiselected.json
 
       - name: "Verify generated files (brief)"
         run: |


### PR DESCRIPTION
### Motivation
- The CI job was failing because the workflow validated 5 selections per market while `airecommendations.js` is intended to produce 10 selections per market (20 total), causing `jq -e` to return `false` and exit non-zero.

### Description
- Update `.github/workflows/stock-recs.yml` to expect `10` items in each market by changing the checks to `jq -e '.korean_market | length == 10'` and `jq -e '.new_york_market | length == 10'`.

### Testing
- Ran `node tests/apple_association.test.js` and `git diff --check`, and both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4b540bdc58833186cf170a93bbd66b)